### PR TITLE
feat: Add multi-turn evaluation support, test case import CLI, and settings fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,5 +76,6 @@
 # =============================================================================
 # ADVANCED: Server Configuration (rarely needed)
 # =============================================================================
-# VITE_BACKEND_PORT=4001
+# VITE_PORT=4000
+# PORT=4001
 # BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0

--- a/agent-health.config.example.ts
+++ b/agent-health.config.example.ts
@@ -53,7 +53,37 @@ export default {
     //   useTraces: false,
     // },
 
-    // Example 4: Agent with authentication hook
+    // Example 4: Claude Code connector with environment passthrough
+    // The `connectorConfig.env` field is a generic passthrough — every key-value
+    // pair is injected into the Claude Code subprocess environment. The framework
+    // does not interpret these; it just delivers them. Claude Code honors its own
+    // env vars (Bedrock routing, telemetry, feature flags, etc.).
+    //
+    // `models` is a reporting label only — it does NOT control which LLM Claude
+    // Code uses. The actual model is determined by the CLI's own configuration.
+    // {
+    //   key: "claude-code-bedrock",
+    //   name: "Claude Code (Bedrock)",
+    //   endpoint: "claude",
+    //   connectorType: "claude-code",
+    //   models: ["claude-sonnet-4"],       // label for reports, not model selection
+    //   useTraces: true,
+    //   connectorConfig: {
+    //     env: {
+    //       // All env vars below are passed through to the Claude Code process.
+    //       // See Claude Code docs for the full list of supported variables.
+    //       CLAUDE_CODE_USE_BEDROCK: "1",
+    //       AWS_PROFILE: "Bedrock",
+    //       AWS_REGION: "us-west-2",
+    //       // Telemetry (OTEL) — optional, enable to export metrics/logs
+    //       // CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+    //       // OTEL_EXPORTER_OTLP_ENDPOINT: "https://your-otel-endpoint.example.com",
+    //       // OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+    //     },
+    //   },
+    // },
+
+    // Example 5: Agent with authentication hook
     // {
     //   key: "authenticated-agent",
     //   name: "Authenticated Agent",

--- a/cli/commands/benchmark.ts
+++ b/cli/commands/benchmark.ts
@@ -15,11 +15,11 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import Table from 'cli-table3';
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { loadConfig, DEFAULT_SERVER_CONFIG, type ResolvedConfig } from '@/lib/config/index.js';
 import { ensureServer, createServerCleanup, isServerRunning, type EnsureServerResult } from '@/cli/utils/serverLifecycle.js';
 import { ApiClient, ServerError, type BenchmarkExecutionEvent } from '@/cli/utils/apiClient.js';
-import { validateTestCasesArrayJson, type ValidatedTestCaseInput } from '@/lib/testCaseValidation.js';
+import { isFilePath, loadAndValidateTestCasesFile } from '@/cli/utils/testCaseFile.js';
 import { calculateRunStats, getReportIdsFromRun } from '@/lib/runStats.js';
 import type { AgentConfig, Benchmark, BenchmarkRun, TestCaseRun, EvaluationReport } from '@/types/index.js';
 
@@ -60,39 +60,8 @@ function getDefaultModel(agent: AgentConfig): string {
   return agent.models[0] || 'claude-sonnet';
 }
 
-/**
- * Check if a string looks like a file path (ends with .json)
- */
-export function isFilePath(value: string): boolean {
-  return value.toLowerCase().endsWith('.json');
-}
-
-/**
- * Load and validate test cases from a JSON file
- */
-export function loadAndValidateTestCasesFile(filePath: string): ValidatedTestCaseInput[] {
-  let raw: string;
-  try {
-    raw = readFileSync(filePath, 'utf-8');
-  } catch (err) {
-    throw new Error(`Cannot read file: ${filePath} (${err instanceof Error ? err.message : err})`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(`Invalid JSON in file: ${filePath}`);
-  }
-
-  const result = validateTestCasesArrayJson(parsed);
-  if (!result.valid || !result.data) {
-    const msgs = result.errors.map(e => e.path ? `${e.path}: ${e.message}` : e.message).join('\n  ');
-    throw new Error(`Validation failed for ${filePath}:\n  ${msgs}`);
-  }
-
-  return result.data;
-}
+// Re-export shared utilities for backward compatibility
+export { isFilePath, loadAndValidateTestCasesFile } from '@/cli/utils/testCaseFile.js';
 
 /**
  * Fetch reports for a run using the same approach as the UI.
@@ -486,10 +455,16 @@ export function createBenchmarkCommand(): Command {
             const validatedTestCases = loadAndValidateTestCasesFile(filePath!);
             importSpinner.succeed(`Validated ${validatedTestCases.length} test cases from file`);
 
-            // Bulk create via server
+            // Import with dedup via server
             const uploadSpinner = ora('Importing test cases to server...').start();
-            const bulkResult = await api.bulkCreateTestCases(validatedTestCases);
-            uploadSpinner.succeed(`Imported ${bulkResult.created} test cases`);
+            const importResult = await api.importTestCases(validatedTestCases);
+            const summary: string[] = [];
+            if (importResult.created > 0) summary.push(`${importResult.created} created`);
+            if (importResult.reused > 0) summary.push(`${importResult.reused} reused`);
+            if (importResult.updated > 0) summary.push(`${importResult.updated} updated`);
+            uploadSpinner.succeed(
+              `Imported ${importResult.testCases.length} test cases (${summary.join(', ')})`
+            );
 
             // Create benchmark from imported test case IDs
             const benchmarkName = (options.file && options.name) ? options.name : `file-${Date.now()}`;
@@ -497,7 +472,7 @@ export function createBenchmarkCommand(): Command {
             benchmark = await api.createBenchmark({
               name: benchmarkName,
               description: `Imported from ${filePath}`,
-              testCaseIds: bulkResult.testCases.map(tc => tc.id),
+              testCaseIds: importResult.testCases.map(tc => tc.id),
             });
             createSpinner.succeed(`Created benchmark: ${benchmark.name}`);
           } catch (error) {

--- a/cli/commands/import.ts
+++ b/cli/commands/import.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Import Command
+ * Import test cases from a JSON file with name-based dedup.
+ * Optionally create a benchmark from the imported test cases.
+ *
+ * Architecture: CLI → Server HTTP API → Storage
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { loadConfig, DEFAULT_SERVER_CONFIG } from '@/lib/config/index.js';
+import { ensureServer, createServerCleanup, isServerRunning } from '@/cli/utils/serverLifecycle.js';
+import { ApiClient } from '@/cli/utils/apiClient.js';
+import { loadAndValidateTestCasesFile } from '@/cli/utils/testCaseFile.js';
+
+interface ImportOptions {
+  file: string;
+  benchmark?: string;
+  verbose?: boolean;
+  stopServer?: boolean;
+}
+
+/**
+ * Create the import command
+ */
+export function createImportCommand(): Command {
+  const command = new Command('import')
+    .description('Import test cases from a JSON file (with name-based dedup)')
+    .requiredOption('-f, --file <path>', 'JSON file of test cases to import')
+    .option('-b, --benchmark <name>', 'Also create a benchmark from the imported test cases')
+    .option('-v, --verbose', 'Show per-test-case status')
+    .option('--stop-server', 'Stop the server after import completes')
+    .action(async (options: ImportOptions) => {
+      console.log(chalk.bold('\nAgent Health - Import Test Cases\n'));
+
+      // Load config
+      const config = await loadConfig();
+      const serverConfig = { ...DEFAULT_SERVER_CONFIG, ...config.server };
+      const isCI = !!process.env.CI;
+
+      const serverWasRunning = await isServerRunning(serverConfig.port);
+      const shouldStopServer = isCI || options.stopServer;
+
+      // Ensure server is running
+      const connectSpinner = ora('Connecting to server...').start();
+      let cleanup: () => void;
+
+      try {
+        const serverResult = await ensureServer(serverConfig);
+        cleanup = createServerCleanup(serverResult, shouldStopServer);
+
+        if (serverResult.wasStarted) {
+          connectSpinner.succeed(`Started server on port ${serverConfig.port}`);
+        } else {
+          connectSpinner.succeed(`Connected to existing server on port ${serverConfig.port}`);
+        }
+
+        const api = new ApiClient(serverResult.baseUrl);
+
+        try {
+          // Load and validate file
+          const loadSpinner = ora(`Loading test cases from ${options.file}...`).start();
+          let validatedTestCases;
+          try {
+            validatedTestCases = loadAndValidateTestCasesFile(options.file);
+            loadSpinner.succeed(`Validated ${validatedTestCases.length} test cases from file`);
+          } catch (error) {
+            loadSpinner.fail(`File validation failed: ${error instanceof Error ? error.message : error}`);
+            process.exit(1);
+          }
+
+          // Import with dedup
+          const importSpinner = ora('Importing test cases (with dedup)...').start();
+          const importResult = await api.importTestCases(validatedTestCases);
+
+          const summary: string[] = [];
+          if (importResult.created > 0) summary.push(`${importResult.created} created`);
+          if (importResult.reused > 0) summary.push(`${importResult.reused} reused`);
+          if (importResult.updated > 0) summary.push(`${importResult.updated} updated`);
+          importSpinner.succeed(
+            `Imported ${importResult.testCases.length} test cases (${summary.join(', ')})`
+          );
+
+          // Verbose: show per-test-case status
+          if (options.verbose) {
+            console.log('');
+            for (const tc of importResult.testCases) {
+              const icon = tc.status === 'created' ? chalk.green('+')
+                : tc.status === 'updated' ? chalk.yellow('~')
+                : chalk.gray('=');
+              console.log(`  ${icon} ${tc.name} ${chalk.gray(`(${tc.id})`)} [${tc.status}]`);
+            }
+          }
+
+          // Optionally create benchmark
+          if (options.benchmark) {
+            const benchSpinner = ora('Creating benchmark...').start();
+            const benchmark = await api.createBenchmark({
+              name: options.benchmark,
+              description: `Imported from ${options.file}`,
+              testCaseIds: importResult.testCases.map(tc => tc.id),
+            });
+            benchSpinner.succeed(`Created benchmark: ${benchmark.name} (${benchmark.id})`);
+            console.log(chalk.gray(`  ${benchmark.testCaseIds.length} test cases`));
+            console.log(chalk.gray(`  View: ${serverResult.baseUrl}/benchmarks/${benchmark.id}`));
+          }
+
+          // Print test case IDs
+          console.log('');
+          console.log(chalk.cyan('Test case IDs:'));
+          for (const tc of importResult.testCases) {
+            console.log(chalk.gray(`  ${tc.id}`));
+          }
+          console.log('');
+        } finally {
+          cleanup!();
+        }
+      } catch (error) {
+        connectSpinner.fail(
+          `Failed to connect to server: ${error instanceof Error ? error.message : error}`
+        );
+        process.exit(1);
+      }
+    });
+
+  return command;
+}

--- a/cli/commands/index.ts
+++ b/cli/commands/index.ts
@@ -11,6 +11,7 @@
 export { createListCommand } from './list.js';
 export { createRunCommand } from './run.js';
 export { createBenchmarkCommand } from './benchmark.js';
+export { createImportCommand } from './import.js';
 export { createExportCommand } from './export.js';
 export { createReportCommand } from './report.js';
 export { createDoctorCommand } from './doctor.js';

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -100,7 +100,7 @@ OPENSEARCH_STORAGE_PASS=admin
 
 # ============ Server Configuration ============
 # Backend port (default: 4001)
-# BACKEND_PORT=4001
+# PORT=4001
 `;
 
 const SAMPLE_TEST_CASE = `# Sample Test Case

--- a/cli/demo/otel-multi-turn-test-cases.json
+++ b/cli/demo/otel-multi-turn-test-cases.json
@@ -1,0 +1,131 @@
+[
+  {
+    "name": "OTEL Demo Multi-Turn: Checkout Timeout Investigation",
+    "description": "Multi-turn investigation of checkout timeouts in the OTEL demo application. The simulated SRE starts broad and drills into the payment service cascade failure.",
+    "category": "RCA",
+    "difficulty": "Medium",
+    "initialPrompt": "We're seeing checkout failures in the OTEL demo app. About 30% of PlaceOrder requests are timing out. Can you look at the traces in otel-v1-apm-span-* to figure out what's going on?",
+    "context": [
+      {
+        "description": "OTEL Demo Architecture",
+        "value": "OTEL Demo microservices:\n- frontend (Node.js) → checkoutservice (Go) → paymentservice, shippingservice, currencyservice, emailservice\n- All services instrumented with OpenTelemetry\n- Traces stored in OpenSearch index: otel-v1-apm-span-*\n- Service map in: otel-v1-apm-service-map\n- Key fields: traceId, spanId, serviceName, operationName, duration, status.code, resource.service.name"
+      },
+      {
+        "description": "Current Symptoms",
+        "value": "- 30% of PlaceOrder requests return HTTP 504\n- Issue started ~45 minutes ago\n- No deployments in the last 2 hours\n- paymentservice pod CPU is at 95%\n- checkoutservice logs show 'context deadline exceeded' errors"
+      }
+    ],
+    "expectedOutcomes": [
+      "Query otel-v1-apm-span-* for error spans in the checkout flow",
+      "Identify paymentservice as the bottleneck causing timeouts",
+      "Trace the cascade: paymentservice timeout → checkoutservice deadline exceeded → frontend 504",
+      "Recommend investigation of paymentservice CPU spike or external dependency"
+    ],
+    "multiTurnScenario": {
+      "userMotivation": "I'm an on-call SRE investigating customer-reported checkout failures. I need the agent to help me find the root cause quickly so I can mitigate the issue. I'll start broad, then drill into specific services based on what the agent finds.",
+      "acceptanceCriteria": [
+        "Agent identified paymentservice as the root cause of the timeout cascade",
+        "Agent showed evidence from trace data (error spans, high durations)",
+        "Agent explained the cascade path: paymentservice → checkoutservice → frontend",
+        "Agent provided an actionable remediation suggestion"
+      ],
+      "idealAnswer": "The checkout timeouts are caused by paymentservice CPU saturation (95%). Traces show paymentservice.Charge spans taking 30s+ (normally <500ms), which causes checkoutservice to hit its context deadline (35s), returning errors to the frontend. The cascade: paymentservice timeout → checkoutservice 'context deadline exceeded' → frontend HTTP 504. Immediate remediation: scale paymentservice horizontally or investigate the CPU spike root cause (possible external payment gateway issue).",
+      "criticalComponents": {
+        "rootCause": "paymentservice CPU saturation causing Charge operation timeouts",
+        "remediation": "Scale paymentservice or investigate CPU spike; add circuit breaker to prevent cascade"
+      },
+      "turnLimit": 5,
+      "referenceTurns": [
+        {
+          "turn": 1,
+          "user": "We're seeing checkout failures in the OTEL demo app. About 30% of PlaceOrder requests are timing out. Can you look at the traces in otel-v1-apm-span-* to figure out what's going on?",
+          "expectedTopics": ["error spans", "checkout flow", "trace query"],
+          "groundTruth": "Error spans in otel-v1-apm-span-* show status.code=2 on checkoutservice and paymentservice spans. The majority of errors originate from paymentservice.Charge with durations over 30 seconds."
+        },
+        {
+          "turn": 2,
+          "user": "Interesting — so the errors are concentrated in paymentservice. Can you show me the span durations for paymentservice.Charge over the last hour? I want to see when the latency spiked.",
+          "expectedTopics": ["paymentservice duration", "latency spike", "timeline"],
+          "groundTruth": "paymentservice.Charge p50 went from 200ms to 30s+ starting 45 minutes ago. The spike correlates exactly with the checkout failure reports."
+        },
+        {
+          "turn": 3,
+          "user": "That confirms paymentservice is the bottleneck. Can you trace through a single failing request end-to-end to show me how the timeout cascades from paymentservice up to the frontend?",
+          "expectedTopics": ["cascade", "trace waterfall", "timeout propagation"],
+          "groundTruth": "A sample failing trace shows: frontend.PlaceOrder (62s, ERROR) → checkoutservice.PlaceOrder (38s, ERROR: context deadline exceeded) → paymentservice.Charge (32s, ERROR: upstream timeout). The timeout propagates upward through the service chain."
+        },
+        {
+          "turn": 4,
+          "user": "Got it. What do you recommend we do right now to stop the bleeding, and what should we investigate as the underlying cause?",
+          "expectedTopics": ["remediation", "scaling", "circuit breaker", "root cause"],
+          "groundTruth": "Immediate: scale paymentservice replicas or restart pods to relieve CPU pressure. Add a circuit breaker on checkoutservice→paymentservice to fail fast instead of waiting 30s. Investigate: check if an external payment gateway is slow or if there's a resource leak in paymentservice causing CPU saturation."
+        }
+      ]
+    }
+  },
+  {
+    "name": "OTEL Demo Multi-Turn: Frontend Latency Regression",
+    "description": "Multi-turn investigation of a frontend latency regression in the OTEL demo. The SRE notices slow page loads and works with the agent to isolate which backend service is responsible.",
+    "category": "RCA",
+    "difficulty": "Medium",
+    "initialPrompt": "Users are complaining that the OTEL demo product listing page is extremely slow — taking 5-8 seconds to load when it normally loads in under 1 second. Can you check the traces in otel-v1-apm-span-* to find what's causing the slowdown?",
+    "context": [
+      {
+        "description": "OTEL Demo Product Listing Flow",
+        "value": "Product listing request flow:\n- frontend → productcatalogservice.ListProducts (gRPC)\n- frontend → recommendationservice.ListRecommendations → productcatalogservice.GetProduct (multiple calls)\n- frontend → adservice.GetAds\n- All traces in otel-v1-apm-span-*\n- Key fields: serviceName, operationName, duration, parentSpanId"
+      },
+      {
+        "description": "Current Observations",
+        "value": "- frontend /products page p95 latency: 6.2s (baseline: 800ms)\n- Issue started ~2 hours ago\n- No code changes or deployments in the last 24 hours\n- All pods are running and healthy (no restarts)\n- recommendationservice logs show elevated query times"
+      }
+    ],
+    "expectedOutcomes": [
+      "Query traces for frontend product listing spans with high duration",
+      "Break down latency by child service to isolate the bottleneck",
+      "Identify recommendationservice as the source of the latency regression",
+      "Find that recommendationservice is making excessive GetProduct calls to productcatalogservice",
+      "Recommend caching or reducing the number of recommendation calls"
+    ],
+    "multiTurnScenario": {
+      "userMotivation": "I'm an SRE investigating a user-reported performance regression on the product listing page. I need the agent to systematically break down the trace data to find which service or operation is causing the slow page loads, and give me an actionable fix.",
+      "acceptanceCriteria": [
+        "Agent identified recommendationservice as the primary latency contributor",
+        "Agent showed that recommendationservice makes many sequential GetProduct calls to productcatalogservice",
+        "Agent provided evidence from trace spans (durations, fan-out pattern)",
+        "Agent suggested a concrete fix (caching, batching, or reducing calls)"
+      ],
+      "idealAnswer": "The frontend latency regression is caused by recommendationservice.ListRecommendations taking 5s+ (normally 300ms). Trace analysis shows it makes 15-20 sequential GetProduct calls to productcatalogservice per request (fan-out pattern). Each call takes ~300ms, and they execute serially, causing the total duration to stack up. This started after a feature flag change that increased the number of recommendations from 5 to 20. Fix: batch the GetProduct calls into a single ListProducts request, add response caching, or revert the recommendation count back to 5.",
+      "criticalComponents": {
+        "rootCause": "recommendationservice making excessive sequential GetProduct calls due to increased recommendation count",
+        "remediation": "Batch GetProduct calls, add caching, or reduce recommendation count"
+      },
+      "turnLimit": 5,
+      "referenceTurns": [
+        {
+          "turn": 1,
+          "user": "Users are complaining that the OTEL demo product listing page is extremely slow — taking 5-8 seconds to load when it normally loads in under 1 second. Can you check the traces in otel-v1-apm-span-* to find what's causing the slowdown?",
+          "expectedTopics": ["frontend spans", "high duration", "child services"],
+          "groundTruth": "Frontend /products traces show total duration of 5-8 seconds. The trace waterfall shows three main child spans: productcatalogservice.ListProducts (200ms — normal), recommendationservice.ListRecommendations (5.2s — abnormal), and adservice.GetAds (150ms — normal)."
+        },
+        {
+          "turn": 2,
+          "user": "So recommendationservice is the culprit. Can you dig into the recommendationservice spans and show me what's happening inside those 5-second calls?",
+          "expectedTopics": ["recommendationservice internals", "GetProduct calls", "fan-out"],
+          "groundTruth": "Inside recommendationservice.ListRecommendations, there are 18 sequential child spans calling productcatalogservice.GetProduct. Each takes 250-350ms and they run serially, totaling ~5.2s. The number of GetProduct calls increased from 5 to 18 about 2 hours ago."
+        },
+        {
+          "turn": 3,
+          "user": "18 sequential calls — that explains it. Can you compare the traces from before the regression to confirm the call count changed?",
+          "expectedTopics": ["before vs after", "call count comparison", "timeline"],
+          "groundTruth": "Traces from 3 hours ago show recommendationservice.ListRecommendations with only 5 GetProduct child spans (total: 1.2s). Traces from the last 2 hours show 15-20 GetProduct child spans (total: 4-6s). The change correlates with a configuration or feature flag update."
+        },
+        {
+          "turn": 4,
+          "user": "Clear root cause. What's your recommendation to fix this?",
+          "expectedTopics": ["batching", "caching", "parallel calls", "revert"],
+          "groundTruth": "Immediate fix: revert the recommendation count back to 5 to restore baseline performance. Long-term: replace sequential GetProduct calls with a single batched ListProducts call filtered by IDs, or run calls in parallel. Also add a response cache with TTL for product data since it changes infrequently."
+        }
+      ]
+    }
+  }
+]

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -22,6 +22,7 @@ import {
   createListCommand,
   createRunCommand,
   createBenchmarkCommand,
+  createImportCommand,
   createExportCommand,
   createReportCommand,
   createDoctorCommand,
@@ -138,6 +139,7 @@ program.action(async (options) => {
 program.addCommand(createListCommand());
 program.addCommand(createRunCommand());
 program.addCommand(createBenchmarkCommand());
+program.addCommand(createImportCommand());
 program.addCommand(createExportCommand());
 program.addCommand(createReportCommand());
 program.addCommand(createDoctorCommand());

--- a/cli/utils/apiClient.ts
+++ b/cli/utils/apiClient.ts
@@ -99,6 +99,16 @@ export interface BulkCreateTestCasesResponse {
 }
 
 /**
+ * Response from importing test cases with dedup
+ */
+export interface ImportTestCasesResponse {
+  created: number;
+  reused: number;
+  updated: number;
+  testCases: Array<{ id: string; name: string; status: 'created' | 'reused' | 'updated' }>;
+}
+
+/**
  * API Client for Agent Health server
  */
 export class ApiClient {
@@ -460,6 +470,31 @@ export class ApiClient {
         errorMessage = errorBody;
       }
       throw new Error(`Failed to bulk create test cases: ${errorMessage}`);
+    }
+
+    return res.json();
+  }
+
+  /**
+   * Import test cases with name-based dedup
+   */
+  async importTestCases(testCases: object[]): Promise<ImportTestCasesResponse> {
+    const res = await fetch(`${this.baseUrl}/api/storage/test-cases/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ testCases }),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      let errorMessage: string;
+      try {
+        const parsed = JSON.parse(errorBody);
+        errorMessage = parsed.error || errorBody;
+      } catch {
+        errorMessage = errorBody;
+      }
+      throw new Error(`Failed to import test cases: ${errorMessage}`);
     }
 
     return res.json();

--- a/cli/utils/startServer.ts
+++ b/cli/utils/startServer.ts
@@ -38,7 +38,7 @@ function findPackageRoot(): string {
  */
 export async function startServer(options: StartOptions): Promise<void> {
   // Set environment variables for the server
-  process.env.VITE_BACKEND_PORT = String(options.port);
+  process.env.PORT = String(options.port);
 
   // Dynamic import the server module from package root
   // Using computed path prevents esbuild from bundling server code into CLI

--- a/cli/utils/testCaseFile.ts
+++ b/cli/utils/testCaseFile.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared utilities for loading and validating test case JSON files.
+ * Used by both `benchmark` and `import` CLI commands.
+ */
+
+import { readFileSync } from 'fs';
+import { validateTestCasesArrayJson, type ValidatedTestCaseInput } from '@/lib/testCaseValidation.js';
+
+/**
+ * Check if a string looks like a file path (ends with .json)
+ */
+export function isFilePath(value: string): boolean {
+  return value.toLowerCase().endsWith('.json');
+}
+
+/**
+ * Load and validate test cases from a JSON file
+ */
+export function loadAndValidateTestCasesFile(filePath: string): ValidatedTestCaseInput[] {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Cannot read file: ${filePath} (${err instanceof Error ? err.message : err})`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in file: ${filePath}`);
+  }
+
+  const result = validateTestCasesArrayJson(parsed);
+  if (!result.valid || !result.data) {
+    const msgs = result.errors.map(e => e.path ? `${e.path}: ${e.message}` : e.message).join('\n  ');
+    throw new Error(`Validation failed for ${filePath}:\n  ${msgs}`);
+  }
+
+  return result.data;
+}

--- a/components/RunDetailsContent.tsx
+++ b/components/RunDetailsContent.tsx
@@ -28,6 +28,9 @@ import {
   Target,
   Hash,
   Maximize2,
+  User,
+  Bot,
+  Repeat,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -87,7 +90,8 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
   const [tracesLoading, setTracesLoading] = useState(false);
   const [tracesError, setTracesError] = useState<string | null>(null);
   const [tracesFetched, setTracesFetched] = useState(false);
-  const [activeTab, setActiveTab] = useState('summary');
+  const [activeTab, setActiveTab] = useState('judge');
+  const [currentTurn, setCurrentTurn] = useState('turn-0');
   const [traceViewMode, setTraceViewMode] = useState<ViewMode>('info');
   const [traceFullscreenOpen, setTraceFullscreenOpen] = useState(false);
 
@@ -790,6 +794,54 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
               )}
             </div>
 
+            {/* Multi-Turn Scores */}
+            {liveReport.multiTurnResult && (
+              <div>
+                <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <Repeat size={18} />
+                  Multi-Turn Results
+                  <Badge variant={liveReport.multiTurnResult.acceptanceCriteriaMet ? 'default' : 'destructive'} className="ml-1">
+                    {liveReport.multiTurnResult.acceptanceCriteriaMet ? (
+                      <><CheckCircle2 size={12} className="mr-1" /> Criteria Met</>
+                    ) : (
+                      <><XCircle size={12} className="mr-1" /> Criteria Not Met</>
+                    )}
+                  </Badge>
+                </h3>
+                <div className="grid grid-cols-4 gap-3 mb-4">
+                  <Card><CardContent className="p-3 text-center">
+                    <div className="text-xs text-muted-foreground mb-1">Root Cause</div>
+                    <div className="text-lg font-semibold text-opensearch-blue">{liveReport.multiTurnResult.rootCauseScore}%</div>
+                  </CardContent></Card>
+                  <Card><CardContent className="p-3 text-center">
+                    <div className="text-xs text-muted-foreground mb-1">Remediation</div>
+                    <div className="text-lg font-semibold text-blue-400">{liveReport.multiTurnResult.remediationScore}%</div>
+                  </CardContent></Card>
+                  <Card><CardContent className="p-3 text-center">
+                    <div className="text-xs text-muted-foreground mb-1">Context Retention</div>
+                    <div className="text-lg font-semibold text-emerald-400">{liveReport.multiTurnResult.contextRetentionScore}%</div>
+                  </CardContent></Card>
+                  <Card><CardContent className="p-3 text-center">
+                    <div className="text-xs text-muted-foreground mb-1">Conciseness</div>
+                    <div className="text-lg font-semibold text-amber-400">{liveReport.multiTurnResult.concisenessScore}%</div>
+                  </CardContent></Card>
+                </div>
+                <div className="text-xs text-muted-foreground mb-2">
+                  {liveReport.multiTurnResult.totalTurns} turn{liveReport.multiTurnResult.totalTurns !== 1 ? 's' : ''} completed
+                </div>
+                {liveReport.multiTurnResult.reasoning && (
+                  <Card className="bg-muted/30"><CardContent className="p-4">
+                    <div className="text-xs text-muted-foreground mb-2">Judge Reasoning</div>
+                    <div className="text-sm prose prose-sm dark:prose-invert max-w-none">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {liveReport.multiTurnResult.reasoning}
+                      </ReactMarkdown>
+                    </div>
+                  </CardContent></Card>
+                )}
+              </div>
+            )}
+
             {/* Test Case Info */}
             {testCase && (
               <div>
@@ -888,43 +940,116 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
           <TabsContent value="trajectory" className="p-6 mt-0">
             {/* Header with Toggle */}
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Conversation History</h3>
-              <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
-                <button
-                  onClick={() => setTrajectoryViewMode('processed')}
-                  className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
-                    trajectoryViewMode === 'processed'
-                      ? 'bg-opensearch-blue text-white'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  Processed
-                </button>
-                <button
-                  onClick={() => setTrajectoryViewMode('raw')}
-                  className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
-                    trajectoryViewMode === 'raw'
-                      ? 'bg-opensearch-blue text-white'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  Raw Events
-                </button>
-              </div>
+              <h3 className="text-lg font-semibold">
+                Conversation History
+                {liveReport.multiTurnResult && (
+                  <Badge variant="secondary" className="ml-2 text-xs">{liveReport.multiTurnResult.totalTurns} turns</Badge>
+                )}
+              </h3>
+              {!liveReport.multiTurnResult && (
+                <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+                  <button
+                    onClick={() => setTrajectoryViewMode('processed')}
+                    className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
+                      trajectoryViewMode === 'processed'
+                        ? 'bg-opensearch-blue text-white'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    Processed
+                  </button>
+                  <button
+                    onClick={() => setTrajectoryViewMode('raw')}
+                    className={`px-3 py-1.5 text-xs rounded-md transition-colors ${
+                      trajectoryViewMode === 'raw'
+                        ? 'bg-opensearch-blue text-white'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    Raw Events
+                  </button>
+                </div>
+              )}
             </div>
 
-            {/* Conditional View */}
-            {trajectoryViewMode === 'processed' ? (
-              <TrajectoryView steps={trajectory} loading={false} />
+            {/* Multi-turn: sub-tabs for each turn with chat format */}
+            {liveReport.multiTurnResult ? (
+              <Tabs value={currentTurn} onValueChange={setCurrentTurn}>
+                <TabsList className="w-full justify-start bg-muted/50 rounded-lg p-1 flex-wrap h-auto gap-1">
+                  {liveReport.multiTurnResult.turns.map((turn, i) => (
+                    <TabsTrigger key={i} value={`turn-${i}`} className="text-xs data-[state=active]:bg-opensearch-blue data-[state=active]:text-white">
+                      Turn {turn.turn}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                {liveReport.multiTurnResult.turns.map((turn, i) => {
+                  const referenceTurn = testCase?.multiTurnScenario?.referenceTurns?.find(
+                    rt => rt.turn === turn.turn
+                  );
+                  return (
+                    <TabsContent key={i} value={`turn-${i}`} className="space-y-4 mt-4">
+                      {/* User message - blue-tinted card */}
+                      <Card className="bg-blue-500/5 border-blue-500/20">
+                        <CardContent className="p-4">
+                          <div className="text-xs font-semibold text-blue-400 mb-2 flex items-center gap-1">
+                            <User size={12} /> User
+                          </div>
+                          <p className="text-sm whitespace-pre-wrap">{turn.userMessage}</p>
+                        </CardContent>
+                      </Card>
+
+                      {/* Agent response - neutral card with markdown */}
+                      <Card className="bg-muted/30">
+                        <CardContent className="p-4">
+                          <div className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+                            <Bot size={12} /> Agent
+                          </div>
+                          <div className="text-sm prose prose-sm dark:prose-invert max-w-none">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                              {turn.agentResponse}
+                            </ReactMarkdown>
+                          </div>
+                        </CardContent>
+                      </Card>
+
+                      {/* Reference turn annotation (if exists) */}
+                      {referenceTurn && (
+                        <div className="bg-muted/30 border-l-2 border-amber-500/30 p-3 rounded-r text-xs space-y-1">
+                          <div className="font-semibold text-amber-400">Expected (Reference Turn {turn.turn})</div>
+                          {referenceTurn.expectedTopics.length > 0 && (
+                            <div className="flex gap-1 flex-wrap items-center">
+                              <span className="text-muted-foreground">Topics:</span>
+                              {referenceTurn.expectedTopics.map(t => (
+                                <Badge key={t} variant="secondary" className="text-[10px]">{t}</Badge>
+                              ))}
+                            </div>
+                          )}
+                          <div className="text-muted-foreground">{referenceTurn.groundTruth}</div>
+                        </div>
+                      )}
+
+                      {/* Trajectory - reuse existing component */}
+                      {turn.trajectory && turn.trajectory.length > 0 && (
+                        <TrajectoryView steps={turn.trajectory} loading={false} />
+                      )}
+                    </TabsContent>
+                  );
+                })}
+              </Tabs>
             ) : (
-              report.rawEvents && report.rawEvents.length > 0 ? (
-                <RawEventsPanel events={report.rawEvents} />
+              /* Single-turn: existing trajectory/raw events view */
+              trajectoryViewMode === 'processed' ? (
+                <TrajectoryView steps={trajectory} loading={false} />
               ) : (
-                <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
-                  <Terminal size={48} className="mb-4 opacity-20" />
-                  <p>No raw events captured for this run</p>
-                  <p className="text-sm mt-1">Raw events are only available for new runs</p>
-                </div>
+                report.rawEvents && report.rawEvents.length > 0 ? (
+                  <RawEventsPanel events={report.rawEvents} />
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                    <Terminal size={48} className="mb-4 opacity-20" />
+                    <p>No raw events captured for this run</p>
+                    <p className="text-sm mt-1">Raw events are only available for new runs</p>
+                  </div>
+                )
               )
             )}
           </TabsContent>

--- a/components/RunDetailsContent.tsx
+++ b/components/RunDetailsContent.tsx
@@ -319,7 +319,7 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
     setTracesFetched(false);
 
     // Auto-fetch if already on traces tab
-    if (activeTab === 'logs' && isTraceMode && report.runId) {
+    if (activeTab === 'logs' && isTraceMode && (report.runId || report.turnRunIds?.length)) {
       // Use setTimeout to ensure state is reset before fetching
       setTimeout(() => {
         fetchTracesForReport();
@@ -329,14 +329,17 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
 
   // Core trace fetching logic
   const fetchTracesForReport = async () => {
-    if (!report.runId) return;
+    const runIdsToFetch = report.turnRunIds?.length
+      ? report.turnRunIds
+      : report.runId ? [report.runId] : [];
+    if (runIdsToFetch.length === 0) return;
 
     setTracesLoading(true);
     setTracesError(null);
 
     try {
-      console.info('[RunDetails] Fetching traces for runId:', report.runId);
-      const result = await fetchTracesByRunIds([report.runId]);
+      console.info('[RunDetails] Fetching traces for runIds:', runIdsToFetch);
+      const result = await fetchTracesByRunIds(runIdsToFetch, 1000);
       
       console.info('[RunDetails] Trace fetch result:', {
         spansCount: result.spans?.length || 0,

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -4,9 +4,8 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { AlertTriangle, Trash2, Database, CheckCircle2, XCircle, Upload, Download, Loader2, Server, Plus, Edit2, X, Save, ExternalLink, Eye, EyeOff, ChevronDown, ChevronRight, RefreshCw, Palette, Circle } from 'lucide-react';
+import { AlertTriangle, Trash2, Database, CheckCircle2, XCircle, Upload, Download, Loader2, Server, Plus, Edit2, X, Save, ExternalLink, Eye, EyeOff, ChevronDown, ChevronRight, RefreshCw, Palette, Circle, Bug } from 'lucide-react';
 import { getTheme, setTheme, type Theme } from '@/lib/theme';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -68,6 +67,184 @@ function getCustomEndpointsFromConfig(): AgentEndpoint[] {
       useTraces: a.useTraces,
     }));
 }
+
+/** Reusable section wrapper */
+const Section: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  last?: boolean;
+  children: React.ReactNode;
+}> = ({ icon, title, subtitle, last, children }) => (
+  <section className={last ? '' : 'pb-6 mb-6 border-b border-border/50'}>
+    <div className="flex items-baseline gap-2 mb-4">
+      <span className="text-muted-foreground">{icon}</span>
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      {subtitle && <span className="text-xs text-muted-foreground/70 ml-1">- {subtitle}</span>}
+    </div>
+    {children}
+  </section>
+);
+
+/** Reusable config source badge */
+const ConfigSourceBadge: React.FC<{ source?: string }> = ({ source }) => {
+  if (!source) return null;
+  const style = source === 'file'
+    ? 'bg-green-100 text-green-900 border-green-300 dark:bg-green-950/50 dark:text-green-300 dark:border-green-700/50'
+    : source === 'environment'
+    ? 'bg-blue-100 text-blue-900 border-blue-300 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-700/50'
+    : 'bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700/50';
+  const label = source === 'file' ? 'Config file' : source === 'environment' ? 'Env vars' : 'Not configured';
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded border ${style}`}>{label}</span>
+  );
+};
+
+/** Reusable connection test status */
+const TestStatus: React.FC<{ status: string; message: string }> = ({ status, message }) => {
+  if (!message) return null;
+  return (
+    <div className={`flex items-center gap-2 text-sm ${
+      status === 'success' ? 'text-green-400' :
+      status === 'error' ? 'text-red-400' :
+      status === 'testing' ? 'text-blue-400' : 'text-muted-foreground'
+    }`}>
+      {status === 'testing' && <Loader2 size={14} className="animate-spin" />}
+      {status === 'success' && <CheckCircle2 size={14} />}
+      {status === 'error' && <XCircle size={14} />}
+      {message}
+    </div>
+  );
+};
+
+/** Auth fields for OpenSearch cluster config */
+const AuthFields: React.FC<{
+  prefix: string;
+  config: {
+    authType: ClusterAuthType;
+    username: string;
+    password: string;
+    awsProfile: string;
+    awsRegion: string;
+    awsService: 'es' | 'aoss';
+    tlsSkipVerify: boolean;
+  };
+  showPassword: boolean;
+  onTogglePassword: () => void;
+  onChange: (patch: Record<string, any>) => void;
+  passwordSentinel: string;
+}> = ({ prefix, config, showPassword, onTogglePassword, onChange, passwordSentinel }) => (
+  <div className="space-y-3">
+    <div className="space-y-1.5">
+      <Label className="text-xs">Authentication</Label>
+      <Select value={config.authType} onValueChange={(v) => onChange({ authType: v })}>
+        <SelectTrigger className="h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="none">No Auth</SelectItem>
+          <SelectItem value="basic">Basic Auth</SelectItem>
+          <SelectItem value="sigv4">AWS SigV4</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+
+    {config.authType === 'none' && (
+      <p className="text-xs text-muted-foreground pl-1">
+        Connects without credentials. Suitable for local dev clusters.
+      </p>
+    )}
+
+    {config.authType === 'basic' && (
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor={`${prefix}-username`} className="text-xs">Username</Label>
+          <Input
+            id={`${prefix}-username`}
+            placeholder="Leave blank for env var"
+            value={config.username}
+            onChange={(e) => onChange({ username: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor={`${prefix}-password`} className="text-xs">Password</Label>
+          <div className="relative">
+            <Input
+              id={`${prefix}-password`}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={config.password === passwordSentinel ? '••••••••' : 'Leave blank for env var'}
+              value={config.password === passwordSentinel ? '' : config.password}
+              onChange={(e) => onChange({ password: e.target.value })}
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={onTogglePassword}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          {config.password === passwordSentinel && (
+            <p className="text-xs text-muted-foreground">Stored on server - type to replace</p>
+          )}
+        </div>
+      </div>
+    )}
+
+    {config.authType === 'sigv4' && (
+      <div className="space-y-3 p-3 border rounded-lg bg-muted/10">
+        <p className="text-xs text-muted-foreground">
+          Uses AWS credential chain (env vars, ~/.aws/credentials, IAM role)
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor={`${prefix}-aws-region`} className="text-xs">AWS Region</Label>
+            <Input
+              id={`${prefix}-aws-region`}
+              placeholder="us-east-1"
+              value={config.awsRegion}
+              onChange={(e) => onChange({ awsRegion: e.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`${prefix}-aws-profile`} className="text-xs">AWS Profile</Label>
+            <Input
+              id={`${prefix}-aws-profile`}
+              placeholder="default"
+              value={config.awsProfile}
+              onChange={(e) => onChange({ awsProfile: e.target.value })}
+            />
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">AWS Service</Label>
+          <Select value={config.awsService} onValueChange={(v) => onChange({ awsService: v })}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="es">es (Managed OpenSearch)</SelectItem>
+              <SelectItem value="aoss">aoss (Serverless)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    )}
+
+    <div className="flex items-center justify-between">
+      <div className="space-y-0.5">
+        <Label htmlFor={`${prefix}-tls-skip`} className="text-xs">Skip TLS Verification</Label>
+        <p className="text-xs text-muted-foreground">For self-signed certificates</p>
+      </div>
+      <Switch
+        id={`${prefix}-tls-skip`}
+        checked={config.tlsSkipVerify}
+        onCheckedChange={(checked) => onChange({ tlsSkipVerify: checked })}
+      />
+    </div>
+  </div>
+);
 
 export const SettingsPage: React.FC = () => {
 
@@ -769,59 +946,443 @@ export const SettingsPage: React.FC = () => {
     }
   };
 
+  /** Endpoint form (shared between add and edit) */
+  const renderEndpointForm = (onSave: () => void, saveLabel: string) => (
+    <div className="p-4 border rounded-lg bg-muted/20 space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="new-endpoint-name" className="text-xs">Name</Label>
+          <Input
+            id="new-endpoint-name"
+            placeholder="My Agent"
+            value={newEndpointName}
+            onChange={(e) => setNewEndpointName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Connector</Label>
+          <Select value={newConnectorType} onValueChange={(v) => setNewConnectorType(v as ConnectorProtocol)}>
+            <SelectTrigger className="h-9 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="agui-streaming">agui-streaming (default)</SelectItem>
+              <SelectItem value="rest">rest</SelectItem>
+              <SelectItem value="litellm">litellm</SelectItem>
+              <SelectItem value="subprocess">subprocess</SelectItem>
+              <SelectItem value="claude-code">claude-code</SelectItem>
+              <SelectItem value="mock">mock</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="new-endpoint-url" className="text-xs">Endpoint URL</Label>
+        <Input
+          id="new-endpoint-url"
+          placeholder="http://localhost:3000/api/agent"
+          value={newEndpointUrl}
+          onChange={(e) => {
+            setNewEndpointUrl(e.target.value);
+            setEndpointUrlError(null);
+          }}
+          className={endpointUrlError ? 'border-red-500' : ''}
+        />
+        {endpointUrlError && (
+          <p className="text-xs text-red-500">{endpointUrlError}</p>
+        )}
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Switch
+            id="new-use-traces"
+            checked={newUseTraces}
+            onCheckedChange={setNewUseTraces}
+          />
+          <Label htmlFor="new-use-traces" className="text-xs">Enable Traces</Label>
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" onClick={onSave} disabled={!newEndpointName.trim() || !newEndpointUrl.trim()}>
+            <Save size={14} className="mr-1" />
+            {saveLabel}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={cancelEdit}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  /** Action buttons for data source config (test/save/clear) */
+  const renderDataSourceActions = (
+    endpoint: string,
+    testStatus: string,
+    onTest: () => void,
+    onSave: () => void,
+    onClear: () => void,
+  ) => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onTest}
+        disabled={!endpoint || testStatus === 'testing'}
+      >
+        {testStatus === 'testing' ? (
+          <><Loader2 size={14} className="mr-1 animate-spin" />Testing...</>
+        ) : (
+          'Test Connection'
+        )}
+      </Button>
+      <Button
+        size="sm"
+        onClick={onSave}
+        disabled={!endpoint}
+        className="bg-opensearch-blue hover:bg-blue-600"
+      >
+        <Save size={14} className="mr-1" />
+        Save
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onClear}
+        disabled={!endpoint}
+      >
+        <Trash2 size={14} className="mr-1" />
+        Clear
+      </Button>
+    </div>
+  );
+
   return (
     <>
-    <div className="p-6 max-w-4xl mx-auto" data-testid="settings-page">
-      <h2 className="text-2xl font-bold mb-6" data-testid="settings-title">Settings</h2>
+    <div className="p-6 max-w-5xl mx-auto" data-testid="settings-page">
+      <h2 className="text-2xl font-bold mb-8" data-testid="settings-title">Settings</h2>
 
-      {/* Preferences */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Palette size={18} />
-            Preferences
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-3">
-            <Label className="text-sm font-medium">Theme</Label>
-            <div className="flex gap-3">
-              <Button
-                variant={currentTheme === 'light' ? 'default' : 'outline'}
-                onClick={() => handleThemeChange('light')}
-                className="flex-1"
+      {/* ── Agent Endpoints ── */}
+      <Section icon={<Server size={16} />} title="Agent Endpoints">
+        {/* Built-in */}
+        <div className="space-y-2 mb-4">
+          <Label className="text-xs text-muted-foreground uppercase tracking-wide">Built-in</Label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {DEFAULT_CONFIG.agents.filter(a => !a.isCustom).map((agent) => (
+              <div
+                key={agent.key}
+                className="p-3 border rounded-lg bg-muted/5"
               >
-                Light Mode
-              </Button>
-              <Button
-                variant={currentTheme === 'dark' ? 'default' : 'outline'}
-                onClick={() => handleThemeChange('dark')}
-                className="flex-1"
-              >
-                Dark Mode
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Choose your preferred color theme for the interface
-            </p>
+                <div className="font-medium text-sm flex items-center gap-2">
+                  {agent.name}
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-blue-100 text-blue-900 border border-blue-300 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-700/50">
+                    built-in
+                  </span>
+                </div>
+                <div className="text-xs text-muted-foreground truncate flex items-center gap-1 mt-1">
+                  <ExternalLink size={10} />
+                  {agent.endpoint || <span className="italic">Not configured</span>}
+                </div>
+                {agent.description && (
+                  <div className="text-xs text-muted-foreground mt-1">{agent.description}</div>
+                )}
+              </div>
+            ))}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
-      {/* Debug Settings */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle>Debug Settings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+        {/* Custom */}
+        <div className="border-t pt-4">
+          <div className="flex items-center justify-between mb-3">
+            <Label className="text-xs text-muted-foreground uppercase tracking-wide">Custom Endpoints</Label>
+            {!isAddingEndpoint && (
+              <Button variant="outline" size="sm" onClick={() => setIsAddingEndpoint(true)}>
+                <Plus size={14} className="mr-1" />
+                Add
+              </Button>
+            )}
+          </div>
+
+          {isAddingEndpoint && renderEndpointForm(handleAddEndpoint, 'Save')}
+
+          {customEndpoints.length > 0 ? (
+            <div className="space-y-2">
+              {customEndpoints.map((ep) => (
+                <div
+                  key={ep.id}
+                  className="p-3 border rounded-lg bg-muted/10 flex items-start justify-between gap-3"
+                >
+                  {editingEndpointId === ep.id ? (
+                    <div className="flex-1">
+                      {renderEndpointForm(() => handleUpdateEndpoint(ep.id), 'Save')}
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-sm">{ep.name}</div>
+                        <div className="text-xs text-muted-foreground truncate flex items-center gap-1 mt-1">
+                          <ExternalLink size={10} />
+                          {ep.endpoint}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
+                          <span>{ep.connectorType ?? 'agui-streaming'}</span>
+                          {ep.useTraces && <span className="px-1.5 py-0.5 rounded bg-green-100 text-green-900 border border-green-300 dark:bg-green-950/50 dark:text-green-300 dark:border-green-700/50">traces</span>}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <Button variant="ghost" size="sm" onClick={() => startEditEndpoint(ep)}>
+                          <Edit2 size={14} />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleDeleteEndpoint(ep.id)}
+                          className="text-red-400 hover:text-red-300"
+                          aria-label={`Remove ${ep.name}`}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            !isAddingEndpoint && (
+              <p className="text-center py-4 text-muted-foreground text-sm">
+                No custom endpoints configured.
+              </p>
+            )
+          )}
+        </div>
+      </Section>
+
+      {/* ── Evaluation Storage ── */}
+      <Section
+        icon={<Database size={16} />}
+        title="Evaluation Storage"
+        subtitle="test cases, benchmarks, runs"
+      >
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="storage-endpoint" className="text-xs">Endpoint URL</Label>
+            <Input
+              id="storage-endpoint"
+              placeholder="https://opensearch.example.com:9200"
+              value={storageConfig.endpoint}
+              onChange={(e) => setStorageConfigState({ ...storageConfig, endpoint: e.target.value })}
+            />
+          </div>
+
+          <AuthFields
+            prefix="storage"
+            config={storageConfig}
+            showPassword={showStoragePassword}
+            onTogglePassword={() => setShowStoragePassword(!showStoragePassword)}
+            onChange={(patch) => setStorageConfigState(prev => ({ ...prev, ...patch }))}
+            passwordSentinel={PASSWORD_STORED_SENTINEL}
+          />
+
+          {configStatus?.storage && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Source:</span>
+              <ConfigSourceBadge source={configStatus.storage.source} />
+            </div>
+          )}
+
+          <TestStatus status={storageTestStatus} message={storageTestMessage} />
+
+          {renderDataSourceActions(
+            storageConfig.endpoint,
+            storageTestStatus,
+            handleTestStorageConnection,
+            handleSaveStorageConfig,
+            handleClearStorageConfig,
+          )}
+
+          {/* Connection Status & Stats */}
+          {storageStats && (
+            <div className="border-t pt-4 mt-2">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  {storageStats.isConnected ? (
+                    <>
+                      <CheckCircle2 size={14} className="text-opensearch-blue" />
+                      <span className="text-sm text-opensearch-blue">Connected</span>
+                    </>
+                  ) : (
+                    <>
+                      <XCircle size={14} className="text-red-400" />
+                      <span className="text-sm text-red-400">Not connected</span>
+                    </>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => loadStorageStats()}
+                  disabled={isLoading}
+                  className="text-xs"
+                >
+                  <RefreshCw size={12} className={`mr-1 ${isLoading ? 'animate-spin' : ''}`} />
+                  Refresh
+                </Button>
+              </div>
+              {storageStats.isConnected && (
+                <div className="grid grid-cols-4 gap-3 text-sm">
+                  {[
+                    ['Test Cases', storageStats.testCases],
+                    ['Benchmarks', storageStats.experiments],
+                    ['Runs', storageStats.runs],
+                    ['Analytics', storageStats.analytics],
+                  ].map(([label, count]) => (
+                    <div key={label as string} className="p-2 bg-muted/30 rounded-lg text-center">
+                      <div className="text-muted-foreground text-xs mb-0.5">{label}</div>
+                      <div className="text-lg font-semibold">{count as number}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {isLoading && (
+            <p className="text-sm text-muted-foreground">Loading storage stats...</p>
+          )}
+
+          {!storageStats?.isConnected && !isLoading && (
+            <Alert className="bg-amber-900/20 border-amber-700/30">
+              <AlertTriangle className="h-4 w-4 text-amber-400" />
+              <AlertDescription className="text-amber-400">
+                Cannot connect to OpenSearch backend. Make sure the server is running.
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+      </Section>
+
+      {/* ── Observability Data Source ── */}
+      <Section
+        icon={<Server size={16} />}
+        title="Observability Data Source"
+        subtitle="OTEL traces, logs, metrics"
+      >
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="obs-endpoint" className="text-xs">Endpoint URL</Label>
+            <Input
+              id="obs-endpoint"
+              placeholder="https://opensearch.example.com:9200"
+              value={observabilityConfig.endpoint}
+              onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, endpoint: e.target.value })}
+            />
+          </div>
+
+          <AuthFields
+            prefix="obs"
+            config={observabilityConfig}
+            showPassword={showObservabilityPassword}
+            onTogglePassword={() => setShowObservabilityPassword(!showObservabilityPassword)}
+            onChange={(patch) => setObservabilityConfigState(prev => ({ ...prev, ...patch }))}
+            passwordSentinel={PASSWORD_STORED_SENTINEL}
+          />
+
+          {/* Advanced: Index Patterns */}
+          <div className="border-t pt-3">
+            <button
+              type="button"
+              onClick={() => setShowAdvancedIndexes(!showAdvancedIndexes)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {showAdvancedIndexes ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              Advanced: Index Patterns
+            </button>
+            {showAdvancedIndexes && (
+              <div className="mt-3 space-y-3 pl-4 border-l-2 border-muted">
+                <div className="space-y-1.5">
+                  <Label htmlFor="obs-traces-index" className="text-xs">Traces Index</Label>
+                  <Input
+                    id="obs-traces-index"
+                    placeholder="otel-v1-apm-span-* (default)"
+                    value={observabilityConfig.tracesIndex}
+                    onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, tracesIndex: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="obs-logs-index" className="text-xs">Logs Index</Label>
+                  <Input
+                    id="obs-logs-index"
+                    placeholder="ml-commons-logs-* (default)"
+                    value={observabilityConfig.logsIndex}
+                    onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, logsIndex: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="obs-metrics-index" className="text-xs">Metrics Index</Label>
+                  <Input
+                    id="obs-metrics-index"
+                    placeholder="otel-v1-apm-service-map* (default)"
+                    value={observabilityConfig.metricsIndex}
+                    onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, metricsIndex: e.target.value })}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {configStatus?.observability && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Source:</span>
+              <ConfigSourceBadge source={configStatus.observability.source} />
+            </div>
+          )}
+
+          <TestStatus status={observabilityTestStatus} message={observabilityTestMessage} />
+
+          {renderDataSourceActions(
+            observabilityConfig.endpoint,
+            observabilityTestStatus,
+            handleTestObservabilityConnection,
+            handleSaveObservabilityConfig,
+            handleClearObservabilityConfig,
+          )}
+        </div>
+      </Section>
+
+      {/* ── Preferences ── */}
+      <Section icon={<Palette size={16} />} title="Preferences">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label className="text-sm font-medium">Theme</Label>
+            <p className="text-xs text-muted-foreground">Color theme for the interface</p>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant={currentTheme === 'light' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => handleThemeChange('light')}
+            >
+              Light
+            </Button>
+            <Button
+              variant={currentTheme === 'dark' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => handleThemeChange('dark')}
+            >
+              Dark
+            </Button>
+          </div>
+        </div>
+      </Section>
+
+      {/* ── Debug ── */}
+      <Section icon={<Bug size={16} />} title="Debug" last={!hasLocalData}>
+        <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <div className="space-y-1">
-              <Label htmlFor="debug-mode" className="text-sm font-medium">
-                Debug Mode
-              </Label>
+            <div className="space-y-0.5">
+              <Label htmlFor="debug-mode" className="text-sm font-medium">Debug Mode</Label>
               <p className="text-xs text-muted-foreground">
-                Enable verbose logging (console.debug) AND real-time performance metrics overlay.
-                Useful for debugging evaluation flow, SSE events, and performance issues.
+                Verbose logging and real-time performance metrics overlay
               </p>
             </div>
             <Switch
@@ -845,11 +1406,11 @@ export const SettingsPage: React.FC = () => {
                   <div className="text-xs opacity-80">
                     <strong>Note:</strong> Browser debug logs use console.debug() which may be hidden by default.
                     <br />
-                    • <strong>Chrome:</strong> Console settings (⚙️) → Check "Verbose"
+                    &bull; <strong>Chrome:</strong> Console settings &gt; Check &quot;Verbose&quot;
                     <br />
-                    • <strong>Firefox:</strong> Console settings → Enable all log levels
+                    &bull; <strong>Firefox:</strong> Console settings &gt; Enable all log levels
                     <br />
-                    • <strong>Safari:</strong> Develop → Show JavaScript Console → All levels
+                    &bull; <strong>Safari:</strong> Develop &gt; Show JavaScript Console &gt; All levels
                   </div>
 
                   {/* Performance Monitoring Info */}
@@ -857,7 +1418,7 @@ export const SettingsPage: React.FC = () => {
                     <strong>Performance Monitoring:</strong> A metrics overlay will appear in the bottom-right corner on instrumented pages (Agent Traces, etc.).
                   </div>
                   <div className="text-xs opacity-80">
-                    <strong>Color coding:</strong> 🟢 Fast (&lt; 50ms) · 🟡 OK (&lt; 200ms) · 🔴 Slow (&gt; 200ms)
+                    <strong>Color coding:</strong> green: Fast (&lt; 50ms) · yellow: OK (&lt; 200ms) · red: Slow (&gt; 200ms)
                     <br />
                     <strong>Tracked:</strong> API calls, tree processing, render performance
                   </div>
@@ -865,906 +1426,92 @@ export const SettingsPage: React.FC = () => {
               </AlertDescription>
             </Alert>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </Section>
 
-      {/* Agent Endpoints */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Server size={18} />
-            Agent Endpoints
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {/* Built-in Agents */}
-          <div className="space-y-2">
-            <Label className="text-xs text-muted-foreground uppercase tracking-wide">Built-in Agents</Label>
+      {/* ── Data Migration (conditional) ── */}
+      {hasLocalData && (
+        <Section icon={<Upload size={16} />} title="Data Migration" last>
+          <p className="text-sm text-muted-foreground mb-4">
+            Found data in browser localStorage. Migrate to OpenSearch for persistent storage.
+          </p>
 
-            {DEFAULT_CONFIG.agents.filter(a => !a.isCustom).map((agent) => {
-
-              return (
-                <div
-                  key={agent.key}
-                  className="p-3 border rounded-lg bg-muted/5 flex items-start justify-between gap-3"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm flex items-center gap-2">
-                      {agent.name}
-                      <span className="text-xs px-2 py-1 rounded inline-block bg-blue-100 text-blue-900 border border-blue-300 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-700/50">
-                        built-in
-                      </span>
-                    </div>
-                    <div className="text-xs text-muted-foreground truncate flex items-center gap-1 mt-1">
-                      <ExternalLink size={10} />
-                      {agent.endpoint || <span className="italic">Not configured</span>}
-                    </div>
-                    {agent.description && (
-                      <div className="text-xs text-muted-foreground mt-1">{agent.description}</div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Custom Endpoints Section */}
-          <div className="border-t pt-4 mt-4">
-            <div className="flex items-center justify-between mb-3">
-              <Label className="text-xs text-muted-foreground uppercase tracking-wide">Custom Endpoints</Label>
-              {!isAddingEndpoint && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setIsAddingEndpoint(true)}
-                >
-                  <Plus size={14} className="mr-1" />
-                  Add
-                </Button>
-              )}
-            </div>
-            <p className="text-xs text-muted-foreground mb-3">
-              Add custom agent endpoints. These are persisted to agent-health.config.json in your project directory.
-            </p>
-          </div>
-
-          {/* Add new endpoint form */}
-          {isAddingEndpoint && (
-            <div className="p-4 border rounded-lg bg-muted/20 space-y-3">
-              <div className="space-y-1.5">
-                <Label htmlFor="new-endpoint-name" className="text-xs">Name</Label>
-                <Input
-                  id="new-endpoint-name"
-                  placeholder="My Agent"
-                  value={newEndpointName}
-                  onChange={(e) => setNewEndpointName(e.target.value)}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="new-endpoint-url" className="text-xs">Endpoint URL</Label>
-                <Input
-                  id="new-endpoint-url"
-                  placeholder="http://localhost:3000/api/agent"
-                  value={newEndpointUrl}
-                  onChange={(e) => {
-                    setNewEndpointUrl(e.target.value);
-                    setEndpointUrlError(null);
-                  }}
-                  className={endpointUrlError ? 'border-red-500' : ''}
-                />
-                {endpointUrlError && (
-                  <p className="text-xs text-red-500">{endpointUrlError}</p>
-                )}
-              </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs">Connector Type</Label>
-                <Select value={newConnectorType} onValueChange={(v) => setNewConnectorType(v as ConnectorProtocol)}>
-                  <SelectTrigger className="h-8 text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="agui-streaming">agui-streaming (default)</SelectItem>
-                    <SelectItem value="rest">rest</SelectItem>
-                    <SelectItem value="litellm">litellm</SelectItem>
-                    <SelectItem value="subprocess">subprocess</SelectItem>
-                    <SelectItem value="claude-code">claude-code</SelectItem>
-                    <SelectItem value="mock">mock</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="new-use-traces"
-                  checked={newUseTraces}
-                  onCheckedChange={setNewUseTraces}
-                />
-                <Label htmlFor="new-use-traces" className="text-xs">Enable Traces</Label>
-              </div>
-              <div className="flex gap-2">
-                <Button size="sm" onClick={handleAddEndpoint} disabled={!newEndpointName.trim() || !newEndpointUrl.trim()}>
-                  <Save size={14} className="mr-1" />
-                  Save
-                </Button>
-                <Button size="sm" variant="ghost" onClick={cancelEdit}>
-                  <X size={14} className="mr-1" />
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* List of custom endpoints */}
-          {customEndpoints.length > 0 ? (
-            <div className="space-y-2">
-              {customEndpoints.map((ep) => (
-                <div
-                  key={ep.id}
-                  className="p-3 border rounded-lg bg-muted/10 flex items-start justify-between gap-3"
-                >
-                  {editingEndpointId === ep.id ? (
-                    <div className="flex-1 space-y-3">
-                      <div className="space-y-1.5">
-                        <Label className="text-xs">Name</Label>
-                        <Input
-                          value={newEndpointName}
-                          onChange={(e) => setNewEndpointName(e.target.value)}
-                        />
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label className="text-xs">Endpoint URL</Label>
-                        <Input
-                          value={newEndpointUrl}
-                          onChange={(e) => {
-                            setNewEndpointUrl(e.target.value);
-                            setEndpointUrlError(null);
-                          }}
-                          className={endpointUrlError ? 'border-red-500' : ''}
-                        />
-                        {endpointUrlError && (
-                          <p className="text-xs text-red-500">{endpointUrlError}</p>
-                        )}
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label className="text-xs">Connector Type</Label>
-                        <Select value={newConnectorType} onValueChange={(v) => setNewConnectorType(v as ConnectorProtocol)}>
-                          <SelectTrigger className="h-8 text-xs">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="agui-streaming">agui-streaming (default)</SelectItem>
-                            <SelectItem value="rest">rest</SelectItem>
-                            <SelectItem value="litellm">litellm</SelectItem>
-                            <SelectItem value="subprocess">subprocess</SelectItem>
-                            <SelectItem value="claude-code">claude-code</SelectItem>
-                            <SelectItem value="mock">mock</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Switch
-                          id={`edit-use-traces-${ep.id}`}
-                          checked={newUseTraces}
-                          onCheckedChange={setNewUseTraces}
-                        />
-                        <Label htmlFor={`edit-use-traces-${ep.id}`} className="text-xs">Enable Traces</Label>
-                      </div>
-                      <div className="flex gap-2">
-                        <Button size="sm" onClick={() => handleUpdateEndpoint(ep.id)}>
-                          <Save size={14} className="mr-1" />
-                          Save
-                        </Button>
-                        <Button size="sm" variant="ghost" onClick={cancelEdit}>
-                          <X size={14} className="mr-1" />
-                          Cancel
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <>
-                      <div className="flex-1 min-w-0">
-                        <div className="font-medium text-sm">{ep.name}</div>
-                        <div className="text-xs text-muted-foreground truncate flex items-center gap-1 mt-1">
-                          <ExternalLink size={10} />
-                          {ep.endpoint}
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
-                          <span>{ep.connectorType ?? 'agui-streaming'}</span>
-                          {ep.useTraces && <span className="px-1.5 py-0.5 rounded bg-green-100 text-green-900 border border-green-300 dark:bg-green-950/50 dark:text-green-300 dark:border-green-700/50">traces</span>}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => startEditEndpoint(ep)}
-                        >
-                          <Edit2 size={14} />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleDeleteEndpoint(ep.id)}
-                          className="text-red-400 hover:text-red-300"
-                          aria-label={`Remove ${ep.name}`}
-                        >
-                          <Trash2 size={14} />
-                        </Button>
-                      </div>
-                    </>
-                  )}
+          {localCounts && (
+            <div className="grid grid-cols-3 gap-3 text-sm mb-4">
+              {[
+                ['Test Cases', localCounts.testCases],
+                ['Experiments', localCounts.experiments],
+                ['Reports', localCounts.reports],
+              ].map(([label, count]) => (
+                <div key={label as string} className="p-2 bg-muted/30 rounded-lg text-center">
+                  <div className="text-muted-foreground text-xs mb-0.5">{label}</div>
+                  <div className="text-lg font-semibold">{count as number}</div>
                 </div>
               ))}
             </div>
-          ) : (
-            !isAddingEndpoint && (
-              <div className="text-center py-6 text-muted-foreground text-sm">
-                No custom endpoints configured.
-                <br />
-                <span className="text-xs">Click "Add Endpoint" to configure a new agent endpoint.</span>
-              </div>
-            )
           )}
 
-          <Alert className="bg-blue-900/10 border-blue-700/20">
-            <AlertDescription className="text-xs text-blue-300">
-              Custom endpoints will appear in the agent selector during evaluations.
-              For authentication, use environment variables in the server configuration.
-            </AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-
-      {/* Evaluation Storage Configuration */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Database size={18} />
-            Evaluation Storage
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Test cases, experiments, and run results
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-xs text-muted-foreground">
-            Configure the OpenSearch cluster for storing evaluation data. Credentials are stored securely on the server (in agent-health.config.json), not in your browser.
-          </p>
-
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="storage-endpoint" className="text-xs">Endpoint URL</Label>
-              <Input
-                id="storage-endpoint"
-                placeholder="https://opensearch.example.com:9200"
-                value={storageConfig.endpoint}
-                onChange={(e) => setStorageConfigState({ ...storageConfig, endpoint: e.target.value })}
-              />
-            </div>
-
-            {/* Authentication Type */}
-            <div className="space-y-1.5">
-              <Label className="text-xs">Authentication Type</Label>
-              <Select
-                value={storageConfig.authType}
-                onValueChange={(v) => setStorageConfigState({ ...storageConfig, authType: v as ClusterAuthType })}
-              >
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">No Auth</SelectItem>
-                  <SelectItem value="basic">Basic Auth (username/password)</SelectItem>
-                  <SelectItem value="sigv4">AWS SigV4</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {storageConfig.authType === 'none' ? (
-              /* No Auth - no credentials needed */
-              <div className="space-y-3 p-3 border rounded-lg bg-muted/10">
-                <p className="text-xs text-muted-foreground">
-                  No authentication — connects directly without credentials. Suitable for local development clusters.
-                </p>
-              </div>
-            ) : storageConfig.authType === 'basic' ? (
-              /* Basic Auth fields */
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="storage-username" className="text-xs">Username (optional)</Label>
-                  <Input
-                    id="storage-username"
-                    placeholder="Leave blank to use env var"
-                    value={storageConfig.username}
-                    onChange={(e) => setStorageConfigState({ ...storageConfig, username: e.target.value })}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="storage-password" className="text-xs">Password (optional)</Label>
-                  <div className="relative">
-                    <Input
-                      id="storage-password"
-                      type={showStoragePassword ? 'text' : 'password'}
-                      placeholder={storageConfig.password === PASSWORD_STORED_SENTINEL ? '••••••••' : 'Leave blank to use env var'}
-                      value={storageConfig.password === PASSWORD_STORED_SENTINEL ? '' : storageConfig.password}
-                      onChange={(e) => setStorageConfigState({ ...storageConfig, password: e.target.value })}
-                      className="pr-10"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowStoragePassword(!showStoragePassword)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                    >
-                      {showStoragePassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
-                  </div>
-                  {storageConfig.password === PASSWORD_STORED_SENTINEL && (
-                    <p className="text-xs text-muted-foreground">Password stored — leave blank to keep it, or type a new one to replace it</p>
-                  )}
-                </div>
-              </div>
-            ) : (
-              /* AWS SigV4 fields */
-              <div className="space-y-3 p-3 border rounded-lg bg-muted/10">
-                <p className="text-xs text-muted-foreground">
-                  Uses the AWS credential chain (env vars, ~/.aws/credentials, IAM role, etc.)
-                </p>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="storage-aws-region" className="text-xs">AWS Region (required)</Label>
-                    <Input
-                      id="storage-aws-region"
-                      placeholder="us-east-1"
-                      value={storageConfig.awsRegion}
-                      onChange={(e) => setStorageConfigState({ ...storageConfig, awsRegion: e.target.value })}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="storage-aws-profile" className="text-xs">AWS Profile (optional)</Label>
-                    <Input
-                      id="storage-aws-profile"
-                      placeholder="default"
-                      value={storageConfig.awsProfile}
-                      onChange={(e) => setStorageConfigState({ ...storageConfig, awsProfile: e.target.value })}
-                    />
-                  </div>
-                </div>
-                <div className="space-y-1.5">
-                  <Label className="text-xs">AWS Service</Label>
-                  <Select
-                    value={storageConfig.awsService}
-                    onValueChange={(v) => setStorageConfigState({ ...storageConfig, awsService: v as 'es' | 'aoss' })}
-                  >
-                    <SelectTrigger className="h-8 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="es">es (Managed OpenSearch)</SelectItem>
-                      <SelectItem value="aoss">aoss (Serverless)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            )}
-
-            {/* TLS Verification Toggle */}
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label htmlFor="storage-tls-skip" className="text-xs">Skip TLS Verification</Label>
-                <p className="text-xs text-muted-foreground">Enable for self-signed certificates</p>
-              </div>
-              <Switch
-                id="storage-tls-skip"
-                checked={storageConfig.tlsSkipVerify}
-                onCheckedChange={(checked) => setStorageConfigState({ ...storageConfig, tlsSkipVerify: checked })}
-              />
-            </div>
-          </div>
-
-          {/* Config source indicator */}
-          {configStatus?.storage && (
-            <div className="flex items-center gap-2 text-xs">
-              <span className="text-muted-foreground">Currently configured via:</span>
-              <span className={`px-2 py-0.5 rounded ${
-                configStatus.storage.source === 'file' 
-                  ? 'bg-green-100 text-green-900 border border-green-300 dark:bg-green-950/50 dark:text-green-300 dark:border-green-700/50'
-                  : configStatus.storage.source === 'environment' 
-                  ? 'bg-blue-100 text-blue-900 border border-blue-300 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-700/50'
-                  : 'bg-gray-100 text-gray-900 border border-gray-300 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700/50'
-              }`}>
-                {configStatus.storage.source === 'file' ? 'Config file (agent-health.config.json)' :
-                 configStatus.storage.source === 'environment' ? 'Environment variables' :
-                 'Not configured'}
-              </span>
-            </div>
+          {migrationStatus && (
+            <Alert className={`mb-4 ${migrationStatus.includes('failed') ? 'bg-red-900/20 border-red-700/30' : 'bg-blue-900/20 border-blue-700/30'}`}>
+              {isMigrating && <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />}
+              <AlertDescription className={migrationStatus.includes('failed') ? 'text-red-400' : 'text-blue-400'}>
+                {migrationStatus}
+              </AlertDescription>
+            </Alert>
           )}
 
-          {/* Test connection status */}
-          {storageTestMessage && (
-            <div className={`flex items-center gap-2 text-sm ${
-              storageTestStatus === 'success' ? 'text-green-400' :
-              storageTestStatus === 'error' ? 'text-red-400' :
-              storageTestStatus === 'testing' ? 'text-blue-400' : 'text-muted-foreground'
-            }`}>
-              {storageTestStatus === 'testing' && <Loader2 size={14} className="animate-spin" />}
-              {storageTestStatus === 'success' && <CheckCircle2 size={14} />}
-              {storageTestStatus === 'error' && <XCircle size={14} />}
-              {storageTestMessage}
-            </div>
-          )}
-
-          <div className="flex flex-wrap gap-2 pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleTestStorageConnection}
-              disabled={!storageConfig.endpoint || storageTestStatus === 'testing'}
-            >
-              {storageTestStatus === 'testing' ? (
-                <>
-                  <Loader2 size={14} className="mr-1 animate-spin" />
-                  Testing...
-                </>
-              ) : (
-                'Test Connection'
+          {migrationResult && (
+            <div className="p-3 bg-muted/30 rounded-lg text-sm space-y-1 mb-4">
+              <div className="font-medium mb-2">Migration Results:</div>
+              <div>Test Cases: {migrationResult.testCases.migrated} migrated, {migrationResult.testCases.skipped} skipped</div>
+              <div>Experiments: {migrationResult.experiments.migrated} migrated, {migrationResult.experiments.skipped} skipped</div>
+              <div>Reports: {migrationResult.reports.migrated} migrated, {migrationResult.reports.skipped} skipped</div>
+              {(migrationResult.testCases.errors.length > 0 ||
+                migrationResult.experiments.errors.length > 0 ||
+                migrationResult.reports.errors.length > 0) && (
+                <div className="text-amber-400 mt-2">
+                  {migrationResult.testCases.errors.length + migrationResult.experiments.errors.length + migrationResult.reports.errors.length} errors occurred
+                </div>
               )}
-            </Button>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
             <Button
+              variant="default"
               size="sm"
-              onClick={handleSaveStorageConfig}
-              disabled={!storageConfig.endpoint}
+              onClick={handleMigrate}
+              disabled={isMigrating || !storageStats?.isConnected}
               className="bg-opensearch-blue hover:bg-blue-600"
             >
-              <Save size={14} className="mr-1" />
-              Save
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleClearStorageConfig}
-              disabled={!storageConfig.endpoint}
-            >
-              <Trash2 size={14} className="mr-1" />
-              Clear
-            </Button>
-          </div>
-
-          {/* Connection Status and Stats */}
-          <div className="border-t pt-4 mt-4">
-            {storageStats && (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    {storageStats.isConnected ? (
-                      <>
-                        <CheckCircle2 size={16} className="text-opensearch-blue" />
-                        <span className="text-sm text-opensearch-blue">Connected to OpenSearch</span>
-                      </>
-                    ) : (
-                      <>
-                        <XCircle size={16} className="text-red-400" />
-                        <span className="text-sm text-red-400">Not connected - start backend with `npm run dev:server`</span>
-                      </>
-                    )}
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => loadStorageStats()}
-                    disabled={isLoading}
-                    className="text-xs"
-                  >
-                    <RefreshCw size={12} className={`mr-1 ${isLoading ? 'animate-spin' : ''}`} />
-                    Refresh
-                  </Button>
-                </div>
-
-                {/* Index Stats */}
-                {storageStats.isConnected && (
-                  <div className="grid grid-cols-2 gap-3 text-sm">
-                    <div className="p-3 bg-muted/30 rounded-lg">
-                      <div className="text-muted-foreground text-xs uppercase mb-1">Test Cases</div>
-                      <div className="text-lg font-semibold">{storageStats.testCases}</div>
-                    </div>
-                    <div className="p-3 bg-muted/30 rounded-lg">
-                      <div className="text-muted-foreground text-xs uppercase mb-1">Experiments</div>
-                      <div className="text-lg font-semibold">{storageStats.experiments}</div>
-                    </div>
-                    <div className="p-3 bg-muted/30 rounded-lg">
-                      <div className="text-muted-foreground text-xs uppercase mb-1">Runs</div>
-                      <div className="text-lg font-semibold">{storageStats.runs}</div>
-                    </div>
-                    <div className="p-3 bg-muted/30 rounded-lg">
-                      <div className="text-muted-foreground text-xs uppercase mb-1">Analytics Records</div>
-                      <div className="text-lg font-semibold">{storageStats.analytics}</div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {isLoading && (
-              <p className="text-sm text-muted-foreground">Loading storage stats...</p>
-            )}
-
-            {!storageStats?.isConnected && !isLoading && (
-              <Alert className="bg-amber-900/20 border-amber-700/30">
-                <AlertTriangle className="h-4 w-4 text-amber-400" />
-                <AlertDescription className="text-amber-400">
-                  Cannot connect to OpenSearch backend. Make sure the server is running.
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Observability Data Source Configuration */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Server size={18} />
-            Observability Data Source
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            OTEL instrumentation for traces, logs, and metrics
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-xs text-muted-foreground">
-            Configure the OpenSearch cluster for observability data. Credentials are stored securely on the server (in agent-health.config.json), not in your browser.
-          </p>
-
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="obs-endpoint" className="text-xs">Endpoint URL</Label>
-              <Input
-                id="obs-endpoint"
-                placeholder="https://opensearch.example.com:9200"
-                value={observabilityConfig.endpoint}
-                onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, endpoint: e.target.value })}
-              />
-            </div>
-
-            {/* Authentication Type */}
-            <div className="space-y-1.5">
-              <Label className="text-xs">Authentication Type</Label>
-              <Select
-                value={observabilityConfig.authType}
-                onValueChange={(v) => setObservabilityConfigState({ ...observabilityConfig, authType: v as ClusterAuthType })}
-              >
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">No Auth</SelectItem>
-                  <SelectItem value="basic">Basic Auth (username/password)</SelectItem>
-                  <SelectItem value="sigv4">AWS SigV4</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {observabilityConfig.authType === 'none' ? (
-              /* No Auth - no credentials needed */
-              <div className="space-y-3 p-3 border rounded-lg bg-muted/10">
-                <p className="text-xs text-muted-foreground">
-                  No authentication — connects directly without credentials. Suitable for local development clusters.
-                </p>
-              </div>
-            ) : observabilityConfig.authType === 'basic' ? (
-              /* Basic Auth fields */
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="obs-username" className="text-xs">Username (optional)</Label>
-                  <Input
-                    id="obs-username"
-                    placeholder="Leave blank to use env var"
-                    value={observabilityConfig.username}
-                    onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, username: e.target.value })}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="obs-password" className="text-xs">Password (optional)</Label>
-                  <div className="relative">
-                    <Input
-                      id="obs-password"
-                      type={showObservabilityPassword ? 'text' : 'password'}
-                      placeholder={observabilityConfig.password === PASSWORD_STORED_SENTINEL ? '••••••••' : 'Leave blank to use env var'}
-                      value={observabilityConfig.password === PASSWORD_STORED_SENTINEL ? '' : observabilityConfig.password}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, password: e.target.value })}
-                      className="pr-10"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowObservabilityPassword(!showObservabilityPassword)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                    >
-                      {showObservabilityPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
-                  </div>
-                  {observabilityConfig.password === PASSWORD_STORED_SENTINEL && (
-                    <p className="text-xs text-muted-foreground">Password stored — leave blank to keep it, or type a new one to replace it</p>
-                  )}
-                </div>
-              </div>
-            ) : (
-              /* AWS SigV4 fields */
-              <div className="space-y-3 p-3 border rounded-lg bg-muted/10">
-                <p className="text-xs text-muted-foreground">
-                  Uses the AWS credential chain (env vars, ~/.aws/credentials, IAM role, etc.)
-                </p>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="obs-aws-region" className="text-xs">AWS Region (required)</Label>
-                    <Input
-                      id="obs-aws-region"
-                      placeholder="us-east-1"
-                      value={observabilityConfig.awsRegion}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, awsRegion: e.target.value })}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="obs-aws-profile" className="text-xs">AWS Profile (optional)</Label>
-                    <Input
-                      id="obs-aws-profile"
-                      placeholder="default"
-                      value={observabilityConfig.awsProfile}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, awsProfile: e.target.value })}
-                    />
-                  </div>
-                </div>
-                <div className="space-y-1.5">
-                  <Label className="text-xs">AWS Service</Label>
-                  <Select
-                    value={observabilityConfig.awsService}
-                    onValueChange={(v) => setObservabilityConfigState({ ...observabilityConfig, awsService: v as 'es' | 'aoss' })}
-                  >
-                    <SelectTrigger className="h-8 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="es">es (Managed OpenSearch)</SelectItem>
-                      <SelectItem value="aoss">aoss (Serverless)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            )}
-
-            {/* TLS Verification Toggle */}
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label htmlFor="obs-tls-skip" className="text-xs">Skip TLS Verification</Label>
-                <p className="text-xs text-muted-foreground">Enable for self-signed certificates</p>
-              </div>
-              <Switch
-                id="obs-tls-skip"
-                checked={observabilityConfig.tlsSkipVerify}
-                onCheckedChange={(checked) => setObservabilityConfigState({ ...observabilityConfig, tlsSkipVerify: checked })}
-              />
-            </div>
-
-            {/* Advanced: Index Patterns */}
-            <div className="border-t pt-3 mt-3">
-              <button
-                type="button"
-                onClick={() => setShowAdvancedIndexes(!showAdvancedIndexes)}
-                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-              >
-                {showAdvancedIndexes ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                Advanced: Index Patterns
-              </button>
-              {showAdvancedIndexes && (
-                <div className="mt-3 space-y-3 pl-4 border-l-2 border-muted">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="obs-traces-index" className="text-xs">Traces Index</Label>
-                    <Input
-                      id="obs-traces-index"
-                      placeholder="otel-v1-apm-span-* (default)"
-                      value={observabilityConfig.tracesIndex}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, tracesIndex: e.target.value })}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="obs-logs-index" className="text-xs">Logs Index</Label>
-                    <Input
-                      id="obs-logs-index"
-                      placeholder="ml-commons-logs-* (default)"
-                      value={observabilityConfig.logsIndex}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, logsIndex: e.target.value })}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="obs-metrics-index" className="text-xs">Metrics Index</Label>
-                    <Input
-                      id="obs-metrics-index"
-                      placeholder="otel-v1-apm-service-map* (default)"
-                      value={observabilityConfig.metricsIndex}
-                      onChange={(e) => setObservabilityConfigState({ ...observabilityConfig, metricsIndex: e.target.value })}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Config source indicator */}
-          {configStatus?.observability && (
-            <div className="flex items-center gap-2 text-xs">
-              <span className="text-muted-foreground">Currently configured via:</span>
-              <span className={`px-2 py-0.5 rounded ${
-                configStatus.observability.source === 'file' 
-                  ? 'bg-green-100 text-green-900 border border-green-300 dark:bg-green-950/50 dark:text-green-300 dark:border-green-700/50'
-                  : configStatus.observability.source === 'environment' 
-                  ? 'bg-blue-100 text-blue-900 border border-blue-300 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-700/50'
-                  : 'bg-gray-100 text-gray-900 border border-gray-300 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700/50'
-              }`}>
-                {configStatus.observability.source === 'file' ? 'Config file (agent-health.config.json)' :
-                 configStatus.observability.source === 'environment' ? 'Environment variables' :
-                 'Not configured'}
-              </span>
-            </div>
-          )}
-
-          {/* Test connection status */}
-          {observabilityTestMessage && (
-            <div className={`flex items-center gap-2 text-sm ${
-              observabilityTestStatus === 'success' ? 'text-green-400' :
-              observabilityTestStatus === 'error' ? 'text-red-400' :
-              observabilityTestStatus === 'testing' ? 'text-blue-400' : 'text-muted-foreground'
-            }`}>
-              {observabilityTestStatus === 'testing' && <Loader2 size={14} className="animate-spin" />}
-              {observabilityTestStatus === 'success' && <CheckCircle2 size={14} />}
-              {observabilityTestStatus === 'error' && <XCircle size={14} />}
-              {observabilityTestMessage}
-            </div>
-          )}
-
-          <div className="flex flex-wrap gap-2 pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleTestObservabilityConnection}
-              disabled={!observabilityConfig.endpoint || observabilityTestStatus === 'testing'}
-            >
-              {observabilityTestStatus === 'testing' ? (
-                <>
-                  <Loader2 size={14} className="mr-1 animate-spin" />
-                  Testing...
-                </>
+              {isMigrating ? (
+                <><Loader2 size={14} className="mr-1 animate-spin" />Migrating...</>
               ) : (
-                'Test Connection'
+                <><Upload size={14} className="mr-1" />Migrate to OpenSearch</>
               )}
             </Button>
-            <Button
-              size="sm"
-              onClick={handleSaveObservabilityConfig}
-              disabled={!observabilityConfig.endpoint}
-              className="bg-opensearch-blue hover:bg-blue-600"
-            >
-              <Save size={14} className="mr-1" />
-              Save
+            <Button variant="outline" size="sm" onClick={handleExportLocalData} disabled={isMigrating}>
+              <Download size={14} className="mr-1" />
+              Export as JSON
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={handleClearObservabilityConfig}
-              disabled={!observabilityConfig.endpoint}
+              onClick={handleClearLocalData}
+              disabled={isMigrating}
+              className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
             >
               <Trash2 size={14} className="mr-1" />
-              Clear
+              Clear localStorage
             </Button>
           </div>
-        </CardContent>
-      </Card>
 
-      {/* Data Migration */}
-      {hasLocalData && (
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Upload size={18} />
-              Data Migration
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Found existing data in browser localStorage. Migrate it to OpenSearch for persistent storage.
+          {!storageStats?.isConnected && (
+            <p className="text-xs text-amber-400 mt-2">
+              Connect to OpenSearch backend first before migrating.
             </p>
-
-            {/* Local Data Stats */}
-            {localCounts && (
-              <div className="grid grid-cols-3 gap-4 text-sm">
-                <div className="p-3 bg-muted/30 rounded-lg">
-                  <div className="text-muted-foreground text-xs uppercase mb-1">Test Cases</div>
-                  <div className="text-lg font-semibold">{localCounts.testCases}</div>
-                </div>
-                <div className="p-3 bg-muted/30 rounded-lg">
-                  <div className="text-muted-foreground text-xs uppercase mb-1">Experiments</div>
-                  <div className="text-lg font-semibold">{localCounts.experiments}</div>
-                </div>
-                <div className="p-3 bg-muted/30 rounded-lg">
-                  <div className="text-muted-foreground text-xs uppercase mb-1">Reports</div>
-                  <div className="text-lg font-semibold">{localCounts.reports}</div>
-                </div>
-              </div>
-            )}
-
-            {/* Migration Status */}
-            {migrationStatus && (
-              <Alert className={migrationStatus.includes('failed') ? 'bg-red-900/20 border-red-700/30' : 'bg-blue-900/20 border-blue-700/30'}>
-                {isMigrating && <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />}
-                <AlertDescription className={migrationStatus.includes('failed') ? 'text-red-400' : 'text-blue-400'}>
-                  {migrationStatus}
-                </AlertDescription>
-              </Alert>
-            )}
-
-            {/* Migration Results */}
-            {migrationResult && (
-              <div className="p-3 bg-muted/30 rounded-lg text-sm space-y-1">
-                <div className="font-medium mb-2">Migration Results:</div>
-                <div>Test Cases: {migrationResult.testCases.migrated} migrated, {migrationResult.testCases.skipped} skipped</div>
-                <div>Experiments: {migrationResult.experiments.migrated} migrated, {migrationResult.experiments.skipped} skipped</div>
-                <div>Reports: {migrationResult.reports.migrated} migrated, {migrationResult.reports.skipped} skipped</div>
-                {(migrationResult.testCases.errors.length > 0 ||
-                  migrationResult.experiments.errors.length > 0 ||
-                  migrationResult.reports.errors.length > 0) && (
-                  <div className="text-amber-400 mt-2">
-                    {migrationResult.testCases.errors.length + migrationResult.experiments.errors.length + migrationResult.reports.errors.length} errors occurred
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="flex flex-wrap gap-2 pt-2">
-              <Button
-                variant="default"
-                size="sm"
-                onClick={handleMigrate}
-                disabled={isMigrating || !storageStats?.isConnected}
-                className="bg-opensearch-blue hover:bg-blue-600"
-              >
-                {isMigrating ? (
-                  <>
-                    <Loader2 size={14} className="mr-1 animate-spin" />
-                    Migrating...
-                  </>
-                ) : (
-                  <>
-                    <Upload size={14} className="mr-1" />
-                    Migrate to OpenSearch
-                  </>
-                )}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleExportLocalData}
-                disabled={isMigrating}
-              >
-                <Download size={14} className="mr-1" />
-                Export as JSON
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleClearLocalData}
-                disabled={isMigrating}
-                className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
-              >
-                <Trash2 size={14} className="mr-1" />
-                Clear localStorage
-              </Button>
-            </div>
-
-            {!storageStats?.isConnected && (
-              <p className="text-xs text-amber-400">
-                Connect to OpenSearch backend first before migrating.
-              </p>
-            )}
-          </CardContent>
-        </Card>
+          )}
+        </Section>
       )}
     </div>
 

--- a/components/TestCaseDetailPanel.tsx
+++ b/components/TestCaseDetailPanel.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Calendar, Play } from 'lucide-react';
+import React, { useState } from 'react';
+import { Calendar, Play, Repeat, ChevronDown, ChevronRight, MessageCircle, Zap } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { TestCase } from '@/types';
@@ -16,6 +16,7 @@ interface TestCaseDetailPanelProps {
 }
 
 export const TestCaseDetailPanel: React.FC<TestCaseDetailPanelProps> = ({ testCase, totalRuns }) => {
+  const [idealAnswerExpanded, setIdealAnswerExpanded] = useState(false);
   return (
     <div className="space-y-4">
       {/* Labels */}
@@ -119,6 +120,129 @@ export const TestCaseDetailPanel: React.FC<TestCaseDetailPanelProps> = ({ testCa
               <pre className="text-xs overflow-x-auto">{testCase.expectedPPL}</pre>
             </CardContent>
           </Card>
+        </div>
+      )}
+
+      {/* Multi-Turn Scenario */}
+      {testCase.multiTurnScenario && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide flex items-center gap-1">
+            <Repeat size={12} /> Multi-Turn Scenario
+          </h4>
+
+          {/* User Motivation */}
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">User Motivation</span>
+            <p className="text-sm">{testCase.multiTurnScenario.userMotivation}</p>
+          </div>
+
+          {/* Acceptance Criteria */}
+          {testCase.multiTurnScenario.acceptanceCriteria.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-xs text-muted-foreground">Acceptance Criteria</span>
+              <ul className="space-y-1">
+                {testCase.multiTurnScenario.acceptanceCriteria.map((criterion, i) => (
+                  <li key={i} className="text-sm text-muted-foreground flex items-start gap-2">
+                    <span className="text-opensearch-blue mt-0.5">•</span>
+                    <span>{criterion}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Ideal Answer (collapsible) */}
+          <div className="space-y-1">
+            <button
+              className="text-xs text-muted-foreground flex items-center gap-1 hover:text-foreground transition-colors"
+              onClick={() => setIdealAnswerExpanded(!idealAnswerExpanded)}
+            >
+              {idealAnswerExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              Ideal Answer
+            </button>
+            {idealAnswerExpanded && (
+              <Card className="bg-muted/30">
+                <CardContent className="p-2">
+                  <p className="text-xs whitespace-pre-wrap">{testCase.multiTurnScenario.idealAnswer}</p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          {/* Critical Components */}
+          {testCase.multiTurnScenario.criticalComponents && (
+            <div className="space-y-1">
+              <span className="text-xs text-muted-foreground">Critical Components</span>
+              <div className="text-xs space-y-1">
+                <div className="flex items-start gap-2 pl-2 border-l-2 border-red-500/30">
+                  <span className="text-red-400 font-medium">Root Cause:</span>
+                  <span className="text-muted-foreground">{testCase.multiTurnScenario.criticalComponents.rootCause}</span>
+                </div>
+                <div className="flex items-start gap-2 pl-2 border-l-2 border-emerald-500/30">
+                  <span className="text-emerald-400 font-medium">Remediation:</span>
+                  <span className="text-muted-foreground">{testCase.multiTurnScenario.criticalComponents.remediation}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Turn Limit */}
+          {testCase.multiTurnScenario.turnLimit && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Turn Limit:</span>
+              <Badge variant="secondary" className="text-[10px]">{testCase.multiTurnScenario.turnLimit}</Badge>
+            </div>
+          )}
+
+          {/* Reference Turns */}
+          {testCase.multiTurnScenario.referenceTurns && testCase.multiTurnScenario.referenceTurns.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-xs text-muted-foreground">Reference Turns ({testCase.multiTurnScenario.referenceTurns.length})</span>
+              <div className="space-y-2">
+                {testCase.multiTurnScenario.referenceTurns.map((rt, i) => (
+                  <Card key={i} className="bg-muted/30">
+                    <CardContent className="p-2 space-y-1">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="text-[10px]">Turn {rt.turn}</Badge>
+                        <span className="text-xs truncate">{rt.user}</span>
+                      </div>
+                      <div className="flex gap-1 flex-wrap">
+                        {rt.expectedTopics.map((topic, j) => (
+                          <Badge key={j} variant="secondary" className="text-[10px]">{topic}</Badge>
+                        ))}
+                      </div>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{rt.groundTruth}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Follow-Up Questions */}
+      {testCase.followUpQuestions && testCase.followUpQuestions.length > 0 && (
+        <div className="space-y-1">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide flex items-center gap-1">
+            <MessageCircle size={12} /> Follow-Up Questions
+          </h4>
+          <div className="space-y-2">
+            {testCase.followUpQuestions.map((fq, i) => (
+              <Card key={i} className="bg-muted/30">
+                <CardContent className="p-2 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-[10px]">
+                      <Zap size={8} className="mr-0.5" />
+                      {fq.trigger}
+                    </Badge>
+                  </div>
+                  <p className="text-sm">{fq.question}</p>
+                  <p className="text-xs text-muted-foreground">{fq.businessValue}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/components/TestCasesPage.tsx
+++ b/components/TestCasesPage.tsx
@@ -73,9 +73,14 @@ const groupByCategory = (testCases: TestCase[]): Record<string, TestCase[]> => {
     tc.updatedAt ? new Date(tc.updatedAt).getTime() : 0,
     tc.createdAt ? new Date(tc.createdAt).getTime() : 0,
   );
-  // Sort categories alphabetically and sort test cases within each category by lastActivity
+  // Sort categories by most-recent activity (so newly imported tests float to the top)
+  // and sort test cases within each category by lastActivity
   return Object.keys(grouped)
-    .sort()
+    .sort((a, b) => {
+      const maxA = Math.max(...grouped[a].map(lastActivity));
+      const maxB = Math.max(...grouped[b].map(lastActivity));
+      return maxB - maxA;
+    })
     .reduce((acc, key) => {
       acc[key] = grouped[key].sort((a, b) => lastActivity(b) - lastActivity(a));
       return acc;
@@ -108,7 +113,7 @@ const TestCaseCard = ({ testCase, runCount, onClick, onRun, onEdit, onDelete, is
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0">
-            <CardTitle className="text-base truncate">{testCase.name || '(Unnamed)'}</CardTitle>
+            <CardTitle className="text-base truncate">{testCase.name || <span className="italic text-muted-foreground">Untitled Test Case</span>}</CardTitle>
             <CardDescription className="flex items-center gap-2 mt-1 flex-wrap">
               {displayLabels.map((label) => (
                 <Badge 

--- a/components/traces/SpanInputOutput.tsx
+++ b/components/traces/SpanInputOutput.tsx
@@ -61,7 +61,12 @@ function getEventContent(span: Span, eventName: string): string | null {
   const value = event.attributes['content'] ||
                 event.attributes['body'] ||
                 event.attributes['gen_ai.content'] ||
-                event.attributes['message'];
+                event.attributes['message'] ||
+                event.attributes['llm.prompt'] ||
+                event.attributes['llm.completion'] ||
+                event.attributes['llm.system_prompt'] ||
+                event.attributes['tool.parameters'] ||
+                event.attributes['tool.result'];
   if (!value) return null;
   return typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
 }
@@ -97,6 +102,7 @@ function extractSpanIO(span: Span): SpanIOData {
   // LLM spans - check span events first (standard OTel), then attributes
   if (category === 'llm') {
     input = getEventContent(span, 'gen_ai.content.prompt') ||
+            getEventContent(span, 'llm.request') ||
             attrs['gen_ai.input.messages'] ||
             attrs['gen_ai.prompt'] ||
             attrs['gen_ai.prompt.0.content'] ||
@@ -106,6 +112,7 @@ function extractSpanIO(span: Span): SpanIOData {
             null;
 
     output = getEventContent(span, 'gen_ai.content.completion') ||
+             getEventContent(span, 'llm.response') ||
              attrs['gen_ai.output.messages'] ||
              attrs['gen_ai.completion'] ||
              attrs['gen_ai.completion.0.content'] ||
@@ -119,6 +126,7 @@ function extractSpanIO(span: Span): SpanIOData {
   if (category === 'tool') {
     input = attrs['gen_ai.tool.call.arguments'] ||
             getEventContent(span, 'gen_ai.tool.input') ||
+            getEventContent(span, 'tool.input') ||
             attrs['gen_ai.tool.input'] ||
             attrs['tool.input'] ||
             attrs['input.value'] ||
@@ -127,6 +135,7 @@ function extractSpanIO(span: Span): SpanIOData {
 
     output = attrs['gen_ai.tool.call.result'] ||
              getEventContent(span, 'gen_ai.tool.output') ||
+             getEventContent(span, 'tool.output') ||
              attrs['gen_ai.tool.output'] ||
              attrs['tool.output'] ||
              attrs['output.value'] ||

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -23,6 +23,7 @@ module.exports = {
     // Mock data files to avoid JSON import issues in tests
     '^@/data/testCases$': '<rootDir>/__mocks__/@/data/testCases.ts',
     '^@/data/mockComparisonData$': '<rootDir>/__mocks__/@/data/mockComparisonData.ts',
+    '^@/(.*)\\.js$': '<rootDir>/$1',
     '^@/(.*)$': '<rootDir>/$1',
     // Mock browser-only modules
     '^dagre$': '<rootDir>/__mocks__/dagre.ts',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,7 @@ export interface EnvConfig {
 
   // API endpoints (derived from backend URL)
   judgeApiUrl: string;
+  simulatorApiUrl: string;
   storageApiUrl: string;
   agentProxyUrl: string;
   openSearchProxyUrl: string;
@@ -102,6 +103,7 @@ export const ENV_CONFIG: EnvConfig = {
 
   // API endpoints (derived from backend URL)
   judgeApiUrl: `${BACKEND_URL}/api/judge`,
+  simulatorApiUrl: `${BACKEND_URL}/api/simulate-followup`,
   storageApiUrl: `${BACKEND_URL}/api/storage`,
   agentProxyUrl: `${BACKEND_URL}/api/agent`,
   openSearchProxyUrl: `${BACKEND_URL}/api/opensearch/logs`,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -20,7 +20,7 @@ const isServerSide = typeof window === 'undefined';
 
 // Empty string = relative URLs (works in browser)
 // Full URL needed for server-side (Node.js) since fetch() has no base URL context
-const SERVER_PORT = isServerSide ? (process.env?.VITE_BACKEND_PORT || process.env?.PORT || '4001') : '4001';
+const SERVER_PORT = isServerSide ? (process.env?.PORT || '4001') : '4001';
 const BACKEND_URL = isServerSide ? `http://localhost:${SERVER_PORT}` : '';
 
 export interface EnvConfig {

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -74,6 +74,11 @@ function toAgentConfig(userAgent: UserAgentConfig): AgentConfig {
     connectorType: userAgent.connectorType,
     connectorConfig: userAgent.connectorConfig,
     hooks: userAgent.hooks,
+    multiTurnOptions: userAgent.multiTurnOptions ? {
+      enabled: userAgent.multiTurnOptions.enabled,
+      maxTurns: userAgent.multiTurnOptions.maxTurns,
+      interruptPolicy: userAgent.multiTurnOptions.interruptPolicy,
+    } : undefined,
   };
 }
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -27,6 +27,13 @@ export interface UserAgentConfig {
   connectorType?: ConnectorProtocol;
   connectorConfig?: Record<string, any>;
   hooks?: AgentHooks;
+  multiTurnOptions?: {
+    enabled?: boolean;
+    maxTurns?: number;
+    interruptPolicy?: 'auto-approve' | 'auto-reject' | 'skip';
+    detectInterrupt?: (result: any) => any;
+    buildResponse?: (interrupt: any, policy: string) => any;
+  };
 }
 
 /**

--- a/lib/testCaseValidation.ts
+++ b/lib/testCaseValidation.ts
@@ -89,7 +89,7 @@ export const testCasesArraySchema = z.array(testCaseSchema).min(1, 'Array cannot
  */
 export type ValidatedTestCaseInput = Pick<
   CreateTestCaseInput,
-  'name' | 'description' | 'category' | 'subcategory' | 'difficulty' | 'initialPrompt' | 'context' | 'expectedOutcomes'
+  'name' | 'description' | 'category' | 'subcategory' | 'difficulty' | 'initialPrompt' | 'context' | 'expectedOutcomes' | 'multiTurnScenario'
 >;
 
 // Form state for the TestCaseEditor component

--- a/lib/testCaseValidation.ts
+++ b/lib/testCaseValidation.ts
@@ -18,6 +18,44 @@ const contextItemSchema = z
 
 const difficultySchema = z.enum(['Easy', 'Medium', 'Hard']);
 
+const referenceTurnSchema = z.object({
+  turn: z.number(),
+  user: z.string(),
+  expectedTopics: z.array(z.string()),
+  groundTruth: z.string(),
+});
+
+const scoringWeightsSchema = z.object({
+  rootCause: z.number().min(0).max(100).optional(),
+  remediation: z.number().min(0).max(100).optional(),
+  contextRetention: z.number().min(0).max(100).optional(),
+  conciseness: z.number().min(0).max(100).optional(),
+}).refine(
+  (weights) => {
+    const values = [
+      weights.rootCause ?? 40,
+      weights.remediation ?? 30,
+      weights.contextRetention ?? 20,
+      weights.conciseness ?? 10,
+    ];
+    return values.reduce((a, b) => a + b, 0) === 100;
+  },
+  'Scoring weights must sum to 100'
+).optional();
+
+const multiTurnScenarioSchema = z.object({
+  userMotivation: z.string().min(1, 'User motivation is required'),
+  acceptanceCriteria: z.array(z.string()).min(1, 'At least one acceptance criterion is required'),
+  idealAnswer: z.string().min(1, 'Ideal answer is required'),
+  criticalComponents: z.object({
+    rootCause: z.string(),
+    remediation: z.string(),
+  }).optional(),
+  turnLimit: z.number().min(1).max(50).optional(),
+  scoringWeights: scoringWeightsSchema,
+  referenceTurns: z.array(referenceTurnSchema).optional(),
+}).optional();
+
 /**
  * Zod schema for validating test case JSON input.
  * This validates a subset of CreateTestCaseInput fields that are relevant for the JSON editor.
@@ -37,6 +75,7 @@ export const testCaseSchema = z.object({
       (outcomes) => outcomes.some((o) => o.trim().length > 0),
       'At least one non-empty expected outcome is required'
     ),
+  multiTurnScenario: multiTurnScenarioSchema,
 });
 
 export const testCasesArraySchema = z.array(testCaseSchema).min(1, 'Array cannot be empty');

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -14,7 +14,7 @@ import { StorageConfig } from '@/types';
 // Server Configuration
 // ============================================================================
 
-export const PORT = parseInt(process.env.PORT || process.env.BACKEND_PORT || process.env.VITE_BACKEND_PORT || '4001', 10);
+export const PORT = parseInt(process.env.PORT || '4001', 10);
 
 // ============================================================================
 // AWS Configuration

--- a/server/constants/indexMappings.ts
+++ b/server/constants/indexMappings.ts
@@ -157,6 +157,8 @@ export function getIndexMappings(): IndexMappings {
           logs: { type: 'object', enabled: false },
           rawEvents: { type: 'object', enabled: false },
           improvementStrategies: { type: 'object', enabled: false },
+          multiTurnResult: { type: 'object', enabled: false },
+          turnRunIds: { type: 'keyword' },
           spans: { type: 'object', enabled: false },
           metricsStatus: { type: 'keyword' },
           traceFetchAttempts: { type: 'integer' },

--- a/server/middleware/index.ts
+++ b/server/middleware/index.ts
@@ -75,9 +75,6 @@ export function setupSpaFallback(app: Express): void {
 
   if (!fs.existsSync(indexPath)) return;
 
-  // Read index.html once at startup — avoids sendFile issues in esbuild bundles
-  const indexHtml = fs.readFileSync(indexPath, 'utf-8');
-
   app.use((req: Request, res: Response, next: NextFunction) => {
     // Skip API routes and health checks
     if (req.path.startsWith('/api/') || req.path === '/health') {
@@ -87,7 +84,18 @@ export function setupSpaFallback(app: Express): void {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       return next();
     }
-    res.type('html').send(indexHtml);
+    // Don't serve index.html for static asset requests — let them 404 properly
+    if (req.path.startsWith('/assets/')) {
+      return next();
+    }
+    // Read index.html from disk on each request so rebuilds are picked up
+    // without needing a server restart
+    try {
+      const indexHtml = fs.readFileSync(indexPath, 'utf-8');
+      res.type('html').send(indexHtml);
+    } catch {
+      next();
+    }
   });
 }
 

--- a/server/middleware/storageClient.ts
+++ b/server/middleware/storageClient.ts
@@ -49,7 +49,7 @@ function getOrCreateClient(config: StorageClusterConfig): Client {
 /**
  * Cleanup expired clients every minute
  */
-setInterval(() => {
+const cleanupInterval = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of clientCache.entries()) {
     if (now - entry.lastUsed > CLIENT_TTL_MS) {
@@ -60,6 +60,8 @@ setInterval(() => {
     }
   }
 }, 60 * 1000);
+// Allow the process to exit even if the interval is still active (e.g., Ctrl+C)
+cleanupInterval.unref();
 
 /**
  * Storage client middleware

--- a/server/prompts/multiTurnJudgePrompt.ts
+++ b/server/prompts/multiTurnJudgePrompt.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Multi-Turn Judge System Prompt
+ *
+ * Instructs the LLM to evaluate an agent's performance across a multi-turn
+ * investigation conversation. Scores four dimensions holistically rather
+ * than per-turn.
+ */
+
+import type { ConversationTurnRecord } from '@/types';
+
+/** Default scoring weights (must sum to 100) */
+export const DEFAULT_SCORING_WEIGHTS = {
+  rootCause: 40,
+  remediation: 30,
+  contextRetention: 20,
+  conciseness: 10,
+};
+
+export interface MultiTurnJudgeInput {
+  turns: ConversationTurnRecord[];
+  idealAnswer: string;
+  criticalComponents?: {
+    rootCause: string;
+    remediation: string;
+  };
+  scoringWeights?: {
+    rootCause?: number;
+    remediation?: number;
+    contextRetention?: number;
+    conciseness?: number;
+  };
+}
+
+export interface MultiTurnJudgeOutput {
+  root_cause_score: number;
+  remediation_score: number;
+  context_retention_score: number;
+  conciseness_score: number;
+  pass_fail_status: 'passed' | 'failed';
+  reasoning: string;
+  improvement_strategies: Array<{
+    category: string;
+    issue: string;
+    recommendation: string;
+    priority: 'high' | 'medium' | 'low';
+  }>;
+}
+
+/**
+ * Build the system prompt for multi-turn holistic evaluation.
+ */
+export function buildMultiTurnJudgeSystemPrompt(input: MultiTurnJudgeInput): string {
+  const weights = {
+    ...DEFAULT_SCORING_WEIGHTS,
+    ...input.scoringWeights,
+  };
+
+  const conversationText = input.turns
+    .map(turn => `### Turn ${turn.turn}\n**User:** ${turn.userMessage}\n**Agent:** ${turn.agentResponse}`)
+    .join('\n\n');
+
+  const criticalSection = input.criticalComponents
+    ? `## Critical Components
+- Root cause: ${input.criticalComponents.rootCause}
+- Remediation: ${input.criticalComponents.remediation}`
+    : '';
+
+  return `You are evaluating an agent's performance in a multi-turn investigation.
+
+## Ideal Answer
+${input.idealAnswer}
+
+${criticalSection}
+
+## Full Conversation
+${conversationText}
+
+## Scoring (score each 0-100)
+
+1. Root Cause Identification (weight: ${weights.rootCause}%)
+   Did the agent correctly identify the root cause? Compare with the ideal answer.
+
+2. Remediation Correctness (weight: ${weights.remediation}%)
+   Did the agent recommend the correct fix? Was it actionable?
+
+3. Context Retention (weight: ${weights.contextRetention}%)
+   Did the agent maintain context across turns? Did later answers build on earlier findings?
+   Did it avoid contradicting itself?
+
+4. Conciseness & Actionability (weight: ${weights.conciseness}%)
+   Were responses clear, concise, and actionable? Did the agent avoid unnecessary verbosity?
+
+## Output (JSON)
+
+You MUST respond with this JSON structure:
+
+\`\`\`json
+{
+  "root_cause_score": <0-100>,
+  "remediation_score": <0-100>,
+  "context_retention_score": <0-100>,
+  "conciseness_score": <0-100>,
+  "pass_fail_status": "passed" | "failed",
+  "reasoning": "<holistic explanation>",
+  "improvement_strategies": [
+    {
+      "category": "<category>",
+      "issue": "<description>",
+      "recommendation": "<suggestion>",
+      "priority": "high" | "medium" | "low"
+    }
+  ]
+}
+\`\`\`
+
+Pass threshold: weighted_score >= 70
+weighted_score = (root_cause_score * ${weights.rootCause} + remediation_score * ${weights.remediation} + context_retention_score * ${weights.contextRetention} + conciseness_score * ${weights.conciseness}) / 100
+
+IMPORTANT:
+- Score each dimension independently
+- The pass_fail_status should reflect the weighted score threshold
+- Be specific in reasoning about which turns showed strength or weakness
+- Always include improvement_strategies (can be empty for excellent performance)`;
+}
+
+/**
+ * Compute the weighted score from individual dimension scores.
+ */
+export function computeWeightedScore(
+  scores: {
+    rootCauseScore: number;
+    remediationScore: number;
+    contextRetentionScore: number;
+    concisenessScore: number;
+  },
+  weights?: {
+    rootCause?: number;
+    remediation?: number;
+    contextRetention?: number;
+    conciseness?: number;
+  }
+): number {
+  const w = { ...DEFAULT_SCORING_WEIGHTS, ...weights };
+  return (
+    scores.rootCauseScore * w.rootCause +
+    scores.remediationScore * w.remediation +
+    scores.contextRetentionScore * w.contextRetention +
+    scores.concisenessScore * w.conciseness
+  ) / 100;
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -20,6 +20,7 @@ import observabilityRoutes from './observability';
 import configRoutes from './config';
 import evaluationRoutes from './evaluation';
 import debugRoutes from './debug';
+import simulatorRoutes from './simulator';
 
 const router = Router();
 
@@ -41,5 +42,6 @@ router.use(observabilityRoutes); // /api/observability/*
 router.use(configRoutes);        // /api/agents, /api/models
 router.use(evaluationRoutes);    // /api/evaluate
 router.use(debugRoutes);         // /api/debug
+router.use(simulatorRoutes);     // /api/simulate-followup
 
 export default router;

--- a/server/routes/judge.ts
+++ b/server/routes/judge.ts
@@ -8,11 +8,14 @@
  */
 
 import { Request, Response, Router } from 'express';
+import { BedrockRuntimeClient, ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
 import { evaluateTrajectory, parseBedrockError } from '../services/bedrockService';
 import { evaluateWithLiteLLM, parseLiteLLMError } from '../services/litellmJudgeService';
 import { loadConfigSync } from '../../lib/config/index';
 import serverConfig from '../config';
 import { debug } from '@/lib/debug';
+import { buildMultiTurnJudgeSystemPrompt, computeWeightedScore } from '../prompts/multiTurnJudgePrompt';
+import type { MultiTurnJudgeOutput } from '../prompts/multiTurnJudgePrompt';
 
 const router = Router();
 
@@ -199,6 +202,124 @@ router.post('/api/judge', async (req: Request, res: Response) => {
     res.status(500).json({
       error: `Judge evaluation failed: ${errorMessage}`,
       details: error.message
+    });
+  }
+});
+
+/**
+ * POST /api/judge/multi-turn - Evaluate multi-turn agent conversation holistically
+ */
+router.post('/api/judge/multi-turn', async (req: Request, res: Response) => {
+  try {
+    const { multiTurnConversation, modelId } = req.body;
+
+    if (!multiTurnConversation) {
+      return res.status(400).json({ error: 'Missing required field: multiTurnConversation' });
+    }
+
+    const { turns, idealAnswer, criticalComponents, scoringWeights } = multiTurnConversation;
+
+    if (!turns?.length) {
+      return res.status(400).json({ error: 'Missing required field: multiTurnConversation.turns' });
+    }
+    if (!idealAnswer) {
+      return res.status(400).json({ error: 'Missing required field: multiTurnConversation.idealAnswer' });
+    }
+
+    // Resolve model
+    const resolvedConfig = loadConfigSync();
+    let modelConfig = resolvedConfig.models[modelId];
+    if (!modelConfig) {
+      modelConfig = Object.values(resolvedConfig.models).find(m => m.model_id === modelId);
+    }
+    const resolvedModelId = modelConfig?.model_id || modelId || serverConfig.BEDROCK_MODEL_ID;
+
+    debug('JudgeAPI', 'Multi-turn evaluation with model:', resolvedModelId, 'turns:', turns.length);
+
+    // Build holistic prompt
+    const systemPrompt = buildMultiTurnJudgeSystemPrompt({
+      turns,
+      idealAnswer,
+      criticalComponents,
+      scoringWeights,
+    });
+
+    // Call Bedrock
+    const bedrockClient = new BedrockRuntimeClient({ region: serverConfig.AWS_REGION });
+    const command = new ConverseCommand({
+      modelId: resolvedModelId,
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Please evaluate the multi-turn conversation described in the system prompt.' }],
+        },
+      ],
+      system: [{ text: systemPrompt }],
+      inferenceConfig: {
+        maxTokens: 4096,
+        temperature: 0.1,
+      },
+    });
+
+    const startTime = Date.now();
+    const response = await bedrockClient.send(command);
+    const duration = Date.now() - startTime;
+
+    // Extract response text
+    let responseText = '';
+    if (response.output?.message?.content) {
+      for (const content of response.output.message.content) {
+        if ('text' in content && content.text) {
+          responseText += content.text;
+        }
+      }
+    }
+
+    debug('JudgeAPI', 'Multi-turn judge response in', duration, 'ms');
+
+    // Parse JSON from response
+    let jsonText = responseText.trim();
+    const jsonMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    if (jsonMatch) {
+      jsonText = jsonMatch[1];
+    } else {
+      const startIdx = jsonText.indexOf('{');
+      const endIdx = jsonText.lastIndexOf('}');
+      if (startIdx !== -1 && endIdx !== -1) {
+        jsonText = jsonText.slice(startIdx, endIdx + 1);
+      }
+    }
+
+    const result: MultiTurnJudgeOutput = JSON.parse(jsonText);
+
+    // Compute weighted score
+    const weightedScore = computeWeightedScore(
+      {
+        rootCauseScore: result.root_cause_score,
+        remediationScore: result.remediation_score,
+        contextRetentionScore: result.context_retention_score,
+        concisenessScore: result.conciseness_score,
+      },
+      scoringWeights
+    );
+
+    return res.json({
+      rootCauseScore: result.root_cause_score,
+      remediationScore: result.remediation_score,
+      contextRetentionScore: result.context_retention_score,
+      concisenessScore: result.conciseness_score,
+      weightedScore: Math.round(weightedScore),
+      passFailStatus: result.pass_fail_status || (weightedScore >= 70 ? 'passed' : 'failed'),
+      reasoning: result.reasoning,
+      improvementStrategies: result.improvement_strategies || [],
+      duration,
+    });
+  } catch (error: any) {
+    console.error('[JudgeAPI] Multi-turn evaluation error:', error);
+    const errorMessage = parseBedrockError(error);
+    return res.status(500).json({
+      error: `Multi-turn judge evaluation failed: ${errorMessage}`,
+      details: error.message,
     });
   }
 });

--- a/server/routes/simulator.ts
+++ b/server/routes/simulator.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * User Simulator Route
+ * Generates follow-up questions for multi-turn evaluation using an LLM
+ */
+
+import { Request, Response, Router } from 'express';
+import { BedrockRuntimeClient, ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
+import config from '../config';
+import { loadConfigSync } from '../../lib/config/index';
+import { buildSimulatorPrompt, parseSimulatorResponse } from '@/services/evaluation/userSimulator';
+import { debug } from '@/lib/debug';
+
+const router = Router();
+
+const bedrockClient = new BedrockRuntimeClient({
+  region: config.AWS_REGION,
+});
+
+/**
+ * POST /api/simulate-followup
+ * Generate the next user follow-up question for multi-turn evaluation
+ */
+router.post('/api/simulate-followup', async (req: Request, res: Response) => {
+  try {
+    const { scenario, conversationHistory, currentTurnIndex, modelId } = req.body;
+
+    // Validate required fields
+    if (!scenario) {
+      return res.status(400).json({ error: 'Missing required field: scenario' });
+    }
+    if (!conversationHistory) {
+      return res.status(400).json({ error: 'Missing required field: conversationHistory' });
+    }
+    if (currentTurnIndex === undefined || currentTurnIndex === null) {
+      return res.status(400).json({ error: 'Missing required field: currentTurnIndex' });
+    }
+
+    // Resolve model ID
+    const resolvedConfig = loadConfigSync();
+    let resolvedModelId = modelId;
+    if (modelId) {
+      const modelConfig = resolvedConfig.models[modelId] ||
+        Object.values(resolvedConfig.models).find(m => m.model_id === modelId);
+      resolvedModelId = modelConfig?.model_id || modelId;
+    } else {
+      resolvedModelId = config.BEDROCK_MODEL_ID;
+    }
+
+    debug('Simulator', 'Generating follow-up for turn', currentTurnIndex + 1, 'with model', resolvedModelId);
+
+    // Build simulator prompt
+    const prompt = buildSimulatorPrompt(scenario, conversationHistory, currentTurnIndex);
+
+    // Call Bedrock
+    const command = new ConverseCommand({
+      modelId: resolvedModelId,
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: prompt }],
+        },
+      ],
+      system: [{ text: 'You are a user simulator for agent evaluation. Always respond with valid JSON.' }],
+      inferenceConfig: {
+        maxTokens: 1024,
+        temperature: 0.3,
+      },
+    });
+
+    const response = await bedrockClient.send(command);
+
+    // Extract response text
+    let responseText = '';
+    if (response.output?.message?.content) {
+      for (const content of response.output.message.content) {
+        if ('text' in content && content.text) {
+          responseText += content.text;
+        }
+      }
+    }
+
+    debug('Simulator', 'Raw response:', responseText.substring(0, 300));
+
+    // Parse response
+    const result = parseSimulatorResponse(responseText);
+
+    debug('Simulator', 'Parsed result: done=', result.done, 'message=', result.message.substring(0, 100));
+
+    return res.json(result);
+  } catch (error: any) {
+    console.error('[Simulator] Error generating follow-up:', error);
+    return res.status(500).json({
+      error: `Simulator failed: ${error.message || 'Unknown error'}`,
+    });
+  }
+});
+
+export default router;

--- a/server/routes/storage/testCases.ts
+++ b/server/routes/storage/testCases.ts
@@ -305,6 +305,11 @@ router.post('/api/storage/test-cases', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Cannot create test case with demo- prefix (reserved for sample data)' });
     }
 
+    // Validate required fields (defense-in-depth — adapter also validates)
+    if (!testCase.name?.trim()) {
+      return res.status(400).json({ error: 'Test case name is required' });
+    }
+
     const storage = getStorageModule();
     const created = await storage.testCases.create(testCase);
 
@@ -368,6 +373,12 @@ router.post('/api/storage/test-cases/import', async (req: Request, res: Response
 
     if (testCases.length === 0) {
       return res.json({ created: 0, reused: 0, updated: 0, testCases: [] });
+    }
+
+    // Validate all test cases have names (defense-in-depth — adapter also validates)
+    const nameless = testCases.filter(tc => !tc.name?.trim());
+    if (nameless.length > 0) {
+      return res.status(400).json({ error: `${nameless.length} test case(s) missing required name field` });
     }
 
     // Check for demo- prefixes

--- a/server/routes/storage/testCases.ts
+++ b/server/routes/storage/testCases.ts
@@ -358,6 +358,82 @@ router.delete('/api/storage/test-cases/:id', async (req: Request, res: Response)
   }
 });
 
+// POST /api/storage/test-cases/import - Import with name-based dedup
+router.post('/api/storage/test-cases/import', async (req: Request, res: Response) => {
+  try {
+    const { testCases } = req.body;
+    if (!Array.isArray(testCases)) {
+      return res.status(400).json({ error: 'testCases must be an array' });
+    }
+
+    if (testCases.length === 0) {
+      return res.json({ created: 0, reused: 0, updated: 0, testCases: [] });
+    }
+
+    // Check for demo- prefixes
+    const hasDemoIds = testCases.some(tc => tc.id && isSampleId(tc.id));
+    if (hasDemoIds) {
+      return res.status(400).json({ error: 'Cannot import test cases with demo- prefix (reserved for sample data)' });
+    }
+
+    const storage = getStorageModule();
+
+    // Fetch all existing test cases for name matching
+    const { items: existing } = await storage.testCases.getAll();
+
+    // Build case-insensitive name → test case map
+    const nameMap = new Map<string, TestCase>();
+    for (const tc of existing) {
+      nameMap.set(tc.name.toLowerCase(), tc);
+    }
+
+    const results: Array<{ id: string; name: string; status: 'created' | 'reused' | 'updated' }> = [];
+    let created = 0;
+    let reused = 0;
+    let updated = 0;
+
+    for (const incoming of testCases) {
+      const name = incoming.name || '';
+      const match = nameMap.get(name.toLowerCase());
+
+      if (!match) {
+        // No name match → create new
+        const newTc = await storage.testCases.create(incoming);
+        results.push({ id: newTc.id, name: newTc.name, status: 'created' });
+        // Add to map so subsequent duplicates within the same batch are caught
+        nameMap.set(newTc.name.toLowerCase(), newTc);
+        created++;
+      } else if (isContentEqual(match, incoming)) {
+        // Same name + same content → reuse existing
+        results.push({ id: match.id, name: match.name, status: 'reused' });
+        reused++;
+      } else {
+        // Same name + different content → update (new version)
+        const updatedTc = await storage.testCases.update(match.id, incoming);
+        results.push({ id: match.id, name: updatedTc.name || match.name, status: 'updated' });
+        updated++;
+      }
+    }
+
+    debug('StorageAPI', `Imported ${results.length} test cases: ${created} created, ${reused} reused, ${updated} updated`);
+    res.json({ created, reused, updated, testCases: results });
+  } catch (error: any) {
+    console.error('[StorageAPI] Import test cases failed:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * Compare content fields that matter for dedup.
+ * Returns true if incoming test case has the same content as the existing one.
+ */
+function isContentEqual(existing: TestCase, incoming: Partial<TestCase>): boolean {
+  if (existing.initialPrompt !== incoming.initialPrompt) return false;
+  const existingOutcomes = [...(existing.expectedOutcomes || [])].sort();
+  const incomingOutcomes = [...(incoming.expectedOutcomes || [])].sort();
+  return JSON.stringify(existingOutcomes) === JSON.stringify(incomingOutcomes);
+}
+
 // POST /api/storage/test-cases/bulk - Bulk create
 router.post('/api/storage/test-cases/bulk', async (req: Request, res: Response) => {
   try {

--- a/server/services/configService.ts
+++ b/server/services/configService.ts
@@ -148,9 +148,7 @@ export function saveStorageConfig(storageConfig: StorageClusterConfig): void {
 
   // Use ?? so that an absent/undefined field in the incoming payload falls back
   // to whatever is already stored. The form converts sentinel and empty values
-  // to undefined before sending. Note: if called directly with password: "",
-  // the empty string passes through ?? but is omitted by the falsy spread
-  // below, effectively clearing the stored credential. This is intentional.
+  // to undefined before sending.
   const resolvedUsername = storageConfig.username ?? existingStorage.username;
   const resolvedPassword = storageConfig.password ?? existingStorage.password;
 

--- a/server/services/storage/index.ts
+++ b/server/services/storage/index.ts
@@ -34,7 +34,7 @@ export async function getAllTestCasesWithClient(client: Client): Promise<any[]> 
       size: 0,
       aggs: {
         test_cases: {
-          terms: { field: 'id.keyword', size: 10000 },
+          terms: { field: 'id', size: 10000 },
           aggs: {
             latest: {
               top_hits: { size: 1, sort: [{ version: { order: 'desc' } }] },

--- a/server/services/storage/index.ts
+++ b/server/services/storage/index.ts
@@ -227,6 +227,8 @@ export async function saveReportWithClient(
   if (report.traceError !== undefined) storageData.traceError = report.traceError;
   if (report.spans !== undefined) storageData.spans = report.spans;
   if (report.connectorProtocol !== undefined) storageData.connectorProtocol = report.connectorProtocol;
+  if (report.multiTurnResult !== undefined) storageData.multiTurnResult = report.multiTurnResult;
+  if (report.turnRunIds !== undefined) storageData.turnRunIds = report.turnRunIds;
 
   const created = await createRunWithClient(client, storageData);
 

--- a/services/agent/aguiConverter.ts
+++ b/services/agent/aguiConverter.ts
@@ -52,6 +52,7 @@ export class AGUIToTrajectoryConverter {
   private activeTools: Map<string, ToolState> = new Map();
   private hasEmittedAction = false;
   private runFinished = false;
+  private runFinishedResult: any = null;
   private pendingTextIsResponse = false;
   private runId: string | null = null;
   private threadId: string | null = null;
@@ -161,6 +162,7 @@ export class AGUIToTrajectoryConverter {
     this.activeTools.clear();
     this.hasEmittedAction = false;
     this.runFinished = false;
+    this.runFinishedResult = null;
     this.pendingTextIsResponse = false;
     this.isThinking = false;
     this.currentThinkingMessage = null;
@@ -177,10 +179,15 @@ export class AGUIToTrajectoryConverter {
 
   private handleRunFinished(event: any): TrajectoryStep[] {
     this.runFinished = true;
+    this.runFinishedResult = event.result ?? null;
     if (this.currentTextMessage) {
       this.pendingTextIsResponse = true;
     }
     return [];
+  }
+
+  getRunFinishedResult(): any {
+    return this.runFinishedResult;
   }
 
   private handleRunError(event: any): TrajectoryStep[] {

--- a/services/connectors/agui/AGUIStreamingConnector.ts
+++ b/services/connectors/agui/AGUIStreamingConnector.ts
@@ -19,8 +19,14 @@ import type {
   ConnectorRawEventCallback,
 } from '@/services/connectors/types';
 import { consumeSSEStream } from '@/services/agent/sseStream';
-import { buildAgentPayload, AgentRequestPayload } from '@/services/agent/payloadBuilder';
+import { buildAgentPayload, buildMultiTurnPayload, AgentRequestPayload, AgentMessage } from '@/services/agent/payloadBuilder';
 import { AGUIToTrajectoryConverter, computeTrajectoryFromRawEvents } from '@/services/agent/aguiConverter';
+import {
+  resolveMultiTurnOptions,
+  defaultDetectInterrupt,
+  defaultBuildApprovalResponse,
+} from './interruptHandlers';
+import type { MultiTurnOptions, InterruptInfo } from './interruptHandlers';
 
 /**
  * AG-UI Streaming Connector
@@ -44,7 +50,9 @@ export class AGUIStreamingConnector extends BaseConnector {
   }
 
   /**
-   * Execute the request using SSE streaming
+   * Execute the request using SSE streaming.
+   * When multiTurnOptions.enabled is true, handles tool approval interrupts
+   * by auto-responding and re-streaming within the same turn.
    */
   async execute(
     endpoint: string,
@@ -53,25 +61,48 @@ export class AGUIStreamingConnector extends BaseConnector {
     onProgress?: ConnectorProgressCallback,
     onRawEvent?: ConnectorRawEventCallback
   ): Promise<ConnectorResponse> {
+    const multiTurnOpts = resolveMultiTurnOptions(request.multiTurnOptions);
+
     // Use pre-built payload from hook if available, otherwise build fresh
-    const hasPrebuiltPayload = !!request.payload;
     const payload = request.payload || this.buildPayload(request);
     const headers = this.buildAuthHeaders(auth);
     const trajectory: TrajectoryStep[] = [];
     const rawEvents: AGUIEvent[] = [];
-    const converter = new AGUIToTrajectoryConverter();
 
     this.debug('Executing AG-UI streaming request');
+
+    // If multi-turn interrupt handling is not enabled, single-pass execution
+    if (!multiTurnOpts.enabled) {
+      return this.executeSinglePass(endpoint, payload, headers, trajectory, rawEvents, onProgress, onRawEvent);
+    }
+
+    // Multi-turn interrupt handling loop
+    return this.executeWithInterruptHandling(
+      endpoint, payload, headers, trajectory, rawEvents,
+      multiTurnOpts, request, onProgress, onRawEvent
+    );
+  }
+
+  /**
+   * Single-pass execution (original behavior, no interrupt handling)
+   */
+  private async executeSinglePass(
+    endpoint: string,
+    payload: any,
+    headers: Record<string, string>,
+    trajectory: TrajectoryStep[],
+    rawEvents: AGUIEvent[],
+    onProgress?: ConnectorProgressCallback,
+    onRawEvent?: ConnectorRawEventCallback
+  ): Promise<ConnectorResponse> {
+    const converter = new AGUIToTrajectoryConverter();
 
     await consumeSSEStream(
       endpoint,
       payload,
       (event: AGUIEvent) => {
-        // Capture raw event for debugging
         rawEvents.push(event);
         onRawEvent?.(event);
-
-        // Convert to trajectory steps
         const steps = converter.processEvent(event);
         steps.forEach(step => {
           trajectory.push(step);
@@ -90,6 +121,106 @@ export class AGUIStreamingConnector extends BaseConnector {
       rawEvents,
       metadata: {
         threadId: converter.getThreadId(),
+      },
+    };
+  }
+
+  /**
+   * Execute with an inner loop that handles tool approval interrupts.
+   * After each SSE stream completes, checks RunFinishedEvent.result for interrupts.
+   * If detected, auto-responds and re-streams until no more interrupts or maxTurns reached.
+   */
+  private async executeWithInterruptHandling(
+    endpoint: string,
+    initialPayload: any,
+    headers: Record<string, string>,
+    trajectory: TrajectoryStep[],
+    rawEvents: AGUIEvent[],
+    opts: MultiTurnOptions,
+    request: ConnectorRequest,
+    onProgress?: ConnectorProgressCallback,
+    onRawEvent?: ConnectorRawEventCallback
+  ): Promise<ConnectorResponse> {
+    const detectInterrupt = opts.detectInterrupt || defaultDetectInterrupt;
+    const buildResponse = opts.buildResponse || defaultBuildApprovalResponse;
+
+    let currentPayload = initialPayload;
+    let threadId: string | null = initialPayload.threadId || null;
+    let latestRunId: string | null = null;
+    let interruptCount = 0;
+    const messages: AgentMessage[] = [...(initialPayload.messages || [])];
+
+    for (let subTurn = 0; subTurn < opts.maxTurns; subTurn++) {
+      const converter = new AGUIToTrajectoryConverter();
+
+      await consumeSSEStream(
+        endpoint,
+        currentPayload,
+        (event: AGUIEvent) => {
+          rawEvents.push(event);
+          onRawEvent?.(event);
+          const steps = converter.processEvent(event);
+          steps.forEach(step => {
+            trajectory.push(step);
+            onProgress?.(step);
+          });
+        },
+        headers
+      );
+
+      latestRunId = converter.getRunId();
+      threadId = converter.getThreadId() || threadId;
+
+      // Check for interrupt in RunFinishedEvent.result
+      const result = converter.getRunFinishedResult();
+      const interrupt: InterruptInfo | null = detectInterrupt(result);
+
+      if (!interrupt) {
+        // No interrupt - normal completion
+        this.debug('Stream completed (no interrupt). RunId:', latestRunId, 'Steps:', trajectory.length);
+        break;
+      }
+
+      // Interrupt detected - build response
+      interruptCount++;
+      this.debug('Interrupt detected:', interrupt.reason, `(count: ${interruptCount})`);
+
+      const responseMsg = buildResponse(interrupt, opts.interruptPolicy);
+      if (!responseMsg) {
+        // Policy is 'skip' - stop the loop
+        this.debug('Interrupt policy is skip, stopping');
+        break;
+      }
+
+      // Accumulate messages for the multi-turn payload
+      // Add assistant response placeholder (extracted from last response step)
+      const lastResponseStep = [...trajectory].reverse().find(s => s.type === 'response' || s.type === 'assistant');
+      if (lastResponseStep) {
+        messages.push({
+          id: `assistant-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+          role: 'assistant',
+          content: lastResponseStep.content,
+        });
+      }
+      messages.push(responseMsg);
+
+      // Build next payload preserving threadId
+      currentPayload = buildMultiTurnPayload(
+        messages,
+        threadId || undefined,
+        undefined, // new runId per sub-turn
+        request.testCase.context || [],
+        request.testCase.tools
+      );
+    }
+
+    return {
+      trajectory,
+      runId: latestRunId,
+      rawEvents,
+      metadata: {
+        threadId,
+        interruptCount,
       },
     };
   }

--- a/services/connectors/agui/interruptHandlers.ts
+++ b/services/connectors/agui/interruptHandlers.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Interrupt Handlers for AG-UI Streaming Connector
+ * Detects and responds to tool approval / human input interrupts
+ * so multi-turn evaluation can continue transparently.
+ */
+
+import type { AgentMessage } from '@/services/agent/payloadBuilder';
+
+// ============ Types ============
+
+/** Policy for handling tool-approval interrupts within a single turn */
+export type InterruptPolicy = 'auto-approve' | 'auto-reject' | 'skip';
+
+/** Parsed interrupt information from RunFinishedEvent.result */
+export interface InterruptInfo {
+  reason: string;
+  toolCalls?: Array<{ id: string; name: string; args?: any }>;
+  rawResult: any;
+}
+
+/** Multi-turn options controlling interrupt handling inside the connector */
+export interface MultiTurnOptions {
+  enabled: boolean;
+  maxTurns: number;
+  interruptPolicy: InterruptPolicy;
+  detectInterrupt?: (result: any) => InterruptInfo | null;
+  buildResponse?: (interrupt: InterruptInfo, policy: InterruptPolicy) => AgentMessage | null;
+}
+
+// ============ Defaults ============
+
+export const DEFAULT_MULTI_TURN_OPTIONS: MultiTurnOptions = {
+  enabled: false,
+  maxTurns: 10,
+  interruptPolicy: 'auto-approve',
+};
+
+// ============ Detection ============
+
+/**
+ * Default interrupt detector.
+ * Checks for common interrupt patterns:
+ *  - Pulsar-style: { outcome: "interrupt", ... }
+ *  - Generic: { type: "tool_approval" | "human_input_required", ... }
+ *  - Explicit: { requiresApproval: true, ... }
+ */
+export function defaultDetectInterrupt(result: any): InterruptInfo | null {
+  if (!result || typeof result !== 'object') {
+    return null;
+  }
+
+  // Pulsar-style interrupt
+  if (result.outcome === 'interrupt') {
+    return {
+      reason: result.reason || 'Tool approval required',
+      toolCalls: Array.isArray(result.toolCalls) ? result.toolCalls : undefined,
+      rawResult: result,
+    };
+  }
+
+  // Generic interrupt types
+  if (result.type === 'tool_approval' || result.type === 'human_input_required') {
+    return {
+      reason: result.message || result.reason || result.type,
+      toolCalls: Array.isArray(result.toolCalls) ? result.toolCalls : undefined,
+      rawResult: result,
+    };
+  }
+
+  // Explicit approval flag
+  if (result.requiresApproval === true) {
+    return {
+      reason: result.reason || 'Approval required',
+      toolCalls: Array.isArray(result.toolCalls) ? result.toolCalls : undefined,
+      rawResult: result,
+    };
+  }
+
+  return null;
+}
+
+// ============ Response Building ============
+
+/**
+ * Build an approval/rejection response message for an interrupt.
+ * Returns null if the policy is 'skip' (don't respond, stop the loop).
+ */
+export function defaultBuildApprovalResponse(
+  interrupt: InterruptInfo,
+  policy: InterruptPolicy
+): AgentMessage | null {
+  if (policy === 'skip') {
+    return null;
+  }
+
+  const approved = policy === 'auto-approve';
+  const content = approved
+    ? 'Approved. Please proceed with the tool calls.'
+    : 'Rejected. Do not execute the proposed tool calls.';
+
+  return {
+    id: `interrupt-resp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+    role: 'user',
+    content,
+  };
+}
+
+// ============ Options Resolution ============
+
+/**
+ * Merge partial multi-turn options with defaults.
+ */
+export function resolveMultiTurnOptions(
+  partial?: Partial<MultiTurnOptions>
+): MultiTurnOptions {
+  if (!partial) {
+    return { ...DEFAULT_MULTI_TURN_OPTIONS };
+  }
+  return {
+    ...DEFAULT_MULTI_TURN_OPTIONS,
+    ...partial,
+  };
+}

--- a/services/connectors/index.ts
+++ b/services/connectors/index.ts
@@ -36,6 +36,20 @@ export {
 // ============ Base Class Export ============
 export { BaseConnector } from './base/BaseConnector';
 
+// ============ Interrupt Handler Exports ============
+export type {
+  InterruptPolicy,
+  InterruptInfo,
+  MultiTurnOptions,
+} from './agui/interruptHandlers';
+
+export {
+  defaultDetectInterrupt,
+  defaultBuildApprovalResponse,
+  resolveMultiTurnOptions,
+  DEFAULT_MULTI_TURN_OPTIONS,
+} from './agui/interruptHandlers';
+
 // ============ Browser-safe Connector Exports ============
 // These connectors work in browser environments (no Node.js dependencies)
 export { AGUIStreamingConnector, aguiStreamingConnector } from './agui/AGUIStreamingConnector';

--- a/services/connectors/registry.ts
+++ b/services/connectors/registry.ts
@@ -93,6 +93,11 @@ class ConnectorRegistryImpl implements ConnectorRegistry {
       return defaultConnector;
     }
 
+    // If agent has connectorConfig and connector supports withConfig, create merged instance
+    if (agent.connectorConfig && 'withConfig' in connector) {
+      return (connector as any).withConfig(agent.connectorConfig);
+    }
+
     return connector;
   }
 

--- a/services/connectors/subprocess/SubprocessConnector.ts
+++ b/services/connectors/subprocess/SubprocessConnector.ts
@@ -50,6 +50,23 @@ export class SubprocessConnector extends BaseConnector {
   }
 
   /**
+   * Create a new connector instance with merged config.
+   * Used by the registry to apply per-agent connectorConfig.
+   *
+   * - Top-level config fields are shallow-merged (overrides win)
+   * - `env` is deep-merged (connector defaults + agent overrides)
+   * - `args` is replaced wholesale when provided (not concatenated)
+   */
+  withConfig(overrides: Partial<SubprocessConfig>): SubprocessConnector {
+    return new (this.constructor as new (config?: Partial<SubprocessConfig>) => SubprocessConnector)({
+      ...this.config,
+      ...overrides,
+      env: { ...this.config.env, ...overrides.env },
+      args: overrides.args ?? this.config.args,
+    });
+  }
+
+  /**
    * Build input for the subprocess
    */
   buildPayload(request: ConnectorRequest): string {

--- a/services/connectors/types.ts
+++ b/services/connectors/types.ts
@@ -70,6 +70,12 @@ export interface ConnectorRequest {
    * Threaded from agent.connectorConfig at evaluation time.
    */
   connectorConfig?: Record<string, any>;
+  /** Multi-turn options for interrupt handling within the connector */
+  multiTurnOptions?: {
+    enabled?: boolean;
+    maxTurns?: number;
+    interruptPolicy?: 'auto-approve' | 'auto-reject' | 'skip';
+  };
 }
 
 /**
@@ -192,6 +198,15 @@ export interface AgentConfigWithConnector {
 
   /** Lifecycle hooks for custom setup/transform logic */
   hooks?: AgentHooks;
+
+  /** Multi-turn options for interrupt handling */
+  multiTurnOptions?: {
+    enabled?: boolean;
+    maxTurns?: number;
+    interruptPolicy?: 'auto-approve' | 'auto-reject' | 'skip';
+    detectInterrupt?: (result: any) => any;
+    buildResponse?: (interrupt: any, policy: string) => any;
+  };
 }
 
 // ============ Registry Types ============

--- a/services/evaluation/index.ts
+++ b/services/evaluation/index.ts
@@ -386,6 +386,35 @@ export async function runEvaluationWithConnector(
 }
 
 /**
+ * Retry wrapper for connector.execute() calls.
+ * Handles transient 409 "Run already in progress" errors caused by race conditions
+ * where the previous turn's cleanup hasn't completed before the next turn starts.
+ */
+async function executeWithRetry<T>(
+  fn: () => Promise<T>,
+  opts: { maxRetries: number; initialDelayMs: number; retryOn409: boolean }
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      lastError = err;
+      const is409 = opts.retryOn409 && (
+        err.message?.includes('409') ||
+        err.message?.includes('already in progress') ||
+        err.status === 409
+      );
+      if (!is409 || attempt === opts.maxRetries) throw err;
+      const delay = opts.initialDelayMs * Math.pow(2, attempt);
+      debug('Eval', `409 on turn, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError!;
+}
+
+/**
  * Run multi-turn evaluation with LLM-simulated user.
  * Sends the initial prompt, then loops: simulator generates follow-up → agent responds.
  * After the conversation, calls the holistic multi-turn judge.
@@ -488,12 +517,11 @@ async function runMultiTurnEvaluation(
         payload: turnPayload,
       };
 
-      const turnResult = await connector.execute(
-        endpoint,
-        turnRequest,
-        auth,
-        onStep,
-        options.onRawEvent
+      // Retry on 409 "Run already in progress" — the previous turn's cleanup
+      // may not have completed before this request arrives at the agent backend.
+      const turnResult = await executeWithRetry(
+        () => connector.execute(endpoint, turnRequest, auth, onStep, options.onRawEvent),
+        { maxRetries: 3, initialDelayMs: 1000, retryOn409: true }
       );
 
       agentRunId = turnResult.runId || agentRunId;

--- a/services/evaluation/index.ts
+++ b/services/evaluation/index.ts
@@ -9,12 +9,14 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { AgentConfig, EvaluationReport, TestCase, TrajectoryStep, OpenSearchLog, LLMJudgeResponse, ConnectorProtocol, BeforeRequestContext, AfterResponseContext, TestCasePerformanceMetrics } from '@/types';
+import { AgentConfig, EvaluationReport, TestCase, TrajectoryStep, OpenSearchLog, LLMJudgeResponse, ConnectorProtocol, BeforeRequestContext, AfterResponseContext, TestCasePerformanceMetrics, ConversationTurnRecord, MultiTurnResult } from '@/types';
 import { executeBeforeRequestHook, executeAfterResponseHook } from '@/lib/hooks';
 import { AGUIToTrajectoryConverter, consumeSSEStream, buildAgentPayload } from '@/services/agent';
+import { buildMultiTurnPayload, AgentMessage } from '@/services/agent/payloadBuilder';
 import { AGUIEvent } from '@/types/agui';
 import { generateMockTrajectory } from './mockTrajectory';
 import { callBedrockJudge } from './bedrockJudge';
+import { generateFollowUp } from './userSimulator';
 
 // Re-export for use by experimentRunner when calling judge after trace polling
 export { callBedrockJudge };
@@ -48,6 +50,7 @@ const getModels = () => {
 import type {
   ConnectorAuth,
   ConnectorRequest,
+  AgentConnector,
   AgentConfigWithConnector,
   ConnectorRegistry,
 } from '@/services/connectors';
@@ -178,6 +181,21 @@ export async function runEvaluationWithConnector(
       if (hookResult.headers) {
         auth.headers = { ...auth.headers, ...hookResult.headers };
       }
+    }
+
+    // Thread multiTurnOptions from agent config into connector request
+    if (agent.multiTurnOptions) {
+      request = {
+        ...request,
+        multiTurnOptions: agent.multiTurnOptions,
+      };
+    }
+
+    // Multi-turn dispatch: if test case has multiTurnScenario, delegate
+    if (testCase.multiTurnScenario) {
+      return runMultiTurnEvaluation(
+        agent, modelId, testCase, connector, effectiveEndpoint, request, auth, onStep, options
+      );
     }
 
     // Execute via connector (with timing)
@@ -365,6 +383,264 @@ export async function runEvaluationWithConnector(
       connectorProtocol: connectorType,
     };
   }
+}
+
+/**
+ * Run multi-turn evaluation with LLM-simulated user.
+ * Sends the initial prompt, then loops: simulator generates follow-up → agent responds.
+ * After the conversation, calls the holistic multi-turn judge.
+ */
+async function runMultiTurnEvaluation(
+  agent: AgentConfig,
+  modelId: string,
+  testCase: TestCase,
+  connector: AgentConnector,
+  endpoint: string,
+  request: ConnectorRequest,
+  auth: ConnectorAuth,
+  onStep: (step: TrajectoryStep) => void,
+  options: RunEvaluationWithConnectorOptions
+): Promise<EvaluationReport> {
+  const reportId = uuidv4();
+  const scenario = testCase.multiTurnScenario!;
+  const turnLimit = scenario.turnLimit || 10;
+  const turns: ConversationTurnRecord[] = [];
+  const allTrajectory: TrajectoryStep[] = [];
+  const allRawEvents: any[] = [];
+  const conversationHistory: AgentMessage[] = [];
+  let agentRunId: string | null = null;
+
+  debug('Eval', 'Starting multi-turn evaluation. Turn limit:', turnLimit);
+
+  try {
+    // Turn 1: send initial prompt
+    const turn1Result = await connector.execute(
+      endpoint,
+      request,
+      auth,
+      onStep,
+      options.onRawEvent
+    );
+
+    agentRunId = turn1Result.runId;
+    const threadId = turn1Result.metadata?.threadId;
+    allTrajectory.push(...turn1Result.trajectory);
+    allRawEvents.push(...(turn1Result.rawEvents || []));
+
+    // Extract agent response text from the last response/assistant step
+    const agentResponseText = extractAgentResponse(turn1Result.trajectory);
+
+    // Record turn 1
+    turns.push({
+      turn: 1,
+      userMessage: testCase.initialPrompt,
+      agentResponse: agentResponseText,
+      trajectory: turn1Result.trajectory,
+    });
+
+    // Build conversation history for simulator
+    conversationHistory.push({
+      id: `msg-turn1-user`,
+      role: 'user',
+      content: testCase.initialPrompt,
+    });
+    conversationHistory.push({
+      id: `msg-turn1-agent`,
+      role: 'assistant',
+      content: agentResponseText,
+    });
+
+    // Subsequent turns
+    for (let turnIdx = 1; turnIdx < turnLimit; turnIdx++) {
+      // Generate follow-up from simulator
+      const followUp = await generateFollowUp(
+        scenario,
+        conversationHistory,
+        turnIdx, // 0-based reference turn index (turn 1 used index 0 for initial)
+        modelId
+      );
+
+      if (followUp.done) {
+        debug('Eval', `Simulator signaled done at turn ${turnIdx + 1}`);
+        break;
+      }
+
+      // Add user message to conversation
+      const userMsg: AgentMessage = {
+        id: `msg-turn${turnIdx + 1}-user`,
+        role: 'user',
+        content: followUp.message,
+      };
+      conversationHistory.push(userMsg);
+
+      // Build multi-turn payload with full conversation
+      const turnPayload = buildMultiTurnPayload(
+        conversationHistory,
+        threadId || undefined,
+        undefined, // new runId per turn
+        testCase.context || [],
+        testCase.tools
+      );
+
+      // Execute turn
+      const turnRequest: ConnectorRequest = {
+        ...request,
+        payload: turnPayload,
+      };
+
+      const turnResult = await connector.execute(
+        endpoint,
+        turnRequest,
+        auth,
+        onStep,
+        options.onRawEvent
+      );
+
+      agentRunId = turnResult.runId || agentRunId;
+      allTrajectory.push(...turnResult.trajectory);
+      allRawEvents.push(...(turnResult.rawEvents || []));
+
+      const turnAgentResponse = extractAgentResponse(turnResult.trajectory);
+
+      // Record turn
+      turns.push({
+        turn: turnIdx + 1,
+        userMessage: followUp.message,
+        agentResponse: turnAgentResponse,
+        trajectory: turnResult.trajectory,
+      });
+
+      conversationHistory.push({
+        id: `msg-turn${turnIdx + 1}-agent`,
+        role: 'assistant',
+        content: turnAgentResponse,
+      });
+    }
+
+    debug('Eval', `Multi-turn conversation completed. Total turns: ${turns.length}`);
+
+    // Call holistic multi-turn judge
+    const models = getModels();
+    const modelConfig = models[modelId];
+    const judgeModelId = modelConfig?.model_id || modelId;
+    const judgeApiUrl = ENV_CONFIG.judgeApiUrl || 'http://localhost:4001/api/judge';
+
+    const judgeStartTime = Date.now();
+    const judgeResponse = await fetch(`${judgeApiUrl}/multi-turn`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        multiTurnConversation: {
+          turns,
+          idealAnswer: scenario.idealAnswer,
+          criticalComponents: scenario.criticalComponents,
+          scoringWeights: scenario.scoringWeights,
+        },
+        modelId: judgeModelId,
+      }),
+    });
+
+    if (!judgeResponse.ok) {
+      const errorData = await judgeResponse.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(errorData.error || `Judge API returned ${judgeResponse.status}`);
+    }
+
+    const judgeResult = await judgeResponse.json();
+    const judgeLatencyMs = Date.now() - judgeStartTime;
+
+    const multiTurnResult: MultiTurnResult = {
+      turns,
+      totalTurns: turns.length,
+      acceptanceCriteriaMet: judgeResult.passFailStatus === 'passed',
+      rootCauseScore: judgeResult.rootCauseScore,
+      remediationScore: judgeResult.remediationScore,
+      contextRetentionScore: judgeResult.contextRetentionScore,
+      concisenessScore: judgeResult.concisenessScore,
+      reasoning: judgeResult.reasoning,
+    };
+
+    const llmJudgeResponse: LLMJudgeResponse = {
+      modelId: judgeModelId,
+      timestamp: new Date().toISOString(),
+      promptTokens: 0,
+      completionTokens: 0,
+      latencyMs: judgeLatencyMs,
+      rawResponse: judgeResult.reasoning,
+      parsedMetrics: {
+        accuracy: judgeResult.weightedScore,
+        faithfulness: 0,
+        latency_score: 0,
+        trajectory_alignment_score: 0,
+      },
+      improvementStrategies: judgeResult.improvementStrategies,
+    };
+
+    return {
+      id: reportId,
+      timestamp: new Date().toISOString(),
+      agentName: agent.name,
+      agentKey: agent.key,
+      modelName: modelId,
+      modelId,
+      testCaseId: testCase.id,
+      testCaseVersion: testCase.currentVersion ?? 1,
+      status: 'completed',
+      passFailStatus: judgeResult.passFailStatus,
+      trajectory: allTrajectory,
+      metrics: { accuracy: judgeResult.weightedScore },
+      llmJudgeReasoning: judgeResult.reasoning,
+      improvementStrategies: judgeResult.improvementStrategies || [],
+      llmJudgeResponse,
+      multiTurnResult,
+      runId: agentRunId || undefined,
+      rawEvents: allRawEvents,
+      connectorProtocol: connector.type as ConnectorProtocol,
+    };
+  } catch (error) {
+    console.error('[Eval] Multi-turn evaluation error:', error instanceof Error ? error.message : error);
+
+    // If we have partial results, evaluate what we have
+    const partialMultiTurnResult: MultiTurnResult | undefined = turns.length > 0 ? {
+      turns,
+      totalTurns: turns.length,
+      acceptanceCriteriaMet: false,
+      rootCauseScore: 0,
+      remediationScore: 0,
+      contextRetentionScore: 0,
+      concisenessScore: 0,
+      reasoning: `Evaluation failed after ${turns.length} turns: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    } : undefined;
+
+    return {
+      id: reportId,
+      timestamp: new Date().toISOString(),
+      agentName: agent.name,
+      agentKey: agent.key,
+      modelName: modelId,
+      modelId,
+      testCaseId: testCase.id,
+      testCaseVersion: testCase.currentVersion ?? 1,
+      status: 'failed',
+      trajectory: allTrajectory,
+      metrics: { accuracy: 0 },
+      llmJudgeReasoning: `Multi-turn evaluation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      improvementStrategies: [],
+      multiTurnResult: partialMultiTurnResult,
+      rawEvents: allRawEvents,
+      connectorProtocol: connector.type as ConnectorProtocol,
+    };
+  }
+}
+
+/**
+ * Extract the agent's response text from a trajectory.
+ * Looks for the last 'response' or 'assistant' step.
+ */
+function extractAgentResponse(trajectory: TrajectoryStep[]): string {
+  const responseStep = [...trajectory].reverse().find(
+    s => s.type === 'response' || s.type === 'assistant'
+  );
+  return responseStep?.content || '';
 }
 
 /**

--- a/services/evaluation/index.ts
+++ b/services/evaluation/index.ts
@@ -386,32 +386,67 @@ export async function runEvaluationWithConnector(
 }
 
 /**
+ * Metrics emitted when a 409 retry succeeds (or is exhausted).
+ */
+interface RetryMetrics {
+  /** Total wall-clock time spent retrying (ms) */
+  totalWaitMs: number;
+  /** Number of 409 retries before success (0 = first attempt worked) */
+  retryCount: number;
+}
+
+/**
  * Retry wrapper for connector.execute() calls.
  * Handles transient 409 "Run already in progress" errors caused by race conditions
  * where the previous turn's cleanup hasn't completed before the next turn starts.
+ *
+ * Uses exponential backoff with no retry limit — keeps retrying until the 409 clears
+ * or the total timeout is exceeded. Individual delays are capped at maxDelayMs.
  */
 async function executeWithRetry<T>(
   fn: () => Promise<T>,
-  opts: { maxRetries: number; initialDelayMs: number; retryOn409: boolean }
-): Promise<T> {
-  let lastError: Error | undefined;
-  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+  opts: {
+    initialDelayMs: number;
+    maxDelayMs: number;
+    timeoutMs: number;
+    retryOn409: boolean;
+  }
+): Promise<T & { _retryMetrics?: RetryMetrics }> {
+  const startTime = Date.now();
+  let attempt = 0;
+
+  while (true) {
     try {
-      return await fn();
+      const result = await fn();
+      // Attach retry metrics to the result if retries occurred
+      if (attempt > 0) {
+        const totalWaitMs = Date.now() - startTime;
+        debug('Eval', `409 cleared after ${attempt} retries, ${totalWaitMs}ms total wait`);
+        (result as any)._retryMetrics = { totalWaitMs, retryCount: attempt };
+      }
+      return result;
     } catch (err: any) {
-      lastError = err;
       const is409 = opts.retryOn409 && (
         err.message?.includes('409') ||
         err.message?.includes('already in progress') ||
         err.status === 409
       );
-      if (!is409 || attempt === opts.maxRetries) throw err;
-      const delay = opts.initialDelayMs * Math.pow(2, attempt);
-      debug('Eval', `409 on turn, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
+      if (!is409) throw err;
+
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= opts.timeoutMs) {
+        debug('Eval', `409 retry timeout after ${attempt} attempts, ${elapsed}ms elapsed`);
+        throw err;
+      }
+
+      const delay = Math.min(opts.initialDelayMs * Math.pow(2, attempt), opts.maxDelayMs);
+      const remaining = opts.timeoutMs - elapsed;
+      const actualDelay = Math.min(delay, remaining);
+      attempt++;
+      debug('Eval', `409 on turn (attempt ${attempt}, ${elapsed}ms elapsed), retrying in ${actualDelay}ms`);
+      await new Promise(resolve => setTimeout(resolve, actualDelay));
     }
   }
-  throw lastError!;
 }
 
 /**
@@ -437,6 +472,7 @@ async function runMultiTurnEvaluation(
   const allTrajectory: TrajectoryStep[] = [];
   const allRawEvents: any[] = [];
   const conversationHistory: AgentMessage[] = [];
+  const allTurnRunIds: string[] = [];
   let agentRunId: string | null = null;
 
   debug('Eval', 'Starting multi-turn evaluation. Turn limit:', turnLimit);
@@ -452,6 +488,7 @@ async function runMultiTurnEvaluation(
     );
 
     agentRunId = turn1Result.runId;
+    if (turn1Result.runId) allTurnRunIds.push(turn1Result.runId);
     const threadId = turn1Result.metadata?.threadId;
     allTrajectory.push(...turn1Result.trajectory);
     allRawEvents.push(...(turn1Result.rawEvents || []));
@@ -519,12 +556,18 @@ async function runMultiTurnEvaluation(
 
       // Retry on 409 "Run already in progress" — the previous turn's cleanup
       // may not have completed before this request arrives at the agent backend.
+      // Uses infinite exponential backoff (2s→4s→...→30s cap) with 5-minute timeout.
       const turnResult = await executeWithRetry(
         () => connector.execute(endpoint, turnRequest, auth, onStep, options.onRawEvent),
-        { maxRetries: 3, initialDelayMs: 1000, retryOn409: true }
+        { initialDelayMs: 2000, maxDelayMs: 30000, timeoutMs: 300000, retryOn409: true }
       );
+      if ((turnResult as any)._retryMetrics) {
+        const m = (turnResult as any)._retryMetrics as RetryMetrics;
+        debug('Eval', `Turn ${turnIdx + 1} retry metrics: ${m.retryCount} retries, ${m.totalWaitMs}ms wait`);
+      }
 
       agentRunId = turnResult.runId || agentRunId;
+      if (turnResult.runId) allTurnRunIds.push(turnResult.runId);
       allTrajectory.push(...turnResult.trajectory);
       allRawEvents.push(...(turnResult.rawEvents || []));
 
@@ -621,6 +664,7 @@ async function runMultiTurnEvaluation(
       llmJudgeResponse,
       multiTurnResult,
       runId: agentRunId || undefined,
+      turnRunIds: allTurnRunIds.length > 0 ? allTurnRunIds : undefined,
       rawEvents: allRawEvents,
       connectorProtocol: connector.type as ConnectorProtocol,
     };
@@ -654,6 +698,7 @@ async function runMultiTurnEvaluation(
       llmJudgeReasoning: `Multi-turn evaluation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       improvementStrategies: [],
       multiTurnResult: partialMultiTurnResult,
+      turnRunIds: allTurnRunIds.length > 0 ? allTurnRunIds : undefined,
       rawEvents: allRawEvents,
       connectorProtocol: connector.type as ConnectorProtocol,
     };

--- a/services/evaluation/userSimulator.ts
+++ b/services/evaluation/userSimulator.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * User Simulator Service
+ * Uses an LLM to simulate an on-call SRE generating follow-up questions
+ * based on the agent's actual responses and reference turn guidance.
+ */
+
+import type { MultiTurnScenario } from '@/types';
+import type { AgentMessage } from '@/services/agent/payloadBuilder';
+import { ENV_CONFIG } from '@/lib/config';
+import { debug } from '@/lib/debug';
+
+export interface SimulatorResponse {
+  message: string;
+  done: boolean;
+}
+
+/**
+ * Build the simulator prompt for generating the next follow-up question.
+ */
+export function buildSimulatorPrompt(
+  scenario: MultiTurnScenario,
+  conversationHistory: AgentMessage[],
+  currentTurnIndex: number
+): string {
+  const referenceTurn = scenario.referenceTurns?.[currentTurnIndex];
+
+  const conversationText = conversationHistory
+    .map(msg => `${msg.role === 'user' ? 'User' : 'Agent'}: ${msg.content}`)
+    .join('\n\n');
+
+  let suggestedSection = '';
+  if (referenceTurn) {
+    suggestedSection = `## Suggested Next Question
+"${referenceTurn.user}"
+Topics to drive toward: ${referenceTurn.expectedTopics.join(', ')}`;
+  } else {
+    suggestedSection = `## Suggested Next Question
+No reference question available for this turn. Generate your own based on the investigation's natural progression.`;
+  }
+
+  return `You are simulating an on-call SRE investigating an incident.
+
+## Your Motivation
+${scenario.userMotivation}
+
+## Acceptance Criteria (stop when ALL are met)
+${scenario.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join('\n')}
+
+${suggestedSection}
+
+## Conversation So Far
+${conversationText}
+
+## Instructions
+Based on the agent's latest response, either:
+1. Generate your next question — use the suggested question as guidance but adapt it
+   to make sense given what the agent actually said
+2. If ALL acceptance criteria are met, respond with {"done": true, "message": "..."}
+
+Rules:
+- If the agent's response aligns with expectations, ask the suggested question naturally
+- If the agent diverged, adapt your question to acknowledge what was said while
+  steering back toward the expected topics
+- Be concise — one question at a time
+- Do NOT reveal the ideal answer, acceptance criteria, or ground truth to the agent
+- If no suggested question is available (past the reference turns), generate your own
+  based on the investigation's natural progression
+
+Respond as JSON: { "done": boolean, "message": "your next question or closing remark" }`;
+}
+
+/**
+ * Parse the LLM simulator response into a structured SimulatorResponse.
+ * Handles both clean JSON and JSON embedded in markdown/text.
+ */
+export function parseSimulatorResponse(responseText: string): SimulatorResponse {
+  const trimmed = responseText.trim();
+
+  // Try direct JSON parse
+  try {
+    const parsed = JSON.parse(trimmed);
+    return {
+      done: !!parsed.done,
+      message: String(parsed.message || ''),
+    };
+  } catch {
+    // Try extracting JSON from markdown code block
+    const jsonMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[1]);
+        return {
+          done: !!parsed.done,
+          message: String(parsed.message || ''),
+        };
+      } catch {
+        // Fall through
+      }
+    }
+
+    // Try finding JSON object in text
+    const startIdx = trimmed.indexOf('{');
+    const endIdx = trimmed.lastIndexOf('}');
+    if (startIdx !== -1 && endIdx > startIdx) {
+      try {
+        const parsed = JSON.parse(trimmed.slice(startIdx, endIdx + 1));
+        return {
+          done: !!parsed.done,
+          message: String(parsed.message || ''),
+        };
+      } catch {
+        // Fall through
+      }
+    }
+
+    // Could not parse JSON — treat entire text as the message
+    return {
+      done: false,
+      message: trimmed,
+    };
+  }
+}
+
+/**
+ * Generate the next user follow-up question based on conversation history.
+ * Calls the backend simulator endpoint, with fallback to reference turns.
+ *
+ * @param scenario - The multi-turn scenario definition
+ * @param conversationHistory - Messages so far (user + assistant)
+ * @param currentTurnIndex - 0-based index of the current turn (used for reference turn lookup)
+ * @param modelId - Optional model ID for the simulator LLM
+ */
+export async function generateFollowUp(
+  scenario: MultiTurnScenario,
+  conversationHistory: AgentMessage[],
+  currentTurnIndex: number,
+  modelId?: string
+): Promise<SimulatorResponse> {
+  const simulatorUrl = ENV_CONFIG.simulatorApiUrl || 'http://localhost:4001/api/simulate-followup';
+
+  try {
+    debug('UserSimulator', `Generating follow-up for turn ${currentTurnIndex + 1}`);
+
+    const response = await fetch(simulatorUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scenario,
+        conversationHistory,
+        currentTurnIndex,
+        modelId,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(errorData.error || `Simulator API returned ${response.status}`);
+    }
+
+    const result = await response.json();
+    debug('UserSimulator', `Follow-up generated: done=${result.done}`);
+    return result;
+  } catch (error) {
+    // Fallback: use reference turn verbatim if available
+    const referenceTurn = scenario.referenceTurns?.[currentTurnIndex];
+    if (referenceTurn) {
+      debug('UserSimulator', `LLM failed, falling back to reference turn ${currentTurnIndex + 1}`);
+      console.warn(
+        '[UserSimulator] LLM simulator failed, using reference turn verbatim:',
+        error instanceof Error ? error.message : error
+      );
+      return {
+        done: false,
+        message: referenceTurn.user,
+      };
+    }
+
+    // No fallback available — stop the conversation
+    debug('UserSimulator', 'LLM failed and no reference turn available, stopping');
+    console.error(
+      '[UserSimulator] LLM simulator failed with no fallback:',
+      error instanceof Error ? error.message : error
+    );
+    return {
+      done: true,
+      message: 'Unable to generate follow-up question.',
+    };
+  }
+}

--- a/services/storage/asyncRunStorage.ts
+++ b/services/storage/asyncRunStorage.ts
@@ -25,6 +25,7 @@ import type {
   ImprovementStrategy,
   OpenSearchLog,
   ConnectorProtocol,
+  MultiTurnResult,
 } from '@/types';
 
 // Re-export search types for convenience
@@ -113,6 +114,8 @@ function toTestCaseRun(stored: StorageRun): TestCaseRun {
     traceError: storedAny.traceError,
     spans: storedAny.spans as any[] | undefined,
     connectorProtocol: storedAny.connectorProtocol as ConnectorProtocol | undefined,
+    multiTurnResult: stored.multiTurnResult as MultiTurnResult | undefined,
+    turnRunIds: stored.turnRunIds,
   };
 }
 
@@ -153,6 +156,8 @@ function toStorageFormat(report: EvaluationReport): Omit<StorageRun, 'id' | 'cre
   if (report.traceError !== undefined) base.traceError = report.traceError;
   if (report.spans !== undefined) base.spans = report.spans;
   if (report.connectorProtocol !== undefined) base.connectorProtocol = report.connectorProtocol;
+  if (report.multiTurnResult !== undefined) base.multiTurnResult = report.multiTurnResult;
+  if (report.turnRunIds !== undefined) base.turnRunIds = report.turnRunIds;
 
   return base;
 }
@@ -272,6 +277,8 @@ class AsyncRunStorage {
     if (updates.lastTraceFetchAt !== undefined) storageUpdates.lastTraceFetchAt = updates.lastTraceFetchAt;
     if (updates.traceError !== undefined) storageUpdates.traceError = updates.traceError;
     if (updates.spans !== undefined) storageUpdates.spans = updates.spans;
+    if (updates.multiTurnResult !== undefined) storageUpdates.multiTurnResult = updates.multiTurnResult;
+    if (updates.turnRunIds !== undefined) storageUpdates.turnRunIds = updates.turnRunIds;
 
     const updated = await opensearchRuns.partialUpdate(reportId, storageUpdates);
     return toTestCaseRun(updated);

--- a/services/storage/asyncTestCaseStorage.ts
+++ b/services/storage/asyncTestCaseStorage.ts
@@ -11,7 +11,7 @@
  */
 
 import { testCaseStorage as opensearchTestCases, StorageTestCase } from './opensearchClient';
-import type { TestCase, TestCaseVersion, AgentContextItem, AgentToolDefinition, Difficulty } from '@/types';
+import type { TestCase, TestCaseVersion, AgentContextItem, AgentToolDefinition, Difficulty, MultiTurnScenario } from '@/types';
 import { buildLabels, parseLabels } from '@/lib/labels';
 
 // Input type for creating a test case
@@ -42,6 +42,7 @@ export interface CreateTestCaseInput {
     question: string;
     businessValue: string;
   }[];
+  multiTurnScenario?: MultiTurnScenario;
   tags?: string[];
   author?: string;
   isPromoted?: boolean;
@@ -73,6 +74,7 @@ export interface UpdateTestCaseInput {
     question: string;
     businessValue: string;
   }[];
+  multiTurnScenario?: MultiTurnScenario;
   tags?: string[];
   isPromoted?: boolean;
 }
@@ -116,6 +118,7 @@ function toTestCase(stored: StorageTestCase): TestCase {
     expectedPPL: stored.expectedPPL,
     expectedOutcomes: stored.expectedOutcomes,
     expectedTrajectory: (stored.expectedTrajectory || []) as TestCase['expectedTrajectory'],
+    multiTurnScenario: stored.multiTurnScenario as TestCase['multiTurnScenario'],
   };
 }
 
@@ -150,6 +153,7 @@ function toStorageFormat(testCase: CreateTestCaseInput | UpdateTestCaseInput): P
     expectedPPL: testCase.expectedPPL,
     expectedOutcomes: testCase.expectedOutcomes,
     expectedTrajectory: testCase.expectedTrajectory,
+    multiTurnScenario: testCase.multiTurnScenario,
     labels,
     // Legacy fields - kept for backward compatibility
     category: testCase.category,
@@ -317,6 +321,7 @@ class AsyncTestCaseStorage {
       expectedPPL: s.expectedPPL,
       expectedOutcomes: s.expectedOutcomes,  // NEW
       expectedTrajectory: (s.expectedTrajectory || []) as TestCaseVersion['expectedTrajectory'],
+      multiTurnScenario: s.multiTurnScenario as TestCaseVersion['multiTurnScenario'],
     }));
   }
 
@@ -336,6 +341,7 @@ class AsyncTestCaseStorage {
       expectedPPL: stored.expectedPPL,
       expectedOutcomes: stored.expectedOutcomes,  // NEW
       expectedTrajectory: (stored.expectedTrajectory || []) as TestCaseVersion['expectedTrajectory'],
+      multiTurnScenario: stored.multiTurnScenario as TestCaseVersion['multiTurnScenario'],
     };
   }
 

--- a/services/storage/opensearchClient.ts
+++ b/services/storage/opensearchClient.ts
@@ -61,6 +61,7 @@ export interface StorageTestCase {
   expectedPPL?: string;  // Expected PPL query
   expectedOutcomes?: string[];  // NEW: Simple text descriptions of expected behavior
   expectedTrajectory?: unknown[];  // Legacy: step-by-step trajectory
+  multiTurnScenario?: unknown;  // Multi-turn evaluation scenario
   labels?: string[];  // Unified labels system (replaces category/subcategory/difficulty)
   category?: string;  // Legacy - kept for backward compatibility
   subcategory?: string;  // Legacy - kept for backward compatibility

--- a/services/storage/opensearchClient.ts
+++ b/services/storage/opensearchClient.ts
@@ -151,6 +151,8 @@ export interface StorageRun {
     priority: 'high' | 'medium' | 'low';
   }[];
   connectorProtocol?: string;
+  multiTurnResult?: unknown;
+  turnRunIds?: string[];
 }
 
 export interface StorageAnalyticsRecord {

--- a/services/traces/index.ts
+++ b/services/traces/index.ts
@@ -57,8 +57,8 @@ export async function fetchTraceById(traceId: string): Promise<TraceSearchResult
 /**
  * Fetch traces by run IDs
  */
-export async function fetchTracesByRunIds(runIds: string[]): Promise<TraceSearchResult> {
-  return fetchTraces({ runIds });
+export async function fetchTracesByRunIds(runIds: string[], size?: number): Promise<TraceSearchResult> {
+  return fetchTraces({ runIds, size });
 }
 
 /**

--- a/tests/e2e/comparison.spec.ts
+++ b/tests/e2e/comparison.spec.ts
@@ -163,7 +163,17 @@ test.describe('Comparison Page - Metrics', () => {
         }
 
         await compareButton.click();
-        await page.waitForTimeout(2000);
+
+        // Wait for comparison page to fully load
+        const comparisonPage = page.locator('[data-testid="comparison-page"]');
+        await comparisonPage.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {});
+
+        // Select a second run (comparison page requires at least 2 runs selected)
+        const secondRunLabel = page.locator('label:has-text("Run 15")');
+        if (await secondRunLabel.isVisible().catch(() => false)) {
+          await secondRunLabel.click();
+          await page.waitForTimeout(2000);
+        }
 
         // Should show run summary cards with metrics
         const hasSummary = await page.locator('text=/Pass Rate|Accuracy|Avg/').first().isVisible().catch(() => false);
@@ -188,7 +198,17 @@ test.describe('Comparison Page - Metrics', () => {
         }
 
         await compareButton.click();
-        await page.waitForTimeout(2000);
+
+        // Wait for comparison page to fully load
+        const comparisonPage = page.locator('[data-testid="comparison-page"]');
+        await comparisonPage.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {});
+
+        // Select a second run (comparison page requires at least 2 runs selected)
+        const secondRunLabel = page.locator('label:has-text("Run 15")');
+        if (await secondRunLabel.isVisible().catch(() => false)) {
+          await secondRunLabel.click();
+          await page.waitForTimeout(2000);
+        }
 
         // Should show use case comparison table or similar
         const hasTable = await page.locator('text=/Use Case|Test Case|Status/').first().isVisible().catch(() => false);

--- a/tests/e2e/debug-api.spec.ts
+++ b/tests/e2e/debug-api.spec.ts
@@ -83,8 +83,8 @@ test.describe('Debug API E2E', () => {
     const initialResponse = await request.get('/api/debug');
     const initialData = await initialResponse.json();
 
-    // Find and click the verbose logging toggle
-    const toggle = page.locator('button[role="switch"]').first();
+    // Find and click the debug mode toggle
+    const toggle = page.locator('#debug-mode');
     await expect(toggle).toBeVisible();
 
     // Click toggle to change state

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -15,8 +15,8 @@ test.describe('Settings Page', () => {
     await expect(page.locator('[data-testid="settings-title"]')).toHaveText('Settings');
   });
 
-  test('should show Debug Settings section', async ({ page }) => {
-    await expect(page.locator('text=Debug Settings')).toBeVisible();
+  test('should show Debug section', async ({ page }) => {
+    await expect(page.locator('text=Debug').first()).toBeVisible();
   });
 
   test('should show Verbose Logging toggle', async ({ page }) => {
@@ -24,7 +24,7 @@ test.describe('Settings Page', () => {
   });
 
   test('should toggle debug mode', async ({ page }) => {
-    const toggle = page.locator('button[role="switch"]').first();
+    const toggle = page.locator('#debug-mode');
     await expect(toggle).toBeVisible();
 
     // Get initial state
@@ -40,7 +40,7 @@ test.describe('Settings Page', () => {
   });
 
   test('should show warning when debug mode is enabled', async ({ page }) => {
-    const toggle = page.locator('button[role="switch"]').first();
+    const toggle = page.locator('#debug-mode');
 
     // Get current state
     let state = await toggle.getAttribute('data-state');
@@ -84,7 +84,7 @@ test.describe('Agent Endpoints Section', () => {
   });
 
   test('should display built-in agents', async ({ page }) => {
-    await expect(page.locator('text=Built-in Agents')).toBeVisible();
+    await expect(page.locator('text=Built-in').first()).toBeVisible();
 
     // Should show at least one built-in agent
     const builtInBadge = page.locator('text=built-in').first();
@@ -161,7 +161,7 @@ test.describe('Custom Endpoint Form Fields', () => {
     await page.waitForTimeout(500);
 
     // The Select trigger for connector type should be visible
-    await expect(page.locator('label:has-text("Connector Type")').first()).toBeVisible();
+    await expect(page.locator('label:has-text("Connector")').first()).toBeVisible();
   });
 
   test('should show Enable Traces toggle in add form', async ({ page }) => {
@@ -409,19 +409,19 @@ test.describe('Evaluation Storage Section', () => {
     await page.waitForTimeout(2000);
 
     // Should show either Connected or Not connected
-    const statusText = page.locator('text=Connected to OpenSearch').or(page.locator('text=Not connected')).first();
+    const statusText = page.locator('text=Connected').or(page.locator('text=Not connected')).first();
     await expect(statusText).toBeVisible();
   });
 
   test('should show storage stats when connected', async ({ page }) => {
     await page.waitForTimeout(2000);
 
-    const isConnected = await page.locator('text=Connected to OpenSearch').isVisible().catch(() => false);
+    const isConnected = await page.locator('text=Connected').first().isVisible().catch(() => false);
 
     if (isConnected) {
       // Should show stats
       await expect(page.locator('text=Test Cases').first()).toBeVisible();
-      await expect(page.locator('text=Experiments').first()).toBeVisible();
+      await expect(page.locator('text=Benchmarks').first()).toBeVisible();
       await expect(page.locator('text=Runs').first()).toBeVisible();
     }
   });

--- a/tests/unit/cli/commands/import.test.ts
+++ b/tests/unit/cli/commands/import.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the import CLI command.
+ *
+ * Tests the core logic: file loading, dedup import call, and benchmark creation.
+ * The command action itself has complex dependencies (server lifecycle, ora spinners)
+ * so we test the integration of shared utilities and ApiClient methods.
+ */
+
+import type { ImportTestCasesResponse } from '@/cli/utils/apiClient';
+import { isFilePath, loadAndValidateTestCasesFile } from '@/cli/utils/testCaseFile';
+import { validateTestCasesArrayJson } from '@/lib/testCaseValidation';
+
+// Mock fs
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}));
+
+import { readFileSync } from 'fs';
+
+// Mock chalk for cleaner test output
+jest.mock('chalk', () => ({
+  default: {
+    cyan: (s: string) => s,
+    green: (s: string) => s,
+    yellow: (s: string) => s,
+    red: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+  },
+  cyan: (s: string) => s,
+  green: (s: string) => s,
+  yellow: (s: string) => s,
+  red: (s: string) => s,
+  gray: (s: string) => s,
+  bold: (s: string) => s,
+}));
+
+describe('Import Command - Helper Functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('loadAndValidateTestCasesFile (shared utility)', () => {
+    it('should load valid test cases from file', () => {
+      const validData = JSON.stringify([
+        {
+          name: 'Test 1',
+          category: 'RCA',
+          difficulty: 'Easy',
+          initialPrompt: 'prompt',
+          expectedOutcomes: ['outcome'],
+        },
+        {
+          name: 'Test 2',
+          category: 'Performance',
+          difficulty: 'Hard',
+          initialPrompt: 'prompt 2',
+          expectedOutcomes: ['outcome 2'],
+        },
+      ]);
+      (readFileSync as jest.Mock).mockReturnValue(validData);
+
+      const result = loadAndValidateTestCasesFile('test-cases.json');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Test 1');
+      expect(result[1].name).toBe('Test 2');
+    });
+
+    it('should throw for missing file', () => {
+      (readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(() => loadAndValidateTestCasesFile('missing.json')).toThrow('Cannot read file');
+    });
+
+    it('should throw for invalid JSON', () => {
+      (readFileSync as jest.Mock).mockReturnValue('not json');
+
+      expect(() => loadAndValidateTestCasesFile('bad.json')).toThrow('Invalid JSON');
+    });
+
+    it('should throw for validation errors', () => {
+      (readFileSync as jest.Mock).mockReturnValue(JSON.stringify([{}]));
+
+      expect(() => loadAndValidateTestCasesFile('invalid.json')).toThrow('Validation failed');
+    });
+  });
+
+  describe('Import response summary formatting', () => {
+    it('should format summary with all types', () => {
+      const importResult: ImportTestCasesResponse = {
+        created: 2,
+        reused: 3,
+        updated: 1,
+        testCases: [
+          { id: 'tc-1', name: 'A', status: 'created' },
+          { id: 'tc-2', name: 'B', status: 'created' },
+          { id: 'tc-3', name: 'C', status: 'reused' },
+          { id: 'tc-4', name: 'D', status: 'reused' },
+          { id: 'tc-5', name: 'E', status: 'reused' },
+          { id: 'tc-6', name: 'F', status: 'updated' },
+        ],
+      };
+
+      // Simulate the summary building logic from the import command
+      const summary: string[] = [];
+      if (importResult.created > 0) summary.push(`${importResult.created} created`);
+      if (importResult.reused > 0) summary.push(`${importResult.reused} reused`);
+      if (importResult.updated > 0) summary.push(`${importResult.updated} updated`);
+
+      expect(summary.join(', ')).toBe('2 created, 3 reused, 1 updated');
+      expect(importResult.testCases.length).toBe(6);
+    });
+
+    it('should omit zero counts from summary', () => {
+      const importResult: ImportTestCasesResponse = {
+        created: 0,
+        reused: 5,
+        updated: 0,
+        testCases: Array(5).fill({ id: 'tc-1', name: 'A', status: 'reused' as const }),
+      };
+
+      const summary: string[] = [];
+      if (importResult.created > 0) summary.push(`${importResult.created} created`);
+      if (importResult.reused > 0) summary.push(`${importResult.reused} reused`);
+      if (importResult.updated > 0) summary.push(`${importResult.updated} updated`);
+
+      expect(summary.join(', ')).toBe('5 reused');
+    });
+  });
+
+  describe('Benchmark creation from import', () => {
+    it('should extract IDs for benchmark creation', () => {
+      const importResult: ImportTestCasesResponse = {
+        created: 1,
+        reused: 1,
+        updated: 1,
+        testCases: [
+          { id: 'tc-new', name: 'New', status: 'created' },
+          { id: 'tc-existing', name: 'Existing', status: 'reused' },
+          { id: 'tc-updated', name: 'Updated', status: 'updated' },
+        ],
+      };
+
+      // The import command extracts IDs for benchmark creation
+      const testCaseIds = importResult.testCases.map(tc => tc.id);
+
+      expect(testCaseIds).toEqual(['tc-new', 'tc-existing', 'tc-updated']);
+    });
+  });
+});

--- a/tests/unit/cli/startServer.test.ts
+++ b/tests/unit/cli/startServer.test.ts
@@ -8,7 +8,7 @@
  *
  * The startServer module:
  * - Finds the package root directory
- * - Sets VITE_BACKEND_PORT environment variable
+ * - Sets PORT environment variable
  * - Dynamically imports the server app and starts it
  */
 
@@ -25,7 +25,7 @@ describe('startServer module', () => {
     });
 
     it('should accept a port option', () => {
-      // startServer({ port: 4001 }) sets VITE_BACKEND_PORT and starts server
+      // startServer({ port: 4001 }) sets PORT and starts server
       const expectedOptions = { port: 4001 };
       expect(expectedOptions).toHaveProperty('port');
       expect(typeof expectedOptions.port).toBe('number');
@@ -42,9 +42,9 @@ describe('startServer module', () => {
   });
 
   describe('environment variable setup', () => {
-    it('should set VITE_BACKEND_PORT from options', () => {
+    it('should set PORT from options', () => {
       // When startServer is called, it sets:
-      // process.env.VITE_BACKEND_PORT = String(options.port)
+      // process.env.PORT = String(options.port)
       const port = 5000;
       const expectedEnvValue = String(port);
       expect(expectedEnvValue).toBe('5000');

--- a/tests/unit/cli/utils/testCaseFile.test.ts
+++ b/tests/unit/cli/utils/testCaseFile.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'fs';
+import { isFilePath, loadAndValidateTestCasesFile } from '@/cli/utils/testCaseFile';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}));
+
+describe('testCaseFile utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isFilePath', () => {
+    it('should detect .json extension', () => {
+      expect(isFilePath('test-cases.json')).toBe(true);
+    });
+
+    it('should detect .JSON extension (case-insensitive)', () => {
+      expect(isFilePath('test-cases.JSON')).toBe(true);
+    });
+
+    it('should detect path with .json extension', () => {
+      expect(isFilePath('./path/to/test-cases.json')).toBe(true);
+    });
+
+    it('should return false for benchmark names', () => {
+      expect(isFilePath('My Benchmark')).toBe(false);
+    });
+
+    it('should return false for benchmark IDs', () => {
+      expect(isFilePath('bench-123456')).toBe(false);
+    });
+
+    it('should return false for strings containing json but not ending with .json', () => {
+      expect(isFilePath('json-benchmark')).toBe(false);
+    });
+  });
+
+  describe('loadAndValidateTestCasesFile', () => {
+    it('should load and validate a valid JSON file', () => {
+      const validData = JSON.stringify([
+        {
+          name: 'Test Case 1',
+          category: 'RCA',
+          difficulty: 'Easy',
+          initialPrompt: 'Investigate the issue',
+          expectedOutcomes: ['Find root cause'],
+        },
+      ]);
+      (readFileSync as jest.Mock).mockReturnValue(validData);
+
+      const result = loadAndValidateTestCasesFile('test.json');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Test Case 1');
+    });
+
+    it('should throw on unreadable file', () => {
+      (readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT: no such file');
+      });
+
+      expect(() => loadAndValidateTestCasesFile('missing.json')).toThrow('Cannot read file');
+    });
+
+    it('should throw on invalid JSON', () => {
+      (readFileSync as jest.Mock).mockReturnValue('{ broken json');
+
+      expect(() => loadAndValidateTestCasesFile('bad.json')).toThrow('Invalid JSON');
+    });
+
+    it('should throw on validation failure', () => {
+      (readFileSync as jest.Mock).mockReturnValue(JSON.stringify([{ name: '' }]));
+
+      expect(() => loadAndValidateTestCasesFile('invalid.json')).toThrow('Validation failed');
+    });
+
+    it('should handle a single object (auto-wrap)', () => {
+      const singleObject = JSON.stringify({
+        name: 'Single Test',
+        category: 'RCA',
+        difficulty: 'Medium',
+        initialPrompt: 'Check this',
+        expectedOutcomes: ['Expected result'],
+      });
+      (readFileSync as jest.Mock).mockReturnValue(singleObject);
+
+      const result = loadAndValidateTestCasesFile('single.json');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Single Test');
+    });
+  });
+});

--- a/tests/unit/lib/testCaseValidation.test.ts
+++ b/tests/unit/lib/testCaseValidation.test.ts
@@ -406,4 +406,123 @@ describe('testCaseValidation', () => {
       expect(result.valid).toBe(false);
     });
   });
+
+  describe('multiTurnScenario validation', () => {
+    const baseTestCase = {
+      name: 'Multi-turn test',
+      category: 'RCA',
+      difficulty: 'Medium' as const,
+      initialPrompt: 'What is wrong?',
+      expectedOutcomes: ['Find root cause'],
+    };
+
+    it('should accept test case without multiTurnScenario', () => {
+      const result = testCaseSchema.safeParse(baseTestCase);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept test case with valid multiTurnScenario', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: 'Investigating cart failure',
+          acceptanceCriteria: ['Root cause found', 'Remediation provided'],
+          idealAnswer: 'Redis connection failure',
+          turnLimit: 5,
+          referenceTurns: [
+            { turn: 1, user: 'What is wrong?', expectedTopics: ['error'], groundTruth: 'Redis down' },
+          ],
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept multiTurnScenario with criticalComponents', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: 'Investigating',
+          acceptanceCriteria: ['Root cause found'],
+          idealAnswer: 'Redis failure',
+          criticalComponents: {
+            rootCause: 'Redis connection timeout',
+            remediation: 'Restart Redis pod',
+          },
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject multiTurnScenario with empty userMotivation', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: '',
+          acceptanceCriteria: ['Root cause found'],
+          idealAnswer: 'Redis failure',
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject multiTurnScenario with empty acceptanceCriteria', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: 'Investigating',
+          acceptanceCriteria: [],
+          idealAnswer: 'Redis failure',
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject scoringWeights that do not sum to 100', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: 'Investigating',
+          acceptanceCriteria: ['Root cause found'],
+          idealAnswer: 'Redis failure',
+          scoringWeights: {
+            rootCause: 50,
+            remediation: 50,
+            contextRetention: 50,
+            conciseness: 50,
+          },
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept scoringWeights that sum to 100 with defaults', () => {
+      const testCase = {
+        ...baseTestCase,
+        multiTurnScenario: {
+          userMotivation: 'Investigating',
+          acceptanceCriteria: ['Root cause found'],
+          idealAnswer: 'Redis failure',
+          scoringWeights: {
+            rootCause: 40,
+            remediation: 30,
+            contextRetention: 20,
+            conciseness: 10,
+          },
+        },
+      };
+
+      const result = testCaseSchema.safeParse(testCase);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/tests/unit/server/config/index.test.ts
+++ b/tests/unit/server/config/index.test.ts
@@ -18,8 +18,6 @@ describe('server/config', () => {
   describe('PORT', () => {
     it('should default to 4001', async () => {
       delete process.env.PORT;
-      delete process.env.BACKEND_PORT;
-      delete process.env.VITE_BACKEND_PORT;
       const config = await import('@/server/config');
       expect(config.PORT).toBe(4001);
     });
@@ -28,13 +26,6 @@ describe('server/config', () => {
       process.env.PORT = '8080';
       const config = await import('@/server/config');
       expect(config.PORT).toBe(8080);
-    });
-
-    it('should use BACKEND_PORT when PORT is not set', async () => {
-      delete process.env.PORT;
-      process.env.BACKEND_PORT = '9000';
-      const config = await import('@/server/config');
-      expect(config.PORT).toBe(9000);
     });
   });
 

--- a/tests/unit/server/constants/indexMappings.test.ts
+++ b/tests/unit/server/constants/indexMappings.test.ts
@@ -158,6 +158,22 @@ describe('indexMappings', () => {
       expect(metricsProps.latency_score.type).toBe('float');
     });
 
+    it('should have multiTurnResult as disabled object', () => {
+      const mappings = getIndexMappings();
+      const key = Object.keys(mappings).find((k) => k.includes('runs'))!;
+      const props = mappings[key].mappings.properties;
+
+      expect(props.multiTurnResult).toEqual({ type: 'object', enabled: false });
+    });
+
+    it('should have turnRunIds as keyword', () => {
+      const mappings = getIndexMappings();
+      const key = Object.keys(mappings).find((k) => k.includes('runs'))!;
+      const props = mappings[key].mappings.properties;
+
+      expect(props.turnRunIds).toEqual({ type: 'keyword' });
+    });
+
     it('should have nested annotations', () => {
       const mappings = getIndexMappings();
       const key = Object.keys(mappings).find((k) => k.includes('runs'))!;

--- a/tests/unit/server/prompts/multiTurnJudgePrompt.test.ts
+++ b/tests/unit/server/prompts/multiTurnJudgePrompt.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildMultiTurnJudgeSystemPrompt,
+  computeWeightedScore,
+  DEFAULT_SCORING_WEIGHTS,
+} from '@/server/prompts/multiTurnJudgePrompt';
+import type { ConversationTurnRecord } from '@/types';
+
+const makeTurn = (
+  turn: number,
+  userMessage: string,
+  agentResponse: string
+): ConversationTurnRecord => ({
+  turn,
+  userMessage,
+  agentResponse,
+  trajectory: [],
+});
+
+describe('multiTurnJudgePrompt', () => {
+  describe('buildMultiTurnJudgeSystemPrompt', () => {
+    const baseTurns: ConversationTurnRecord[] = [
+      makeTurn(1, 'What caused the outage?', 'The database connection pool was exhausted.'),
+      makeTurn(2, 'How do I fix it?', 'Increase the max pool size to 50 and add connection timeout settings.'),
+    ];
+
+    it('should include the ideal answer in the prompt', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'DB pool exhaustion due to leaked connections',
+      });
+
+      expect(prompt).toContain('## Ideal Answer');
+      expect(prompt).toContain('DB pool exhaustion due to leaked connections');
+    });
+
+    it('should include critical components when provided', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+        criticalComponents: {
+          rootCause: 'Connection pool leak in service X',
+          remediation: 'Patch connection close handler',
+        },
+      });
+
+      expect(prompt).toContain('## Critical Components');
+      expect(prompt).toContain('Root cause: Connection pool leak in service X');
+      expect(prompt).toContain('Remediation: Patch connection close handler');
+    });
+
+    it('should not include critical components section when not provided', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+      });
+
+      expect(prompt).not.toContain('## Critical Components');
+    });
+
+    it('should include all conversation turns formatted correctly', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+      });
+
+      expect(prompt).toContain('## Full Conversation');
+      expect(prompt).toContain('### Turn 1');
+      expect(prompt).toContain('**User:** What caused the outage?');
+      expect(prompt).toContain('**Agent:** The database connection pool was exhausted.');
+      expect(prompt).toContain('### Turn 2');
+      expect(prompt).toContain('**User:** How do I fix it?');
+      expect(prompt).toContain('**Agent:** Increase the max pool size to 50 and add connection timeout settings.');
+    });
+
+    it('should use default weights when no custom weights are provided', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+      });
+
+      expect(prompt).toContain(`weight: ${DEFAULT_SCORING_WEIGHTS.rootCause}%`);
+      expect(prompt).toContain(`weight: ${DEFAULT_SCORING_WEIGHTS.remediation}%`);
+      expect(prompt).toContain(`weight: ${DEFAULT_SCORING_WEIGHTS.contextRetention}%`);
+      expect(prompt).toContain(`weight: ${DEFAULT_SCORING_WEIGHTS.conciseness}%`);
+      // Verify the actual default values appear
+      expect(prompt).toContain('weight: 40%');
+      expect(prompt).toContain('weight: 30%');
+      expect(prompt).toContain('weight: 20%');
+      expect(prompt).toContain('weight: 10%');
+    });
+
+    it('should use custom weights when provided', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+        scoringWeights: {
+          rootCause: 50,
+          remediation: 25,
+          contextRetention: 15,
+          conciseness: 10,
+        },
+      });
+
+      expect(prompt).toContain('weight: 50%');
+      expect(prompt).toContain('weight: 25%');
+      expect(prompt).toContain('weight: 15%');
+      // conciseness stays at 10 (same as default)
+      expect(prompt).toContain('weight: 10%');
+    });
+
+    it('should merge partial custom weights with defaults', () => {
+      const prompt = buildMultiTurnJudgeSystemPrompt({
+        turns: baseTurns,
+        idealAnswer: 'Some ideal answer',
+        scoringWeights: {
+          rootCause: 60,
+        },
+      });
+
+      // rootCause overridden
+      expect(prompt).toContain('weight: 60%');
+      // Others remain default
+      expect(prompt).toContain('weight: 30%');
+      expect(prompt).toContain('weight: 20%');
+      expect(prompt).toContain('weight: 10%');
+    });
+  });
+
+  describe('computeWeightedScore', () => {
+    it('should compute correctly with default weights: (80*40 + 70*30 + 90*20 + 85*10) / 100 = 80.5', () => {
+      const result = computeWeightedScore({
+        rootCauseScore: 80,
+        remediationScore: 70,
+        contextRetentionScore: 90,
+        concisenessScore: 85,
+      });
+
+      // (80*40 + 70*30 + 90*20 + 85*10) / 100
+      // = (3200 + 2100 + 1800 + 850) / 100
+      // = 7950 / 100
+      // = 79.5
+      expect(result).toBe(79.5);
+    });
+
+    it('should compute correctly with custom weights', () => {
+      const result = computeWeightedScore(
+        {
+          rootCauseScore: 80,
+          remediationScore: 70,
+          contextRetentionScore: 90,
+          concisenessScore: 85,
+        },
+        {
+          rootCause: 25,
+          remediation: 25,
+          contextRetention: 25,
+          conciseness: 25,
+        }
+      );
+
+      // (80*25 + 70*25 + 90*25 + 85*25) / 100
+      // = (2000 + 1750 + 2250 + 2125) / 100
+      // = 8125 / 100
+      // = 81.25
+      expect(result).toBe(81.25);
+    });
+
+    it('should return 0 when all scores are 0', () => {
+      const result = computeWeightedScore({
+        rootCauseScore: 0,
+        remediationScore: 0,
+        contextRetentionScore: 0,
+        concisenessScore: 0,
+      });
+
+      expect(result).toBe(0);
+    });
+
+    it('should return 100 when all scores are 100', () => {
+      const result = computeWeightedScore({
+        rootCauseScore: 100,
+        remediationScore: 100,
+        contextRetentionScore: 100,
+        concisenessScore: 100,
+      });
+
+      // (100*40 + 100*30 + 100*20 + 100*10) / 100 = 10000 / 100 = 100
+      expect(result).toBe(100);
+    });
+  });
+});

--- a/tests/unit/server/routes/storage/testCaseImport.test.ts
+++ b/tests/unit/server/routes/storage/testCaseImport.test.ts
@@ -1,0 +1,383 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Request, Response } from 'express';
+import testCasesRoutes from '@/server/routes/storage/testCases';
+
+// Mock the adapters module
+jest.mock('@/server/adapters/index', () => ({
+  getStorageModule: jest.fn(),
+}));
+
+import { getStorageModule } from '@/server/adapters/index';
+
+// Mock sample test cases
+jest.mock('@/cli/demo/sampleTestCases', () => ({
+  SAMPLE_TEST_CASES: [],
+}));
+
+// Silence console output
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+// Create mock storage module
+function createMockStorage() {
+  return {
+    isConfigured: jest.fn().mockReturnValue(true),
+    testCases: {
+      getAll: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+      getById: jest.fn().mockResolvedValue(null),
+      getVersions: jest.fn().mockResolvedValue([]),
+      getVersion: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      bulkCreate: jest.fn(),
+      search: jest.fn(),
+    },
+    benchmarks: {},
+    runs: {},
+    analytics: {},
+    health: jest.fn(),
+  };
+}
+
+// Helper to create mock request/response
+function createMocks(params: any = {}, body: any = {}, query: any = {}) {
+  const req = {
+    params,
+    body,
+    query,
+  } as unknown as Request;
+  const res = {
+    json: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { req, res };
+}
+
+// Helper to get route handler
+function getRouteHandler(router: any, method: string, path: string) {
+  const routes = router.stack;
+  const route = routes.find(
+    (layer: any) =>
+      layer.route &&
+      layer.route.path === path &&
+      layer.route.methods[method.toLowerCase()]
+  );
+  return route?.route.stack[0].handle;
+}
+
+describe('POST /api/storage/test-cases/import', () => {
+  let mockStorage: ReturnType<typeof createMockStorage>;
+  let handler: Function;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorage = createMockStorage();
+    (getStorageModule as jest.Mock).mockReturnValue(mockStorage);
+    handler = getRouteHandler(testCasesRoutes, 'post', '/api/storage/test-cases/import');
+  });
+
+  it('should reject non-array input', async () => {
+    const { req, res } = createMocks({}, { testCases: 'not-an-array' });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'testCases must be an array' });
+  });
+
+  it('should return empty result for empty array', async () => {
+    const { req, res } = createMocks({}, { testCases: [] });
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      created: 0,
+      reused: 0,
+      updated: 0,
+      testCases: [],
+    });
+  });
+
+  it('should reject test cases with demo- prefix', async () => {
+    const { req, res } = createMocks({}, {
+      testCases: [{ id: 'demo-test', name: 'Bad' }],
+    });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('demo- prefix') })
+    );
+  });
+
+  it('should create new test cases when no name match', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({ items: [], total: 0 });
+    mockStorage.testCases.create
+      .mockResolvedValueOnce({ id: 'tc-new-1', name: 'Test Case A' })
+      .mockResolvedValueOnce({ id: 'tc-new-2', name: 'Test Case B' });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Test Case A', initialPrompt: 'prompt A', expectedOutcomes: ['outcome A'] },
+        { name: 'Test Case B', initialPrompt: 'prompt B', expectedOutcomes: ['outcome B'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.create).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith({
+      created: 2,
+      reused: 0,
+      updated: 0,
+      testCases: [
+        { id: 'tc-new-1', name: 'Test Case A', status: 'created' },
+        { id: 'tc-new-2', name: 'Test Case B', status: 'created' },
+      ],
+    });
+  });
+
+  it('should reuse test cases with identical name and content', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-existing-1',
+          name: 'Existing Test',
+          initialPrompt: 'same prompt',
+          expectedOutcomes: ['outcome 1', 'outcome 2'],
+        },
+      ],
+      total: 1,
+    });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Existing Test', initialPrompt: 'same prompt', expectedOutcomes: ['outcome 2', 'outcome 1'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.create).not.toHaveBeenCalled();
+    expect(mockStorage.testCases.update).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      created: 0,
+      reused: 1,
+      updated: 0,
+      testCases: [
+        { id: 'tc-existing-1', name: 'Existing Test', status: 'reused' },
+      ],
+    });
+  });
+
+  it('should update test cases with same name but different content', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-existing-1',
+          name: 'Existing Test',
+          initialPrompt: 'old prompt',
+          expectedOutcomes: ['old outcome'],
+        },
+      ],
+      total: 1,
+    });
+    mockStorage.testCases.update.mockResolvedValue({
+      id: 'tc-existing-1',
+      name: 'Existing Test',
+      version: 2,
+    });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Existing Test', initialPrompt: 'new prompt', expectedOutcomes: ['new outcome'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.update).toHaveBeenCalledWith('tc-existing-1', expect.objectContaining({
+      name: 'Existing Test',
+      initialPrompt: 'new prompt',
+    }));
+    expect(res.json).toHaveBeenCalledWith({
+      created: 0,
+      reused: 0,
+      updated: 1,
+      testCases: [
+        { id: 'tc-existing-1', name: 'Existing Test', status: 'updated' },
+      ],
+    });
+  });
+
+  it('should handle mixed batch: created, reused, updated', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-1',
+          name: 'Unchanged',
+          initialPrompt: 'same',
+          expectedOutcomes: ['same'],
+        },
+        {
+          id: 'tc-2',
+          name: 'Modified',
+          initialPrompt: 'old',
+          expectedOutcomes: ['old'],
+        },
+      ],
+      total: 2,
+    });
+    mockStorage.testCases.create.mockResolvedValue({ id: 'tc-3', name: 'Brand New' });
+    mockStorage.testCases.update.mockResolvedValue({ id: 'tc-2', name: 'Modified', version: 2 });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Unchanged', initialPrompt: 'same', expectedOutcomes: ['same'] },
+        { name: 'Modified', initialPrompt: 'new', expectedOutcomes: ['new'] },
+        { name: 'Brand New', initialPrompt: 'fresh', expectedOutcomes: ['fresh'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      created: 1,
+      reused: 1,
+      updated: 1,
+      testCases: [
+        { id: 'tc-1', name: 'Unchanged', status: 'reused' },
+        { id: 'tc-2', name: 'Modified', status: 'updated' },
+        { id: 'tc-3', name: 'Brand New', status: 'created' },
+      ],
+    });
+  });
+
+  it('should use case-insensitive name matching', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-1',
+          name: 'My Test Case',
+          initialPrompt: 'prompt',
+          expectedOutcomes: ['outcome'],
+        },
+      ],
+      total: 1,
+    });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'my test case', initialPrompt: 'prompt', expectedOutcomes: ['outcome'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.create).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ reused: 1 })
+    );
+  });
+
+  it('should detect content change when expectedOutcomes differ', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-1',
+          name: 'Test',
+          initialPrompt: 'prompt',
+          expectedOutcomes: ['outcome A'],
+        },
+      ],
+      total: 1,
+    });
+    mockStorage.testCases.update.mockResolvedValue({ id: 'tc-1', name: 'Test', version: 2 });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Test', initialPrompt: 'prompt', expectedOutcomes: ['outcome A', 'outcome B'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.update).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ updated: 1 })
+    );
+  });
+
+  it('should detect content change when initialPrompt differs', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({
+      items: [
+        {
+          id: 'tc-1',
+          name: 'Test',
+          initialPrompt: 'old prompt',
+          expectedOutcomes: ['outcome'],
+        },
+      ],
+      total: 1,
+    });
+    mockStorage.testCases.update.mockResolvedValue({ id: 'tc-1', name: 'Test', version: 2 });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Test', initialPrompt: 'new prompt', expectedOutcomes: ['outcome'] },
+      ],
+    });
+    await handler(req, res);
+
+    expect(mockStorage.testCases.update).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ updated: 1 })
+    );
+  });
+
+  it('should handle storage errors', async () => {
+    mockStorage.testCases.getAll.mockRejectedValue(new Error('Storage down'));
+
+    const { req, res } = createMocks({}, {
+      testCases: [{ name: 'Test', initialPrompt: 'p', expectedOutcomes: ['o'] }],
+    });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Storage down' });
+  });
+
+  it('should handle duplicates within the same batch', async () => {
+    mockStorage.testCases.getAll.mockResolvedValue({ items: [], total: 0 });
+    mockStorage.testCases.create.mockResolvedValue({
+      id: 'tc-new-1',
+      name: 'Duplicate Name',
+      initialPrompt: 'prompt',
+      expectedOutcomes: ['outcome'],
+    });
+
+    const { req, res } = createMocks({}, {
+      testCases: [
+        { name: 'Duplicate Name', initialPrompt: 'prompt', expectedOutcomes: ['outcome'] },
+        { name: 'Duplicate Name', initialPrompt: 'prompt', expectedOutcomes: ['outcome'] },
+      ],
+    });
+    await handler(req, res);
+
+    // First one created, second one reused (since first was added to map)
+    expect(mockStorage.testCases.create).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      created: 1,
+      reused: 1,
+      updated: 0,
+      testCases: [
+        { id: 'tc-new-1', name: 'Duplicate Name', status: 'created' },
+        { id: 'tc-new-1', name: 'Duplicate Name', status: 'reused' },
+      ],
+    });
+  });
+});

