### PR TITLE
fix(deps): Re-apply security updates for lodash and lychee-action

### DIFF
--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v2.0.2
         with:
           fail: true
           args: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,5 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Security
 - Updated @modelcontextprotocol/sdk to address GHSA-8r9q-7v3j-jr4g
+- Updated lodash from 4.17.21 to 4.17.23 to fix CVE-2025-13465 prototype pollution vulnerability
+- Updated lycheeverse/lychee-action from v1 to v2.0.2 in CI workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -10757,9 +10757,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {


### PR DESCRIPTION
### Description
- lodash: 4.17.21 → 4.17.23 (fixes CVE-2025-13465 prototype pollution)
- lychee-action: v1 → v2.0.2 (CI workflow update)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
