### PR TITLE
fix(tests): fix failing unit and e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- Update `RunSummaryTable` unit tests to match dark-mode-aware color classes (`text-green-700 dark:text-green-400`) introduced in a previous PR ([#51](https://github.com/opensearch-project/agent-health/pull/51))
+- Replace ambiguous `text=Import Failed` Playwright locator (matched 2 elements, causing strict mode rejection) with `getByRole('alertdialog')` in benchmark import e2e test ([#51](https://github.com/opensearch-project/agent-health/pull/51))
+
 ### Added
 - Minimap toggle control for trace visualization with persistent state ([#44](https://github.com/opensearch-project/agent-health/pull/44))
 - Resizable flyout panels with drag-to-resize functionality and responsive layout ([#44](https://github.com/opensearch-project/agent-health/pull/44))

--- a/tests/e2e/benchmarks.spec.ts
+++ b/tests/e2e/benchmarks.spec.ts
@@ -327,7 +327,7 @@ test.describe('Import JSON on Benchmarks Page', () => {
     // Race navigation against error dialog - whichever comes first
     const navigationOrError = await Promise.race([
       page.waitForURL(/\/benchmarks\/bench-.*\/runs/, { timeout: 15000 }).then(() => 'navigated'),
-      page.locator('text=Import Failed').waitFor({ state: 'visible', timeout: 15000 }).then(() => 'error'),
+      page.getByRole('alertdialog').waitFor({ state: 'visible', timeout: 15000 }).then(() => 'error'),
     ]).catch(() => 'timeout');
 
     // Either successfully navigated or got an expected error (e.g., storage not configured)

--- a/tests/unit/components/comparison/RunSummaryTable.test.ts
+++ b/tests/unit/components/comparison/RunSummaryTable.test.ts
@@ -33,22 +33,22 @@ const createMockRun = (overrides: Partial<RunAggregateMetrics> = {}): RunAggrega
 
 describe('RunSummaryTable', () => {
   describe('getPassRateColorClass', () => {
-    it('returns blue for pass rate >= 80', () => {
-      expect(getPassRateColorClass(80)).toBe('text-opensearch-blue');
-      expect(getPassRateColorClass(100)).toBe('text-opensearch-blue');
-      expect(getPassRateColorClass(95)).toBe('text-opensearch-blue');
+    it('returns green for pass rate >= 80', () => {
+      expect(getPassRateColorClass(80)).toBe('text-green-700 dark:text-green-400');
+      expect(getPassRateColorClass(100)).toBe('text-green-700 dark:text-green-400');
+      expect(getPassRateColorClass(95)).toBe('text-green-700 dark:text-green-400');
     });
 
     it('returns amber for pass rate >= 50 and < 80', () => {
-      expect(getPassRateColorClass(50)).toBe('text-amber-400');
-      expect(getPassRateColorClass(79)).toBe('text-amber-400');
-      expect(getPassRateColorClass(65)).toBe('text-amber-400');
+      expect(getPassRateColorClass(50)).toBe('text-amber-700 dark:text-amber-400');
+      expect(getPassRateColorClass(79)).toBe('text-amber-700 dark:text-amber-400');
+      expect(getPassRateColorClass(65)).toBe('text-amber-700 dark:text-amber-400');
     });
 
     it('returns red for pass rate < 50', () => {
-      expect(getPassRateColorClass(0)).toBe('text-red-400');
-      expect(getPassRateColorClass(49)).toBe('text-red-400');
-      expect(getPassRateColorClass(25)).toBe('text-red-400');
+      expect(getPassRateColorClass(0)).toBe('text-red-700 dark:text-red-400');
+      expect(getPassRateColorClass(49)).toBe('text-red-700 dark:text-red-400');
+      expect(getPassRateColorClass(25)).toBe('text-red-700 dark:text-red-400');
     });
   });
 


### PR DESCRIPTION
Two test failures addressed:

1. RunSummaryTable unit tests: `getPassRateColorClass` was updated to return dark-mode-aware Tailwind classes (e.g. `text-green-700 dark:text-green-400`) but the unit tests still asserted the old single-class values (`text-opensearch-blue`, `text-amber-400`, `text-red-400`). Updated expectations to match the current implementation.

2. Import JSON e2e test: `page.locator('text=Import Failed')` matched two elements (the alertdialog container via aria-labelledby and the h2 heading), causing a Playwright strict mode violation that rejected the promise immediately instead of waiting. Replaced with `page.getByRole('alertdialog')` which uniquely identifies the dialog.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