--- a/tests/unit/server/services/storage/index.test.ts
+++ b/tests/unit/server/services/storage/index.test.ts
@@ -494,6 +494,38 @@ describe('Storage Service', () => {
       );
     });
 
+    it('should include multiTurnResult and turnRunIds when present', async () => {
+      mockClient.index.mockResolvedValue({ body: { result: 'created' } });
+
+      const multiTurnResult = {
+        turns: [{ turn: 1, userMessage: 'Q', agentResponse: 'A', trajectory: [] }],
+        totalTurns: 1,
+        acceptanceCriteriaMet: true,
+        rootCauseScore: 90,
+        remediationScore: 85,
+        contextRetentionScore: 80,
+        concisenessScore: 95,
+        reasoning: 'Good multi-turn performance',
+      };
+
+      const report = {
+        testCaseId: 'tc-1',
+        multiTurnResult,
+        turnRunIds: ['run-t1', 'run-t2'],
+      };
+
+      await saveReport(report);
+
+      expect(mockClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            multiTurnResult,
+            turnRunIds: ['run-t1', 'run-t2'],
+          }),
+        })
+      );
+    });
+
     it('should use openSearchLogs as fallback for logs', async () => {
       mockClient.index.mockResolvedValue({ body: { result: 'created' } });
 

--- a/tests/unit/server/services/storage/index.test.ts
+++ b/tests/unit/server/services/storage/index.test.ts
@@ -82,7 +82,7 @@ describe('Storage Service', () => {
           size: 0,
           aggs: {
             test_cases: {
-              terms: { field: 'id.keyword', size: 10000 },
+              terms: { field: 'id', size: 10000 },
               aggs: {
                 latest: {
                   top_hits: { size: 1, sort: [{ version: { order: 'desc' } }] },

--- a/tests/unit/services/agent/aguiConverter.test.ts
+++ b/tests/unit/services/agent/aguiConverter.test.ts
@@ -669,6 +669,75 @@ describe('AGUIToTrajectoryConverter', () => {
       expect(steps).toEqual([]);
     });
   });
+
+  describe('getRunFinishedResult', () => {
+    it('should return null by default when no events have been processed', () => {
+      expect(converter.getRunFinishedResult()).toBeNull();
+    });
+
+    it('should capture result from RUN_FINISHED event', () => {
+      const result = { status: 'success', output: 'Analysis complete' };
+
+      converter.processEvent({
+        type: AGUIEventType.RUN_STARTED,
+        runId: 'run-1',
+        threadId: 'thread-1',
+        timestamp: Date.now(),
+      });
+
+      converter.processEvent({
+        type: AGUIEventType.RUN_FINISHED,
+        result,
+        timestamp: Date.now(),
+      });
+
+      expect(converter.getRunFinishedResult()).toEqual(result);
+    });
+
+    it('should return null when RUN_FINISHED has no result', () => {
+      converter.processEvent({
+        type: AGUIEventType.RUN_STARTED,
+        runId: 'run-1',
+        threadId: 'thread-1',
+        timestamp: Date.now(),
+      });
+
+      converter.processEvent({
+        type: AGUIEventType.RUN_FINISHED,
+        timestamp: Date.now(),
+      });
+
+      expect(converter.getRunFinishedResult()).toBeNull();
+    });
+
+    it('should reset to null on RUN_STARTED', () => {
+      // First run with a result
+      converter.processEvent({
+        type: AGUIEventType.RUN_STARTED,
+        runId: 'run-1',
+        threadId: 'thread-1',
+        timestamp: Date.now(),
+      });
+
+      converter.processEvent({
+        type: AGUIEventType.RUN_FINISHED,
+        result: { output: 'first run result' },
+        timestamp: Date.now(),
+      });
+
+      expect(converter.getRunFinishedResult()).toEqual({ output: 'first run result' });
+
+      // Starting a new run should reset the result
+      converter.processEvent({
+        type: AGUIEventType.RUN_STARTED,
+        runId: 'run-2',
+        threadId: 'thread-2',
+        timestamp: Date.now(),
+      });
+
+      expect(converter.getRunFinishedResult()).toBeNull();
+    });
+  });
 });
 
 describe('computeTrajectoryFromRawEvents', () => {

--- a/tests/unit/services/connectors/agui/AGUIStreamingConnector.test.ts
+++ b/tests/unit/services/connectors/agui/AGUIStreamingConnector.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/services/agent/aguiConverter', () => ({
     processEvent: jest.fn().mockReturnValue([]),
     getRunId: jest.fn().mockReturnValue('test-run-id'),
     getThreadId: jest.fn().mockReturnValue('test-thread-id'),
+    getRunFinishedResult: jest.fn().mockReturnValue(null),
   })),
   computeTrajectoryFromRawEvents: jest.fn().mockReturnValue([]),
 }));
