### PR TITLE
Update permission to release drafter on github

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,15 +4,13 @@ on:
   push:
     tags:
       - "*"
-
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
-  issues: write
-
 jobs:
   draft-a-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: write
+      issues: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
### Description
Update permission to release drafter on github

### Issues Resolved
https://github.com/opensearch-project/agent-health/actions/runs/22374001242/job/64760794068


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
