### PR TITLE
Upgrade node to version 24 so npm is v11

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,6 +26,10 @@ jobs:
           issue-title: 'Release opensearch-benchmark'
           issue-body: "Please approve or deny the release of opensearch-benchmark. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
           exclude-workflow-initiator-as-approver: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
### Description
Upgrade node to version 24 so npm is v11

### Issues Resolved
https://github.com/opensearch-project/agent-health/actions/runs/22373609001/workflow
https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