@@ -25,14 +26,25 @@ jest.mock('@/services/agent/aguiConverter', () => ({
 // Mock the payload builder
 jest.mock('@/services/agent/payloadBuilder', () => ({
   buildAgentPayload: jest.fn().mockReturnValue({
+    threadId: 'thread-1',
+    runId: 'run-1',
     messages: [{ content: 'test' }],
     model: 'test-model',
+  }),
+  buildMultiTurnPayload: jest.fn().mockReturnValue({
+    threadId: 'thread-1',
+    runId: 'run-2',
+    messages: [],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   }),
 }));
 
 import { consumeSSEStream } from '@/services/agent/sseStream';
 import { AGUIToTrajectoryConverter, computeTrajectoryFromRawEvents } from '@/services/agent/aguiConverter';
-import { buildAgentPayload } from '@/services/agent/payloadBuilder';
+import { buildAgentPayload, buildMultiTurnPayload } from '@/services/agent/payloadBuilder';
 
 describe('AGUIStreamingConnector', () => {
   let connector: AGUIStreamingConnector;
@@ -267,6 +279,200 @@ describe('AGUIStreamingConnector', () => {
   describe('default instance', () => {
     it('should export a default instance', () => {
       expect(aguiStreamingConnector).toBeInstanceOf(AGUIStreamingConnector);
+    });
+  });
+
+  describe('interrupt handling (multiTurnOptions)', () => {
+    it('should execute single pass when multiTurnOptions not enabled', async () => {
+      (consumeSSEStream as jest.Mock).mockResolvedValue(undefined);
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      expect(consumeSSEStream).toHaveBeenCalledTimes(1);
+      expect(response.runId).toBe('test-run-id');
+    });
+
+    it('should execute single pass when multiTurnOptions.enabled is false', async () => {
+      (consumeSSEStream as jest.Mock).mockResolvedValue(undefined);
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+        multiTurnOptions: { enabled: false },
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      expect(consumeSSEStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle interrupt with auto-approve and make second call', async () => {
+      let callCount = 0;
+
+      // Mock converter that returns interrupt on first call, no interrupt on second
+      (AGUIToTrajectoryConverter as jest.Mock).mockImplementation(() => {
+        callCount++;
+        const currentCall = callCount;
+        return {
+          processEvent: jest.fn().mockReturnValue([
+            { id: `step-${currentCall}`, timestamp: Date.now(), type: 'response', content: `Response ${currentCall}` },
+          ]),
+          getRunId: jest.fn().mockReturnValue(`run-${currentCall}`),
+          getThreadId: jest.fn().mockReturnValue('thread-1'),
+          getRunFinishedResult: jest.fn().mockReturnValue(
+            currentCall === 1 ? { outcome: 'interrupt', reason: 'Tool approval needed' } : null
+          ),
+        };
+      });
+
+      // consumeSSEStream must invoke the callback to trigger processEvent
+      (consumeSSEStream as jest.Mock).mockImplementation(
+        async (_endpoint: string, _payload: any, callback: (event: any) => void) => {
+          callback({ type: 'TEXT_MESSAGE_CONTENT' });
+        }
+      );
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+        multiTurnOptions: { enabled: true, maxTurns: 5, interruptPolicy: 'auto-approve' },
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      // Should have been called twice: initial + after interrupt
+      expect(consumeSSEStream).toHaveBeenCalledTimes(2);
+      // Trajectory should have steps from both calls
+      expect(response.trajectory.length).toBe(2);
+      expect(response.metadata?.interruptCount).toBe(1);
+      expect(response.metadata?.threadId).toBe('thread-1');
+    });
+
+    it('should stop when interrupt policy is skip', async () => {
+      (AGUIToTrajectoryConverter as jest.Mock).mockImplementation(() => ({
+        processEvent: jest.fn().mockReturnValue([
+          { id: 'step-1', timestamp: Date.now(), type: 'response', content: 'Response' },
+        ]),
+        getRunId: jest.fn().mockReturnValue('run-1'),
+        getThreadId: jest.fn().mockReturnValue('thread-1'),
+        getRunFinishedResult: jest.fn().mockReturnValue({ outcome: 'interrupt', reason: 'Needs approval' }),
+      }));
+
+      (consumeSSEStream as jest.Mock).mockImplementation(
+        async (_endpoint: string, _payload: any, callback: (event: any) => void) => {
+          callback({ type: 'TEXT_MESSAGE_CONTENT' });
+        }
+      );
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+        multiTurnOptions: { enabled: true, maxTurns: 5, interruptPolicy: 'skip' },
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      // Should only call once since skip policy stops the loop
+      expect(consumeSSEStream).toHaveBeenCalledTimes(1);
+      expect(response.trajectory.length).toBe(1);
+    });
+
+    it('should respect maxTurns limit for interrupts', async () => {
+      // Always return interrupt
+      (AGUIToTrajectoryConverter as jest.Mock).mockImplementation(() => ({
+        processEvent: jest.fn().mockReturnValue([]),
+        getRunId: jest.fn().mockReturnValue('run-1'),
+        getThreadId: jest.fn().mockReturnValue('thread-1'),
+        getRunFinishedResult: jest.fn().mockReturnValue({ outcome: 'interrupt', reason: 'Needs approval' }),
+      }));
+
+      (consumeSSEStream as jest.Mock).mockImplementation(
+        async (_endpoint: string, _payload: any, callback: (event: any) => void) => {
+          callback({ type: 'TEXT_MESSAGE_CONTENT' });
+        }
+      );
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+        multiTurnOptions: { enabled: true, maxTurns: 3, interruptPolicy: 'auto-approve' },
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      // Should stop at maxTurns
+      expect(consumeSSEStream).toHaveBeenCalledTimes(3);
+    });
+
+    it('should preserve threadId across interrupt sub-turns', async () => {
+      let callCount = 0;
+      (AGUIToTrajectoryConverter as jest.Mock).mockImplementation(() => {
+        callCount++;
+        const currentCall = callCount;
+        return {
+          processEvent: jest.fn().mockReturnValue([
+            { id: `s${currentCall}`, timestamp: Date.now(), type: 'response', content: `R${currentCall}` },
+          ]),
+          getRunId: jest.fn().mockReturnValue(`run-${currentCall}`),
+          getThreadId: jest.fn().mockReturnValue('preserved-thread'),
+          getRunFinishedResult: jest.fn().mockReturnValue(
+            currentCall === 1 ? { outcome: 'interrupt', reason: 'approve' } : null
+          ),
+        };
+      });
+
+      (consumeSSEStream as jest.Mock).mockImplementation(
+        async (_endpoint: string, _payload: any, callback: (event: any) => void) => {
+          callback({ type: 'TEXT_MESSAGE_CONTENT' });
+        }
+      );
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+        multiTurnOptions: { enabled: true, interruptPolicy: 'auto-approve' },
+      };
+
+      const response = await connector.execute(
+        'http://localhost:8080/stream',
+        request,
+        mockAuth
+      );
+
+      expect(response.metadata?.threadId).toBe('preserved-thread');
+      // buildMultiTurnPayload should have been called with the preserved threadId
+      expect(buildMultiTurnPayload).toHaveBeenCalledWith(
+        expect.any(Array),
+        'preserved-thread',
+        undefined,
+        expect.any(Array),
+        undefined
+      );
     });
   });
 });

--- a/tests/unit/services/connectors/agui/interruptHandlers.test.ts
+++ b/tests/unit/services/connectors/agui/interruptHandlers.test.ts
@@ -1,0 +1,385 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  defaultDetectInterrupt,
+  defaultBuildApprovalResponse,
+  resolveMultiTurnOptions,
+  DEFAULT_MULTI_TURN_OPTIONS,
+} from '@/services/connectors/agui/interruptHandlers';
+import type { InterruptInfo, InterruptPolicy, MultiTurnOptions } from '@/services/connectors/agui/interruptHandlers';
+
+describe('interruptHandlers', () => {
+  describe('defaultDetectInterrupt', () => {
+    describe('returns null for non-interrupt inputs', () => {
+      it('should return null for null input', () => {
+        expect(defaultDetectInterrupt(null)).toBeNull();
+      });
+
+      it('should return null for undefined input', () => {
+        expect(defaultDetectInterrupt(undefined)).toBeNull();
+      });
+
+      it('should return null for a string input', () => {
+        expect(defaultDetectInterrupt('some string')).toBeNull();
+      });
+
+      it('should return null for a number input', () => {
+        expect(defaultDetectInterrupt(42)).toBeNull();
+      });
+
+      it('should return null for a boolean input', () => {
+        expect(defaultDetectInterrupt(true)).toBeNull();
+      });
+
+      it('should return null for an empty object', () => {
+        expect(defaultDetectInterrupt({})).toBeNull();
+      });
+
+      it('should return null for a normal result without interrupt markers', () => {
+        expect(defaultDetectInterrupt({ outcome: 'success', data: 'some data' })).toBeNull();
+      });
+
+      it('should return null for a result with unrelated type field', () => {
+        expect(defaultDetectInterrupt({ type: 'response', content: 'hello' })).toBeNull();
+      });
+
+      it('should return null when requiresApproval is false', () => {
+        expect(defaultDetectInterrupt({ requiresApproval: false, reason: 'nope' })).toBeNull();
+      });
+
+      it('should return null when requiresApproval is a truthy non-boolean value', () => {
+        expect(defaultDetectInterrupt({ requiresApproval: 'yes' })).toBeNull();
+      });
+    });
+
+    describe('Pulsar-style interrupt (outcome: "interrupt")', () => {
+      it('should detect interrupt with reason and toolCalls', () => {
+        const result = {
+          outcome: 'interrupt',
+          reason: 'Tool needs approval',
+          toolCalls: [{ id: 'tc-1', name: 'search_logs', args: { query: 'error' } }],
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Tool needs approval');
+        expect(info!.toolCalls).toEqual([{ id: 'tc-1', name: 'search_logs', args: { query: 'error' } }]);
+        expect(info!.rawResult).toBe(result);
+      });
+
+      it('should use default reason when reason is not provided', () => {
+        const result = { outcome: 'interrupt' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Tool approval required');
+      });
+
+      it('should set toolCalls to undefined when toolCalls is not an array', () => {
+        const result = { outcome: 'interrupt', reason: 'test', toolCalls: 'not-an-array' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.toolCalls).toBeUndefined();
+      });
+
+      it('should handle empty toolCalls array', () => {
+        const result = { outcome: 'interrupt', reason: 'test', toolCalls: [] };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.toolCalls).toEqual([]);
+      });
+    });
+
+    describe('generic interrupt (type: "tool_approval")', () => {
+      it('should detect tool_approval interrupt with message', () => {
+        const result = {
+          type: 'tool_approval',
+          message: 'Please approve tool execution',
+          toolCalls: [{ id: 'tc-2', name: 'run_query' }],
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Please approve tool execution');
+        expect(info!.toolCalls).toEqual([{ id: 'tc-2', name: 'run_query' }]);
+        expect(info!.rawResult).toBe(result);
+      });
+
+      it('should fall back to reason when message is not provided', () => {
+        const result = { type: 'tool_approval', reason: 'Needs human review' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Needs human review');
+      });
+
+      it('should fall back to type name when neither message nor reason is provided', () => {
+        const result = { type: 'tool_approval' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('tool_approval');
+      });
+    });
+
+    describe('generic interrupt (type: "human_input_required")', () => {
+      it('should detect human_input_required interrupt', () => {
+        const result = {
+          type: 'human_input_required',
+          message: 'User confirmation needed',
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('User confirmation needed');
+        expect(info!.rawResult).toBe(result);
+      });
+
+      it('should fall back to type name when no message or reason', () => {
+        const result = { type: 'human_input_required' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('human_input_required');
+      });
+
+      it('should set toolCalls to undefined when not present', () => {
+        const result = { type: 'human_input_required', message: 'confirm' };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.toolCalls).toBeUndefined();
+      });
+    });
+
+    describe('explicit interrupt (requiresApproval: true)', () => {
+      it('should detect when requiresApproval is true', () => {
+        const result = {
+          requiresApproval: true,
+          reason: 'Dangerous operation',
+          toolCalls: [{ id: 'tc-3', name: 'delete_index', args: { index: 'test' } }],
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Dangerous operation');
+        expect(info!.toolCalls).toEqual([{ id: 'tc-3', name: 'delete_index', args: { index: 'test' } }]);
+        expect(info!.rawResult).toBe(result);
+      });
+
+      it('should use default reason when reason is not provided', () => {
+        const result = { requiresApproval: true };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.reason).toBe('Approval required');
+      });
+
+      it('should set toolCalls to undefined when toolCalls is not an array', () => {
+        const result = { requiresApproval: true, toolCalls: { id: 'tc-1' } };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        expect(info!.toolCalls).toBeUndefined();
+      });
+    });
+
+    describe('priority order', () => {
+      it('should match outcome=interrupt before type checks', () => {
+        const result = {
+          outcome: 'interrupt',
+          type: 'tool_approval',
+          reason: 'from outcome',
+          message: 'from type',
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        // outcome branch uses result.reason, not result.message
+        expect(info!.reason).toBe('from outcome');
+      });
+
+      it('should match type before requiresApproval', () => {
+        const result = {
+          type: 'tool_approval',
+          requiresApproval: true,
+          message: 'from type',
+          reason: 'from requiresApproval',
+        };
+
+        const info = defaultDetectInterrupt(result);
+
+        expect(info).not.toBeNull();
+        // type branch uses message first
+        expect(info!.reason).toBe('from type');
+      });
+    });
+  });
+
+  describe('defaultBuildApprovalResponse', () => {
+    const sampleInterrupt: InterruptInfo = {
+      reason: 'Tool approval required',
+      toolCalls: [{ id: 'tc-1', name: 'search_logs' }],
+      rawResult: { outcome: 'interrupt' },
+    };
+
+    it('should return null when policy is "skip"', () => {
+      const response = defaultBuildApprovalResponse(sampleInterrupt, 'skip');
+      expect(response).toBeNull();
+    });
+
+    describe('auto-approve policy', () => {
+      it('should return approval message with role "user"', () => {
+        const response = defaultBuildApprovalResponse(sampleInterrupt, 'auto-approve');
+
+        expect(response).not.toBeNull();
+        expect(response!.role).toBe('user');
+        expect(response!.content).toBe('Approved. Please proceed with the tool calls.');
+      });
+
+      it('should generate a unique id starting with "interrupt-resp-"', () => {
+        const response = defaultBuildApprovalResponse(sampleInterrupt, 'auto-approve');
+
+        expect(response).not.toBeNull();
+        expect(response!.id).toMatch(/^interrupt-resp-\d+-[a-z0-9]+$/);
+      });
+
+      it('should generate different ids on successive calls', () => {
+        const response1 = defaultBuildApprovalResponse(sampleInterrupt, 'auto-approve');
+        const response2 = defaultBuildApprovalResponse(sampleInterrupt, 'auto-approve');
+
+        expect(response1).not.toBeNull();
+        expect(response2).not.toBeNull();
+        // IDs include Date.now() and random component, so they should differ
+        // (in rare cases Date.now() could be the same, but the random part should differ)
+        expect(response1!.id).not.toBe(response2!.id);
+      });
+    });
+
+    describe('auto-reject policy', () => {
+      it('should return rejection message with role "user"', () => {
+        const response = defaultBuildApprovalResponse(sampleInterrupt, 'auto-reject');
+
+        expect(response).not.toBeNull();
+        expect(response!.role).toBe('user');
+        expect(response!.content).toBe('Rejected. Do not execute the proposed tool calls.');
+      });
+
+      it('should generate a unique id starting with "interrupt-resp-"', () => {
+        const response = defaultBuildApprovalResponse(sampleInterrupt, 'auto-reject');
+
+        expect(response).not.toBeNull();
+        expect(response!.id).toMatch(/^interrupt-resp-\d+-[a-z0-9]+$/);
+      });
+    });
+  });
+
+  describe('resolveMultiTurnOptions', () => {
+    it('should return a copy of defaults when called with no arguments', () => {
+      const resolved = resolveMultiTurnOptions();
+
+      expect(resolved).toEqual(DEFAULT_MULTI_TURN_OPTIONS);
+      // Ensure it is a copy, not the same reference
+      expect(resolved).not.toBe(DEFAULT_MULTI_TURN_OPTIONS);
+    });
+
+    it('should return a copy of defaults when called with undefined', () => {
+      const resolved = resolveMultiTurnOptions(undefined);
+
+      expect(resolved).toEqual(DEFAULT_MULTI_TURN_OPTIONS);
+      expect(resolved).not.toBe(DEFAULT_MULTI_TURN_OPTIONS);
+    });
+
+    it('should merge partial options over defaults', () => {
+      const resolved = resolveMultiTurnOptions({ enabled: true, maxTurns: 5 });
+
+      expect(resolved.enabled).toBe(true);
+      expect(resolved.maxTurns).toBe(5);
+      expect(resolved.interruptPolicy).toBe('auto-approve'); // from defaults
+    });
+
+    it('should allow overriding interruptPolicy', () => {
+      const resolved = resolveMultiTurnOptions({ interruptPolicy: 'auto-reject' });
+
+      expect(resolved.interruptPolicy).toBe('auto-reject');
+      expect(resolved.enabled).toBe(false); // from defaults
+      expect(resolved.maxTurns).toBe(10); // from defaults
+    });
+
+    it('should allow providing custom detectInterrupt function', () => {
+      const customDetect = jest.fn().mockReturnValue(null);
+      const resolved = resolveMultiTurnOptions({ detectInterrupt: customDetect });
+
+      expect(resolved.detectInterrupt).toBe(customDetect);
+      expect(resolved.enabled).toBe(false); // from defaults
+    });
+
+    it('should allow providing custom buildResponse function', () => {
+      const customBuild = jest.fn().mockReturnValue(null);
+      const resolved = resolveMultiTurnOptions({ buildResponse: customBuild });
+
+      expect(resolved.buildResponse).toBe(customBuild);
+    });
+
+    it('should allow overriding all fields at once', () => {
+      const customDetect = jest.fn();
+      const customBuild = jest.fn();
+
+      const resolved = resolveMultiTurnOptions({
+        enabled: true,
+        maxTurns: 3,
+        interruptPolicy: 'skip',
+        detectInterrupt: customDetect,
+        buildResponse: customBuild,
+      });
+
+      expect(resolved).toEqual({
+        enabled: true,
+        maxTurns: 3,
+        interruptPolicy: 'skip',
+        detectInterrupt: customDetect,
+        buildResponse: customBuild,
+      });
+    });
+
+    it('should not include detectInterrupt or buildResponse by default', () => {
+      const resolved = resolveMultiTurnOptions();
+
+      expect(resolved.detectInterrupt).toBeUndefined();
+      expect(resolved.buildResponse).toBeUndefined();
+    });
+  });
+
+  describe('DEFAULT_MULTI_TURN_OPTIONS', () => {
+    it('should have enabled set to false', () => {
+      expect(DEFAULT_MULTI_TURN_OPTIONS.enabled).toBe(false);
+    });
+
+    it('should have maxTurns set to 10', () => {
+      expect(DEFAULT_MULTI_TURN_OPTIONS.maxTurns).toBe(10);
+    });
+
+    it('should have interruptPolicy set to auto-approve', () => {
+      expect(DEFAULT_MULTI_TURN_OPTIONS.interruptPolicy).toBe('auto-approve');
+    });
+  });
+});

--- a/tests/unit/services/evaluation/index.test.ts
+++ b/tests/unit/services/evaluation/index.test.ts
@@ -715,5 +715,46 @@ describe('Evaluation Service Index', () => {
         undefined
       );
     });
+
+    it('should thread multiTurnOptions from agent config into connector request', async () => {
+      const agentWithMultiTurn = {
+        ...mockAgent,
+        multiTurnOptions: {
+          enabled: true,
+          maxTurns: 5,
+          interruptPolicy: 'auto-approve' as const,
+        },
+      };
+
+      const mockConnector = {
+        type: 'mock',
+        execute: jest.fn().mockResolvedValue({
+          trajectory: [{ type: 'response', content: 'Done', timestamp: Date.now() }],
+          runId: 'multi-turn-run',
+          rawEvents: [],
+        }),
+      };
+
+      const mockRegistry = {
+        getForAgent: jest.fn().mockReturnValue(mockConnector),
+      };
+
+      await runEvaluationWithConnector(
+        agentWithMultiTurn,
+        'claude-3-sonnet',
+        mockTestCase,
+        jest.fn(),
+        { registry: mockRegistry }
+      );
+
+      // Verify multiTurnOptions was passed in the request
+      const executeCall = mockConnector.execute.mock.calls[0];
+      const requestArg = executeCall[1];
+      expect(requestArg.multiTurnOptions).toEqual({
+        enabled: true,
+        maxTurns: 5,
+        interruptPolicy: 'auto-approve',
+      });
+    });
   });
 });

--- a/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
+++ b/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
@@ -501,6 +501,58 @@ describe('Multi-Turn Evaluation', () => {
       expect(result.rawEvents[1].type).toBe('event-2');
     });
 
+    it('multi-turn collects turnRunIds from all turns', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Follow-up 1' })
+        .mockResolvedValueOnce({ done: true, message: 'Done' });
+
+      let callCount = 0;
+      const mockConnector = createMockConnector({
+        execute: jest.fn().mockImplementation(async () => {
+          callCount++;
+          return {
+            trajectory: [
+              { id: `step-${callCount}`, timestamp: Date.now(), type: 'response', content: `Response ${callCount}` },
+            ],
+            runId: `run-turn-${callCount}`,
+            rawEvents: [],
+            metadata: { threadId: 'thread-1' },
+          };
+        }),
+      });
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 80,
+          rootCauseScore: 80,
+          remediationScore: 80,
+          contextRetentionScore: 80,
+          concisenessScore: 80,
+          reasoning: 'Good',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // turnRunIds should contain runIds from both turns
+      expect(result.turnRunIds).toBeDefined();
+      expect(result.turnRunIds).toEqual(['run-turn-1', 'run-turn-2']);
+    });
+
     it('multi-turn passes conversation history to buildMultiTurnPayload', async () => {
       const { generateFollowUp } = require('@/services/evaluation/userSimulator');
       const { buildMultiTurnPayload } = require('@/services/agent/payloadBuilder');

--- a/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
+++ b/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
@@ -1,0 +1,600 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @ts-nocheck - Test file uses simplified mock objects
+import type { AgentConfig, TestCase, TrajectoryStep } from '@/types';
+
+// Mock dependencies
+jest.mock('@/services/agent', () => ({
+  AGUIToTrajectoryConverter: jest.fn().mockImplementation(() => ({
+    processEvent: jest.fn().mockReturnValue([]),
+    getRunId: jest.fn().mockReturnValue('mock-run-id'),
+  })),
+  consumeSSEStream: jest.fn().mockResolvedValue(undefined),
+  buildAgentPayload: jest.fn().mockReturnValue({ prompt: 'test' }),
+}));
+
+jest.mock('@/services/agent/payloadBuilder', () => ({
+  buildMultiTurnPayload: jest.fn().mockReturnValue({
+    threadId: 'thread-mt',
+    runId: 'run-mt',
+    messages: [],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  }),
+  buildAgentPayload: jest.fn().mockReturnValue({ prompt: 'test' }),
+}));
+
+jest.mock('@/services/evaluation/userSimulator', () => ({
+  generateFollowUp: jest.fn(),
+}));
+
+jest.mock('@/services/evaluation/bedrockJudge', () => ({
+  callBedrockJudge: jest.fn().mockResolvedValue({
+    passFailStatus: 'passed',
+    metrics: {
+      accuracy: 85,
+      faithfulness: 80,
+      latency_score: 90,
+      trajectory_alignment_score: 75,
+    },
+    llmJudgeReasoning: 'Good single-turn performance',
+    improvementStrategies: [],
+  }),
+}));
+
+jest.mock('@/services/evaluation/mockTrajectory', () => ({
+  generateMockTrajectory: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/services/opensearch', () => ({
+  openSearchClient: {
+    fetchLogsForRun: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+jest.mock('@/lib/hooks', () => ({
+  executeBeforeRequestHook: jest.fn().mockImplementation(async (_hooks, context) => context),
+}));
+
+jest.mock('@/lib/debug', () => ({
+  debug: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('test-report-id'),
+}));
+
+// Mock global fetch for the multi-turn judge API call
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('Multi-Turn Evaluation', () => {
+  // Import the function under test
+  let runEvaluationWithConnector: any;
+
+  const mockAgent: AgentConfig = {
+    key: 'test-agent',
+    name: 'Test Agent',
+    endpoint: 'http://test/agent',
+    models: ['test-model'],
+    protocol: 'agui' as const,
+    type: 'langgraph',
+    useTraces: false,
+  };
+
+  const mockSingleTurnTestCase: TestCase = {
+    id: 'tc-single',
+    name: 'Single-turn test',
+    description: 'A standard single-turn test case',
+    labels: [],
+    category: 'RCA',
+    difficulty: 'Medium',
+    currentVersion: 1,
+    versions: [],
+    isPromoted: true,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    initialPrompt: 'What is wrong with the cluster?',
+    context: [],
+    expectedOutcomes: ['Find root cause'],
+  };
+
+  const mockMultiTurnTestCase: TestCase = {
+    id: 'tc-mt-1',
+    name: 'Multi-turn test',
+    description: 'A multi-turn investigation scenario',
+    labels: [],
+    category: 'RCA',
+    difficulty: 'Medium',
+    currentVersion: 1,
+    versions: [],
+    isPromoted: true,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    initialPrompt: 'What is wrong?',
+    context: [],
+    expectedOutcomes: ['Find root cause'],
+    multiTurnScenario: {
+      userMotivation: 'Investigating incident',
+      acceptanceCriteria: ['Root cause found'],
+      idealAnswer: 'Redis failure caused cascading timeouts',
+      turnLimit: 5,
+      referenceTurns: [
+        { turn: 1, user: 'What is wrong?', expectedTopics: ['error'], groundTruth: 'Redis down' },
+        { turn: 2, user: 'Is it Redis?', expectedTopics: ['Redis'], groundTruth: 'Yes' },
+      ],
+    },
+  };
+
+  const createMockConnector = (overrides = {}) => ({
+    type: 'agui-streaming',
+    name: 'Mock Connector',
+    supportsStreaming: true,
+    buildPayload: jest.fn().mockReturnValue({
+      threadId: 'thread-1',
+      runId: 'run-1',
+      messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
+      tools: [],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    }),
+    execute: jest.fn().mockResolvedValue({
+      trajectory: [
+        { id: 's1', timestamp: Date.now(), type: 'response', content: 'Agent response' },
+      ],
+      runId: 'run-1',
+      rawEvents: [],
+      metadata: { threadId: 'thread-1' },
+    }),
+    parseResponse: jest.fn(),
+    ...overrides,
+  });
+
+  const createMockRegistry = (connector: any) => ({
+    getForAgent: jest.fn().mockReturnValue(connector),
+    register: jest.fn(),
+    get: jest.fn(),
+    getAll: jest.fn(),
+    has: jest.fn(),
+    getRegisteredTypes: jest.fn(),
+    clear: jest.fn(),
+  });
+
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Re-import the module fresh for each test
+    jest.resetModules();
+    const module = await import('@/services/evaluation');
+    runEvaluationWithConnector = module.runEvaluationWithConnector;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('single-turn dispatch', () => {
+    it('single-turn test case uses existing flow unchanged', async () => {
+      const { callBedrockJudge } = require('@/services/evaluation/bedrockJudge');
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockSingleTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // connector.execute called exactly once (no multi-turn loop)
+      expect(mockConnector.execute).toHaveBeenCalledTimes(1);
+
+      // Single-turn judge is callBedrockJudge, not fetch to /api/judge/multi-turn
+      expect(callBedrockJudge).toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      // Report should be completed with single-turn metrics
+      expect(result.status).toBe('completed');
+      expect(result.passFailStatus).toBe('passed');
+      expect(result.multiTurnResult).toBeUndefined();
+      expect(result.connectorProtocol).toBe('agui-streaming');
+    });
+  });
+
+  describe('multi-turn dispatch', () => {
+    it('multi-turn test case dispatches to multi-turn evaluation', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+      const { buildMultiTurnPayload } = require('@/services/agent/payloadBuilder');
+      const { callBedrockJudge } = require('@/services/evaluation/bedrockJudge');
+
+      // Simulator generates one follow-up, then signals done
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Is it Redis?' })
+        .mockResolvedValueOnce({ done: true, message: 'Thanks, that answers my question.' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      // Mock the multi-turn judge API response
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 88,
+          rootCauseScore: 90,
+          remediationScore: 85,
+          contextRetentionScore: 80,
+          concisenessScore: 95,
+          reasoning: 'Agent correctly identified Redis as the root cause.',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // connector.execute called for initial turn + 1 follow-up = 2 times
+      expect(mockConnector.execute).toHaveBeenCalledTimes(2);
+
+      // generateFollowUp called to get follow-up questions
+      expect(generateFollowUp).toHaveBeenCalled();
+
+      // buildMultiTurnPayload called for the follow-up turn
+      expect(buildMultiTurnPayload).toHaveBeenCalled();
+
+      // fetch called with /api/judge/multi-turn for holistic judge
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/judge/multi-turn'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      // callBedrockJudge should NOT be called for multi-turn
+      expect(callBedrockJudge).not.toHaveBeenCalled();
+
+      // Report should contain multiTurnResult
+      expect(result.status).toBe('completed');
+      expect(result.passFailStatus).toBe('passed');
+      expect(result.multiTurnResult).toBeDefined();
+      expect(result.multiTurnResult.totalTurns).toBe(2);
+      expect(result.multiTurnResult.turns).toHaveLength(2);
+      expect(result.multiTurnResult.acceptanceCriteriaMet).toBe(true);
+      expect(result.multiTurnResult.rootCauseScore).toBe(90);
+      expect(result.multiTurnResult.remediationScore).toBe(85);
+      expect(result.multiTurnResult.contextRetentionScore).toBe(80);
+      expect(result.multiTurnResult.concisenessScore).toBe(95);
+      expect(result.multiTurnResult.reasoning).toContain('Redis');
+      expect(result.metrics.accuracy).toBe(88);
+      expect(result.connectorProtocol).toBe('agui-streaming');
+    });
+
+    it('multi-turn stops when simulator signals done', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      // Simulator does 1 follow-up, then signals done on the second call
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Can you check Redis?' })
+        .mockResolvedValueOnce({ done: true, message: 'That is sufficient, thanks.' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 75,
+          rootCauseScore: 80,
+          remediationScore: 70,
+          contextRetentionScore: 75,
+          concisenessScore: 90,
+          reasoning: 'Good investigation with early resolution.',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // Initial turn + 1 follow-up = 2 connector.execute calls
+      // The second generateFollowUp returns done=true so the loop breaks
+      expect(mockConnector.execute).toHaveBeenCalledTimes(2);
+      expect(generateFollowUp).toHaveBeenCalledTimes(2);
+
+      // Result should have 2 turns (initial + 1 follow-up)
+      expect(result.multiTurnResult).toBeDefined();
+      expect(result.multiTurnResult.totalTurns).toBe(2);
+      expect(result.multiTurnResult.turns).toHaveLength(2);
+
+      // First turn is the initial prompt
+      expect(result.multiTurnResult.turns[0].turn).toBe(1);
+      expect(result.multiTurnResult.turns[0].userMessage).toBe('What is wrong?');
+
+      // Second turn is the follow-up
+      expect(result.multiTurnResult.turns[1].turn).toBe(2);
+      expect(result.multiTurnResult.turns[1].userMessage).toBe('Can you check Redis?');
+    });
+
+    it('multi-turn stops at turnLimit', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      // Use a test case with turnLimit of 2
+      const limitedTestCase: TestCase = {
+        ...mockMultiTurnTestCase,
+        multiTurnScenario: {
+          ...mockMultiTurnTestCase.multiTurnScenario!,
+          turnLimit: 2,
+        },
+      };
+
+      // Simulator never says done - always returns a follow-up
+      generateFollowUp.mockResolvedValue({ done: false, message: 'Tell me more.' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'failed',
+          weightedScore: 40,
+          rootCauseScore: 30,
+          remediationScore: 50,
+          contextRetentionScore: 60,
+          concisenessScore: 40,
+          reasoning: 'Turn limit reached before acceptance criteria met.',
+          improvementStrategies: [
+            { category: 'depth', issue: 'Shallow analysis', recommendation: 'Dig deeper', priority: 'high' },
+          ],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        limitedTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // turnLimit=2: initial turn (turn 1) + loop runs for turnIdx=1 (turn 2) = 2 execute calls
+      // Loop runs from turnIdx=1 to turnIdx < turnLimit (2), so one iteration
+      expect(mockConnector.execute).toHaveBeenCalledTimes(2);
+
+      // generateFollowUp called once (for turnIdx=1)
+      expect(generateFollowUp).toHaveBeenCalledTimes(1);
+
+      // Result should have exactly 2 turns
+      expect(result.multiTurnResult).toBeDefined();
+      expect(result.multiTurnResult.totalTurns).toBe(2);
+      expect(result.multiTurnResult.turns).toHaveLength(2);
+
+      // Judge was still called even though limit was reached
+      expect(mockFetch).toHaveBeenCalled();
+      expect(result.passFailStatus).toBe('failed');
+    });
+
+    it('multi-turn handles judge API failure gracefully', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      // One follow-up turn then done
+      generateFollowUp.mockResolvedValueOnce({ done: true, message: 'Done.' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      // Judge API returns an error
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValue({ error: 'Internal server error' }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // Should return failed status with partial results
+      expect(result.status).toBe('failed');
+      expect(result.llmJudgeReasoning).toContain('Multi-turn evaluation failed');
+
+      // Partial multiTurnResult should still have the completed turns
+      expect(result.multiTurnResult).toBeDefined();
+      expect(result.multiTurnResult.turns).toHaveLength(1);
+      expect(result.multiTurnResult.acceptanceCriteriaMet).toBe(false);
+    });
+
+    it('multi-turn accumulates trajectory and rawEvents from all turns', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Follow-up 1' })
+        .mockResolvedValueOnce({ done: true, message: 'Done' });
+
+      let callCount = 0;
+      const mockConnector = createMockConnector({
+        execute: jest.fn().mockImplementation(async () => {
+          callCount++;
+          return {
+            trajectory: [
+              { id: `step-${callCount}`, timestamp: Date.now(), type: 'response', content: `Response ${callCount}` },
+            ],
+            runId: `run-${callCount}`,
+            rawEvents: [{ type: `event-${callCount}` }],
+            metadata: { threadId: 'thread-1' },
+          };
+        }),
+      });
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 80,
+          rootCauseScore: 80,
+          remediationScore: 80,
+          contextRetentionScore: 80,
+          concisenessScore: 80,
+          reasoning: 'Good',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // Trajectory should contain steps from both turns
+      expect(result.trajectory).toHaveLength(2);
+      expect(result.trajectory[0].content).toBe('Response 1');
+      expect(result.trajectory[1].content).toBe('Response 2');
+
+      // rawEvents should contain events from both turns
+      expect(result.rawEvents).toHaveLength(2);
+      expect(result.rawEvents[0].type).toBe('event-1');
+      expect(result.rawEvents[1].type).toBe('event-2');
+    });
+
+    it('multi-turn passes conversation history to buildMultiTurnPayload', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+      const { buildMultiTurnPayload } = require('@/services/agent/payloadBuilder');
+
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Is it Redis?' })
+        .mockResolvedValueOnce({ done: true, message: 'Got it' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 90,
+          rootCauseScore: 90,
+          remediationScore: 90,
+          contextRetentionScore: 90,
+          concisenessScore: 90,
+          reasoning: 'Excellent',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // buildMultiTurnPayload should have been called for the follow-up turn
+      expect(buildMultiTurnPayload).toHaveBeenCalledTimes(1);
+
+      // Note: conversationHistory is passed by reference and mutated after the call,
+      // so we verify the call was made with the expected arguments using argument matchers.
+      expect(buildMultiTurnPayload).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ role: 'user', content: 'What is wrong?' }),
+          expect.objectContaining({ role: 'assistant' }),
+          expect.objectContaining({ role: 'user', content: 'Is it Redis?' }),
+        ]),
+        'thread-1', // threadId from turn 1 metadata
+        undefined,   // new runId per turn
+        [],          // context from test case
+        undefined    // tools from test case
+      );
+    });
+
+    it('multi-turn sends judge request with correct payload shape', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      // End immediately after the initial turn
+      generateFollowUp.mockResolvedValueOnce({ done: true, message: 'Done.' });
+
+      const mockConnector = createMockConnector();
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 80,
+          rootCauseScore: 80,
+          remediationScore: 80,
+          contextRetentionScore: 80,
+          concisenessScore: 80,
+          reasoning: 'Good',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // Verify the fetch call body has the correct structure
+      const fetchCall = mockFetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+
+      expect(body.multiTurnConversation).toBeDefined();
+      expect(body.multiTurnConversation.turns).toHaveLength(1);
+      expect(body.multiTurnConversation.idealAnswer).toBe('Redis failure caused cascading timeouts');
+      expect(body.modelId).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
+++ b/tests/unit/services/evaluation/multiTurnEvaluation.test.ts
@@ -554,6 +554,73 @@ describe('Multi-Turn Evaluation', () => {
       );
     });
 
+    it('multi-turn retries on 409 "Run already in progress" and succeeds', async () => {
+      const { generateFollowUp } = require('@/services/evaluation/userSimulator');
+
+      // Simulator generates one follow-up, then signals done
+      generateFollowUp
+        .mockResolvedValueOnce({ done: false, message: 'Is it Redis?' })
+        .mockResolvedValueOnce({ done: true, message: 'Thanks.' });
+
+      // Turn 1 succeeds, Turn 2 first attempt gets 409, second attempt succeeds
+      let executeCallCount = 0;
+      const mockConnector = createMockConnector({
+        execute: jest.fn().mockImplementation(async () => {
+          executeCallCount++;
+          if (executeCallCount === 2) {
+            // First attempt at Turn 2: simulate 409 race condition
+            const error: any = new Error('HTTP 409: Conflict - Run already in progress');
+            error.status = 409;
+            throw error;
+          }
+          return {
+            trajectory: [
+              { id: `step-${executeCallCount}`, timestamp: Date.now(), type: 'response', content: `Response ${executeCallCount}` },
+            ],
+            runId: `run-${executeCallCount}`,
+            rawEvents: [],
+            metadata: { threadId: 'thread-1' },
+          };
+        }),
+      });
+      const mockRegistry = createMockRegistry(mockConnector);
+
+      // Mock the multi-turn judge API response
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          passFailStatus: 'passed',
+          weightedScore: 85,
+          rootCauseScore: 90,
+          remediationScore: 80,
+          contextRetentionScore: 85,
+          concisenessScore: 90,
+          reasoning: 'Agent recovered after retry and completed investigation.',
+          improvementStrategies: [],
+        }),
+      });
+
+      const onStepMock = jest.fn();
+
+      const result = await runEvaluationWithConnector(
+        mockAgent,
+        'test-model',
+        mockMultiTurnTestCase,
+        onStepMock,
+        { registry: mockRegistry }
+      );
+
+      // connector.execute called 3 times: Turn 1 (success), Turn 2 attempt 1 (409), Turn 2 attempt 2 (success)
+      expect(mockConnector.execute).toHaveBeenCalledTimes(3);
+
+      // Evaluation should complete successfully despite the 409
+      expect(result.status).toBe('completed');
+      expect(result.passFailStatus).toBe('passed');
+      expect(result.multiTurnResult).toBeDefined();
+      expect(result.multiTurnResult.totalTurns).toBe(2);
+      expect(result.multiTurnResult.turns).toHaveLength(2);
+    });
+
     it('multi-turn sends judge request with correct payload shape', async () => {
       const { generateFollowUp } = require('@/services/evaluation/userSimulator');
 

--- a/tests/unit/services/evaluation/userSimulator.test.ts
+++ b/tests/unit/services/evaluation/userSimulator.test.ts
@@ -1,0 +1,395 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MultiTurnScenario } from '@/types';
+import type { AgentMessage } from '@/services/agent/payloadBuilder';
+
+// Mock @/lib/config with simulatorApiUrl
+jest.mock('@/lib/config', () => ({
+  ENV_CONFIG: {
+    simulatorApiUrl: 'http://localhost:4001/api/simulate-followup',
+  },
+}));
+
+// Mock @/lib/debug
+jest.mock('@/lib/debug', () => ({
+  debug: jest.fn(),
+}));
+
+import {
+  buildSimulatorPrompt,
+  parseSimulatorResponse,
+  generateFollowUp,
+  SimulatorResponse,
+} from '@/services/evaluation/userSimulator';
+
+// ---- helpers ----
+
+function makeScenario(overrides?: Partial<MultiTurnScenario>): MultiTurnScenario {
+  return {
+    userMotivation: 'Investigate the root cause of the 5xx spike on the checkout service.',
+    acceptanceCriteria: [
+      'Identify the root cause',
+      'Provide a remediation step',
+    ],
+    idealAnswer: 'The root cause is a memory leak in the checkout service.',
+    referenceTurns: [
+      {
+        turn: 1,
+        user: 'Can you check the error logs for the checkout service?',
+        expectedTopics: ['error logs', 'checkout service'],
+        groundTruth: 'Logs show OOM errors.',
+      },
+      {
+        turn: 2,
+        user: 'What is the memory trend over the past hour?',
+        expectedTopics: ['memory', 'trend'],
+        groundTruth: 'Memory is increasing linearly.',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeHistory(pairs: Array<[string, string]>): AgentMessage[] {
+  const messages: AgentMessage[] = [];
+  pairs.forEach(([userMsg, assistantMsg], i) => {
+    messages.push({ id: `u${i}`, role: 'user', content: userMsg });
+    messages.push({ id: `a${i}`, role: 'assistant', content: assistantMsg });
+  });
+  return messages;
+}
+
+// ---- global fetch mock ----
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+// ================================================================
+// buildSimulatorPrompt
+// ================================================================
+
+describe('buildSimulatorPrompt', () => {
+  it('should include userMotivation in the prompt', () => {
+    const scenario = makeScenario();
+    const prompt = buildSimulatorPrompt(scenario, [], 0);
+
+    expect(prompt).toContain(scenario.userMotivation);
+  });
+
+  it('should include all acceptance criteria numbered', () => {
+    const scenario = makeScenario();
+    const prompt = buildSimulatorPrompt(scenario, [], 0);
+
+    expect(prompt).toContain('1. Identify the root cause');
+    expect(prompt).toContain('2. Provide a remediation step');
+  });
+
+  it('should include conversation history with role labels', () => {
+    const scenario = makeScenario();
+    const history = makeHistory([
+      ['What happened?', 'There was a 5xx spike.'],
+    ]);
+
+    const prompt = buildSimulatorPrompt(scenario, history, 1);
+
+    expect(prompt).toContain('User: What happened?');
+    expect(prompt).toContain('Agent: There was a 5xx spike.');
+  });
+
+  it('should include the reference turn when available', () => {
+    const scenario = makeScenario();
+    const prompt = buildSimulatorPrompt(scenario, [], 0);
+
+    expect(prompt).toContain('Suggested Next Question');
+    expect(prompt).toContain('Can you check the error logs for the checkout service?');
+    expect(prompt).toContain('error logs, checkout service');
+  });
+
+  it('should include reference turn for turn index 1', () => {
+    const scenario = makeScenario();
+    const prompt = buildSimulatorPrompt(scenario, [], 1);
+
+    expect(prompt).toContain('What is the memory trend over the past hour?');
+    expect(prompt).toContain('memory, trend');
+  });
+
+  it('should handle missing reference turns gracefully', () => {
+    const scenario = makeScenario();
+    // Turn index 5 is beyond the reference turns array
+    const prompt = buildSimulatorPrompt(scenario, [], 5);
+
+    expect(prompt).toContain('No reference question available for this turn');
+    expect(prompt).toContain("investigation's natural progression");
+  });
+
+  it('should handle scenario with no referenceTurns at all', () => {
+    const scenario = makeScenario({ referenceTurns: undefined });
+    const prompt = buildSimulatorPrompt(scenario, [], 0);
+
+    expect(prompt).toContain('No reference question available for this turn');
+  });
+
+  it('should include JSON response instruction', () => {
+    const scenario = makeScenario();
+    const prompt = buildSimulatorPrompt(scenario, [], 0);
+
+    expect(prompt).toContain('Respond as JSON');
+    expect(prompt).toContain('"done"');
+    expect(prompt).toContain('"message"');
+  });
+});
+
+// ================================================================
+// parseSimulatorResponse
+// ================================================================
+
+describe('parseSimulatorResponse', () => {
+  it('should parse clean JSON with done=false', () => {
+    const input = '{"done": false, "message": "What are the recent logs?"}';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'What are the recent logs?',
+    });
+  });
+
+  it('should parse clean JSON with done=true', () => {
+    const input = '{"done": true, "message": "All criteria met. Investigation complete."}';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: true,
+      message: 'All criteria met. Investigation complete.',
+    });
+  });
+
+  it('should coerce done to boolean', () => {
+    const input = '{"done": 0, "message": "hello"}';
+    const result = parseSimulatorResponse(input);
+    expect(result.done).toBe(false);
+
+    const input2 = '{"done": 1, "message": "world"}';
+    const result2 = parseSimulatorResponse(input2);
+    expect(result2.done).toBe(true);
+  });
+
+  it('should handle missing message as empty string', () => {
+    const input = '{"done": false}';
+    const result = parseSimulatorResponse(input);
+    expect(result.message).toBe('');
+  });
+
+  it('should parse JSON inside a markdown code block', () => {
+    const input = '```json\n{"done": false, "message": "Check the traces."}\n```';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'Check the traces.',
+    });
+  });
+
+  it('should parse JSON inside a code block without json tag', () => {
+    const input = '```\n{"done": true, "message": "Done."}\n```';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: true,
+      message: 'Done.',
+    });
+  });
+
+  it('should parse JSON embedded in surrounding text', () => {
+    const input = 'Here is my response: {"done": false, "message": "What about memory?"} Hope that helps.';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'What about memory?',
+    });
+  });
+
+  it('should return entire text as message when JSON is invalid', () => {
+    const input = 'I think you should check the CPU metrics next.';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'I think you should check the CPU metrics next.',
+    });
+  });
+
+  it('should trim whitespace from input', () => {
+    const input = '   {"done": false, "message": "trimmed"}   ';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'trimmed',
+    });
+  });
+
+  it('should handle non-JSON text with braces that do not form valid JSON', () => {
+    const input = 'function foo() { return bar; }';
+    const result = parseSimulatorResponse(input);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'function foo() { return bar; }',
+    });
+  });
+});
+
+// ================================================================
+// generateFollowUp
+// ================================================================
+
+describe('generateFollowUp', () => {
+  const scenario = makeScenario();
+  const history = makeHistory([
+    ['What happened?', 'There was a 5xx spike on checkout.'],
+  ]);
+
+  it('should call the simulator API and return the result on success', async () => {
+    const mockResponse: SimulatorResponse = {
+      done: false,
+      message: 'Can you check the error logs?',
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockResponse),
+    });
+
+    const result = await generateFollowUp(scenario, history, 1);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4001/api/simulate-followup',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    // Verify the body contains the right fields
+    const callArgs = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.scenario).toEqual(scenario);
+    expect(body.conversationHistory).toEqual(history);
+    expect(body.currentTurnIndex).toBe(1);
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should pass modelId in the request body when provided', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ done: false, message: 'test' }),
+    });
+
+    await generateFollowUp(scenario, history, 0, 'claude-sonnet-4');
+
+    const callArgs = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.modelId).toBe('claude-sonnet-4');
+  });
+
+  it('should fall back to reference turn verbatim when API returns non-ok response', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: jest.fn().mockResolvedValue({ error: 'Internal server error' }),
+    });
+
+    const result = await generateFollowUp(scenario, history, 0);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'Can you check the error logs for the checkout service?',
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should fall back to reference turn verbatim when fetch throws', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const result = await generateFollowUp(scenario, history, 1);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'What is the memory trend over the past hour?',
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should return done:true when API fails and no reference turn is available', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    // Turn index 5 has no reference turn
+    const result = await generateFollowUp(scenario, history, 5);
+
+    expect(result).toEqual({
+      done: true,
+      message: 'Unable to generate follow-up question.',
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should return done:true when API fails and scenario has no referenceTurns', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const noRefScenario = makeScenario({ referenceTurns: undefined });
+
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Timeout'));
+
+    const result = await generateFollowUp(noRefScenario, history, 0);
+
+    expect(result).toEqual({
+      done: true,
+      message: 'Unable to generate follow-up question.',
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle non-ok response where json() parsing fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: jest.fn().mockRejectedValue(new Error('invalid json')),
+    });
+
+    // Turn 0 has a reference turn, so it falls back
+    const result = await generateFollowUp(scenario, history, 0);
+
+    expect(result).toEqual({
+      done: false,
+      message: 'Can you check the error logs for the checkout service?',
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/services/storage/asyncRunStorage.test.ts
+++ b/tests/unit/services/storage/asyncRunStorage.test.ts
@@ -256,6 +256,32 @@ describe('AsyncRunStorage', () => {
       }));
     });
 
+    it('updates multiTurnResult and turnRunIds', async () => {
+      const mockUpdated = createMockStorageRun('run-1');
+      mockOsRuns.partialUpdate.mockResolvedValue(mockUpdated);
+
+      const multiTurnResult = {
+        turns: [],
+        totalTurns: 3,
+        acceptanceCriteriaMet: true,
+        rootCauseScore: 90,
+        remediationScore: 85,
+        contextRetentionScore: 80,
+        concisenessScore: 95,
+        reasoning: 'Good',
+      };
+
+      await asyncRunStorage.updateReport('run-1', {
+        multiTurnResult,
+        turnRunIds: ['id-1', 'id-2'],
+      });
+
+      expect(mockOsRuns.partialUpdate).toHaveBeenCalledWith('run-1', expect.objectContaining({
+        multiTurnResult,
+        turnRunIds: ['id-1', 'id-2'],
+      }));
+    });
+
     it('maps metrics correctly', async () => {
       const mockUpdated = createMockStorageRun('run-1');
       mockOsRuns.partialUpdate.mockResolvedValue(mockUpdated);
@@ -336,6 +362,30 @@ describe('AsyncRunStorage', () => {
         lastTraceFetchAt: '2024-01-01T12:00:00Z',
         spans: [{ spanId: 'span-1' }],
       });
+    });
+
+    it('handles multiTurnResult in conversion', async () => {
+      const mockMultiTurnResult = {
+        turns: [{ turn: 1, userMessage: 'Hello', agentResponse: 'Hi', trajectory: [] }],
+        totalTurns: 1,
+        acceptanceCriteriaMet: true,
+        rootCauseScore: 90,
+        remediationScore: 85,
+        contextRetentionScore: 80,
+        concisenessScore: 95,
+        reasoning: 'Good performance',
+      };
+      const mockStorageRun = {
+        ...createMockStorageRun('run-1'),
+        multiTurnResult: mockMultiTurnResult,
+        turnRunIds: ['run-id-1', 'run-id-2'],
+      };
+      mockOsRuns.getById.mockResolvedValue(mockStorageRun);
+
+      const result = await asyncRunStorage.getReportById('run-1');
+
+      expect(result?.multiTurnResult).toEqual(mockMultiTurnResult);
+      expect(result?.turnRunIds).toEqual(['run-id-1', 'run-id-2']);
     });
   });
 
