### PR TITLE
fix: use build:all in release workflow to include CLI build

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm run build --if-present
+      - run: npm run build:all
       - run: npm test
       - run: npm publish
       - name: Draft a release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [0.2.0]
 
+### Fixed
+- Release workflow using `build` instead of `build:all`, causing CLI tests to fail ([#123](https://github.com/opensearch-project/agent-health/pull/123))
+
 ### Changed
 - Increase release workflow approval timeout from 6 hours (default) to 24 hours
 - Allow workflow initiator to count as one of the required release approvers

--- a/package-lock.json
+++ b/package-lock.json
@@ -9180,9 +9180,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
+      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
       "funding": [
         {
           "type": "github",
@@ -9192,8 +9192,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.2.1",
+        "strnum": "^2.2.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13298,9 +13298,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
+      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
       "funding": [
         {
           "type": "github",
@@ -15176,9 +15176,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",
@@ -16273,9 +16273,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.4",
-    "fast-xml-parser": "5.5.6"
+    "fast-xml-parser": "5.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- The release workflow (`release-drafter.yml`) used `npm run build` which only builds UI+types (`tsc && vite build`), but does not build the CLI
- The CLI help output tests in `tests/unit/cli/index.test.ts` execute `node cli/dist/index.js --help`, which requires the CLI artifact produced by `npm run build:cli`
- Changed to `npm run build:all` so the CLI, server, and lib are all built before tests run

## Test plan
- [x] Verified all unit, integration, and E2E tests pass locally with `build:all`

Fixes https://github.com/opensearch-project/agent-health/actions/runs/24043982826