@@ -721,6 +771,49 @@ describe('AsyncRunStorage', () => {
           logs: [{ message: 'test log' }],
         })
       );
+    });
+
+    it('persists multiTurnResult and turnRunIds', async () => {
+      const mockStorageRun = createMockStorageRun('run-1');
+      mockOsRuns.create.mockResolvedValue(mockStorageRun);
+
+      const multiTurnResult = {
+        turns: [{ turn: 1, userMessage: 'Hello', agentResponse: 'Hi', trajectory: [] }],
+        totalTurns: 1,
+        acceptanceCriteriaMet: true,
+        rootCauseScore: 90,
+        remediationScore: 85,
+        contextRetentionScore: 80,
+        concisenessScore: 95,
+        reasoning: 'Good',
+      };
+
+      const report: EvaluationReport = {
+        ...createMockReport('report-mt'),
+        multiTurnResult,
+        turnRunIds: ['run-t1', 'run-t2', 'run-t3'],
+      };
+
+      await asyncRunStorage.saveReport(report);
+
+      expect(mockOsRuns.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          multiTurnResult,
+          turnRunIds: ['run-t1', 'run-t2', 'run-t3'],
+        })
+      );
+    });
+
+    it('does not include multiTurnResult when undefined', async () => {
+      const mockStorageRun = createMockStorageRun('run-1');
+      mockOsRuns.create.mockResolvedValue(mockStorageRun);
+
+      const report = createMockReport('report-single');
+      await asyncRunStorage.saveReport(report);
+
+      const createCallArg = mockOsRuns.create.mock.calls[0][0];
+      expect(createCallArg).not.toHaveProperty('multiTurnResult');
+      expect(createCallArg).not.toHaveProperty('turnRunIds');
     });
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -254,6 +254,7 @@ export interface TestCaseRun {
   openSearchLogs?: OpenSearchLog[]; // Storage: Persisted logs (alternative to logs)
   annotations?: RunAnnotation[]; // Storage: User notes on this run
   runId?: string; // Agent's run ID from AG UI events (for log correlation)
+  turnRunIds?: string[]; // All per-turn runIds for multi-turn evaluations (trace fetching)
   logs?: OpenSearchLog[]; // OpenSearch logs for the run (master version)
   rawEvents?: any[]; // Raw AG UI events for debugging
   connectorProtocol?: ConnectorProtocol; // Protocol used to execute this run (for trajectory parsing)

--- a/types/index.ts
+++ b/types/index.ts
@@ -78,6 +78,11 @@ export interface AgentConfig {
   connectorConfig?: Record<string, any>; // Connector-specific configuration
   hooks?: AgentHooks; // Lifecycle hooks for custom setup/transform logic
   isCustom?: boolean; // True for user-added custom endpoints (not from config file)
+  multiTurnOptions?: {
+    enabled?: boolean;
+    maxTurns?: number;
+    interruptPolicy?: 'auto-approve' | 'auto-reject' | 'skip';
+  };
 }
 
 /**
@@ -118,6 +123,60 @@ export interface TrajectoryStep {
   toolOutput?: any;
   status?: ToolCallStatus;
   latencyMs?: number;
+}
+
+// ============ Multi-Turn Evaluation Types ============
+
+/** Scenario definition for multi-turn evaluation with LLM-simulated user */
+export interface MultiTurnScenario {
+  /** What the simulated user is trying to achieve */
+  userMotivation: string;
+  /** Conditions that signal the conversation is complete */
+  acceptanceCriteria: string[];
+  /** The correct answer with critical components */
+  idealAnswer: string;
+  /** Critical components the answer must include */
+  criticalComponents?: {
+    rootCause: string;
+    remediation: string;
+  };
+  /** Max turns before stopping (default: 10) */
+  turnLimit?: number;
+  /** Optional scoring weight overrides (must sum to 100) */
+  scoringWeights?: {
+    rootCause?: number;      // default: 40
+    remediation?: number;    // default: 30
+    contextRetention?: number; // default: 20
+    conciseness?: number;    // default: 10
+  };
+  /** Reference turns used as directional guidance for the LLM user simulator */
+  referenceTurns?: Array<{
+    turn: number;
+    user: string;
+    expectedTopics: string[];
+    groundTruth: string;
+  }>;
+}
+
+/** Record of a single turn in a multi-turn conversation */
+export interface ConversationTurnRecord {
+  turn: number;
+  userMessage: string;
+  agentResponse: string;
+  trajectory: TrajectoryStep[];
+}
+
+/** Result of a multi-turn evaluation */
+export interface MultiTurnResult {
+  turns: ConversationTurnRecord[];
+  totalTurns: number;
+  acceptanceCriteriaMet: boolean;
+  /** Holistic scores (0-100) */
+  rootCauseScore: number;
+  remediationScore: number;
+  contextRetentionScore: number;
+  concisenessScore: number;
+  reasoning: string;
 }
 
 export interface EvaluationMetrics {
@@ -202,6 +261,9 @@ export interface TestCaseRun {
   // Server-side performance metrics (timing data from evaluation execution)
   performanceMetrics?: TestCasePerformanceMetrics;
 
+  // Multi-turn evaluation results
+  multiTurnResult?: MultiTurnResult;
+
   // Trace mode fields (for agents with useTraces: true)
   metricsStatus?: MetricsStatus; // Status of deferred metrics/judge calculation
   traceFetchAttempts?: number; // Number of polling attempts for traces
@@ -257,6 +319,7 @@ export interface TestCaseVersion {
     question: string;
     businessValue: string;
   }[];
+  multiTurnScenario?: MultiTurnScenario;
 }
 
 // TestCase is referred to as "Use Case" in the UI
@@ -303,6 +366,7 @@ export interface TestCase {
     question: string;
     businessValue: string;
   }[];
+  multiTurnScenario?: MultiTurnScenario;
 }
 
 export interface OpenSearchLog {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,11 +40,11 @@ export default defineConfig(({ mode }) => {
       host: true,
       proxy: {
         '/api': {
-          target: `http://localhost:${env.BACKEND_PORT || '4001'}`,
+          target: `http://localhost:${env.PORT || '4001'}`,
           changeOrigin: true
         },
         '/health': {
-          target: `http://localhost:${env.BACKEND_PORT || '4001'}`,
+          target: `http://localhost:${env.PORT || '4001'}`,
           changeOrigin: true
         }
       }


### PR DESCRIPTION
### Description

This PR introduces multi-turn evaluation capabilities, a new CLI import command, and several quality-of-life fixes.

**Multi-turn evaluation engine**
- Agents can now be evaluated over multi-turn conversations with an LLM-simulated user. Test cases support a `multiTurnScenario` definition (user motivation, acceptance criteria, ideal answer, scoring weights, reference turns).
- The evaluation engine orchestrates turn-by-turn agent execution, tracks per-turn trajectories and `turnRunIds`, and produces a `MultiTurnResult` with holistic scores (root cause, remediation, context retention, conciseness).
- New `userSimulator` service generates follow-up messages via a server-side `/api/simulator/follow-up` endpoint, driving realistic multi-turn conversations based on the scenario definition.
- Dedicated multi-turn judge prompt evaluates full conversation quality against acceptance criteria and scoring weights.

**AG-UI interrupt handling**
- Added interrupt handler support in the AG-UI streaming connector with configurable policies (`auto-approve`, `auto-reject`, `skip`).
- Retry logic for transient 409 errors during multi-turn flows.
- New `multiTurnOptions` on `AgentConfig` to configure max turns and interrupt policy.

**CLI `import` command**
- New `npx agent-health import -f <file.json>` command imports test cases from JSON with name-based deduplication.
- Optionally creates a benchmark from imported cases.
- Includes sample multi-turn test cases in `cli/demo/otel-multi-turn-test-cases.json`.

**Settings credential fix**
- Fixed a bug where cluster credentials were silently dropped on save (`&&` spread replaced with `??` fallback to existing stored value).
- Username is now pre-filled in the settings form with a `hasPassword` boolean indicator (raw password never sent to browser).

**Other changes**
- Enhanced comparison page loading logic and added second run selection support.
- Updated `getAllTestCases` aggregation field to use `id` instead of `id.keyword`.
- Renamed `VITE_BACKEND_PORT` env var to `PORT`.
- Improved debug identifiers and client cleanup logic (allows process exit even if cleanup interval is active).
- Added multi-turn scenario editing UI in `TestCaseDetailPanel` and result display in `RunDetailsContent`.

#### New files
| File | Purpose |
|------|---------|
| `services/evaluation/userSimulator.ts` | LLM user simulator for multi-turn conversations |
| `services/connectors/agui/interruptHandlers.ts` | AG-UI interrupt policy handlers |
| `server/prompts/multiTurnJudgePrompt.ts` | Multi-turn judge evaluation prompt |
| `server/routes/simulator.ts` | Simulator API endpoint |
| `cli/commands/import.ts` | CLI import command |
| `cli/utils/testCaseFile.ts` | JSON file loading/validation for import |
| `cli/demo/otel-multi-turn-test-cases.json` | Sample multi-turn test cases |

#### Key modified files
| File | Change |
|------|--------|
| `types/index.ts` | Added `MultiTurnScenario`, `ConversationTurnRecord`, `MultiTurnResult`, `multiTurnOptions` |
| `services/evaluation/index.ts` | Multi-turn orchestration loop in `runEvaluationWithConnector` |
| `services/connectors/agui/AGUIStreamingConnector.ts` | Interrupt handling and retry logic |
| `components/SettingsPage.tsx` | Credential preservation, username pre-fill |
| `lib/testCaseValidation.ts` | Validation for multi-turn scenario fields and test case names |

#### Tests added
- `multiTurnEvaluation.test.ts` — Multi-turn scenarios and edge cases
- `userSimulator.test.ts` — Simulator follow-up generation
- `interruptHandlers.test.ts` — Interrupt policy handlers
- `multiTurnJudgePrompt.test.ts` — Judge prompt construction
- `testCaseImport.test.ts` — Import route with deduplication
- `import.test.ts`, `testCaseFile.test.ts` — CLI import command and file utils
- `testCaseValidation.test.ts` — Multi-turn scenario validation

### Issues Resolved

_N/A_

### Test Plan

- [ ] `npm run build:all` succeeds
- [ ] `npm run test:all` passes (unit + integration + e2e)
- [ ] Multi-turn evaluation runs end-to-end with a configured agent that supports interrupts
- [ ] `npx agent-health import -f ./cli/demo/otel-multi-turn-test-cases.json` imports without duplicates
- [ ] Settings page preserves credentials on save and pre-fills username
- [ ] Comparison page loads correctly with two run selections

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).