### PR TITLE
feat: Add Evaluations section with compare prototypes and dense UI (#…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,17 @@ import { TracesPage } from './components/traces/TracesPage';
 import { AgentTracesPage } from './components/traces/AgentTracesPage';
 import { PerformanceOverlay } from './components/PerformanceOverlay';
 
+// Evals 3 — Evaluations
+import { BenchmarksPage4 as Evals3Benchmarks } from './components/evals3/BenchmarksPage';
+import { TestCasesPage4 as Evals3TestCases } from './components/evals3/TestCasesPage';
+import { BenchmarkRunsPage2 as Evals3BenchmarkRuns } from './components/evals3/BenchmarkRunsPage';
+import { TestCaseDetailPage as Evals3TestCaseDetail } from './components/evals3/TestCaseDetailPage';
+import { EvalRunsPage as Evals3EvalRuns } from './components/evals3/EvalRunsPage';
+import { RunInspectorPage as Evals3RunInspector } from './components/evals3/RunInspectorPage';
+import { ComparePage as Evals3Compare } from './components/evals3/ComparePage';
+import { ComparePage2 as Evals3Compare2 } from './components/evals3/ComparePage2';
+import { ComparePage3 as Evals3Compare3 } from './components/evals3/ComparePage3';
+
 function ExperimentRunsRedirect() {
   const { experimentId } = useParams();
   return <Navigate to={`/benchmarks/${experimentId}/runs`} replace />;
@@ -111,6 +122,18 @@ function App() {
 
             {/* Agent Traces - Table View */}
             <Route path="/agent-traces" element={<AgentTracesPage />} />
+
+            {/* Evals 3 → Evaluations */}
+            <Route path="/evaluations/benchmarks" element={<Evals3Benchmarks />} />
+            <Route path="/evaluations/test-cases" element={<Evals3TestCases />} />
+            <Route path="/evaluations/test-cases/:testCaseId" element={<Evals3TestCaseDetail />} />
+            <Route path="/evaluations/runs" element={<Evals3EvalRuns />} />
+            <Route path="/evaluations/benchmarks/:benchmarkId/runs" element={<Evals3BenchmarkRuns />} />
+            <Route path="/evaluations/benchmarks/:benchmarkId/runs/:runId" element={<Navigate to="inspect" replace />} />
+            <Route path="/evaluations/benchmarks/:benchmarkId/runs/:runId/inspect" element={<Evals3RunInspector />} />
+            <Route path="/evaluations/compare" element={<Evals3Compare />} />
+            <Route path="/evaluations/compare2" element={<Evals3Compare2 />} />
+            <Route path="/evaluations/compare3" element={<Evals3Compare3 />} />
 
             {/* Redirects for deprecated routes */}
             <Route path="/evals" element={<Navigate to="/test-cases" replace />} />

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -278,6 +278,66 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                   </SidebarMenuItem>
                 )}
 
+                {/* Evaluations (evals3) collapsible section */}
+                {!isCollapsed && (
+                  <Collapsible defaultOpen={true}>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
+                        tooltip="Evaluations"
+                        isActive={location.pathname.startsWith("/evals3")}
+                        className="h-9 w-full"
+                      >
+                        <div className="flex items-center w-full">
+                          <Link to="/evaluations/benchmarks" className="flex items-center gap-2 flex-1 min-w-0">
+                            <Gauge className="h-3.5 w-3.5" />
+                            <span className="text-xs">Evaluations</span>
+                          </Link>
+                          <CollapsibleTrigger asChild>
+                            <button
+                              onClick={(e) => e.stopPropagation()}
+                              className="p-0.5 rounded hover:bg-muted-foreground/20 transition-colors ml-auto"
+                              aria-label="Toggle evaluations submenu"
+                            >
+                              <ChevronDown className="h-3.5 w-3.5 transition-transform duration-200" />
+                            </button>
+                          </CollapsibleTrigger>
+                        </div>
+                      </SidebarMenuButton>
+                      <CollapsibleContent>
+                        <SidebarMenuSub className="ml-4 mt-1 space-y-1">
+                          <SidebarMenuSubItem>
+                            <SidebarMenuSubButton asChild isActive={location.pathname === "/evaluations/benchmarks" || (location.pathname.startsWith("/evaluations/benchmarks/") && !/\/evals3\/benchmarks\/[^/]+\/runs\/[^/]+/.test(location.pathname))} data-testid="nav-evals3-benchmarks" className="h-8">
+                              <Link to="/evaluations/benchmarks" className="text-xs">Benchmarks</Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                          <SidebarMenuSubItem>
+                            <SidebarMenuSubButton asChild isActive={location.pathname.startsWith("/evaluations/test-cases")} data-testid="nav-evals3-test-cases" className="h-8">
+                              <Link to="/evaluations/test-cases" className="text-xs">Test Cases</Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                          <SidebarMenuSubItem>
+                            <SidebarMenuSubButton asChild isActive={location.pathname === "/evaluations/runs" || /\/evals3\/benchmarks\/[^/]+\/runs\/[^/]+/.test(location.pathname)} data-testid="nav-evals3-runs" className="h-8">
+                              <Link to="/evaluations/runs" className="text-xs">Evaluation Runs</Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        </SidebarMenuSub>
+                      </CollapsibleContent>
+                    </SidebarMenuItem>
+                  </Collapsible>
+                )}
+
+                {/* Evaluations icon only when collapsed */}
+                {isCollapsed && (
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={location.pathname.startsWith("/evals3")} tooltip="Evaluations" data-testid="nav-evals3" className="h-9">
+                      <Link to="/evaluations/benchmarks" className="justify-center">
+                        <Gauge className="h-4 w-4" />
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )}
+
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     asChild

--- a/components/comparison/ComparisonPage.tsx
+++ b/components/comparison/ComparisonPage.tsx
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -17,19 +14,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { GitCompare, ArrowLeft, ChevronDown, ChevronRight, X, Check, Eye } from 'lucide-react';
 import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/dropdown-menu';
-import { GitCompare, ArrowLeft, Download } from 'lucide-react';
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { RunSummaryTable } from './RunSummaryTable';
 import { AggregateMetricsChart } from './AggregateMetricsChart';
 import { MetricsTimeSeriesChart } from './MetricsTimeSeriesChart';
 import { UseCaseComparisonTable } from './UseCaseComparisonTable';
-import { ComparisonSummaryBanner } from './ComparisonSummaryBanner';
-import { asyncBenchmarkStorage, asyncRunStorage } from '@/services/storage';
+import { EvaluatorType } from './MetricCell';
+import { asyncBenchmarkStorage, asyncRunStorage, asyncTestCaseStorage } from '@/services/storage';
 import {
   calculateRunAggregates,
   buildTestCaseComparisonRows,
@@ -42,15 +39,127 @@ import {
   RowStatus,
 } from '@/services/comparisonService';
 import { fetchBatchMetrics } from '@/services/metrics';
-import { Category, Benchmark, BenchmarkRun, EvaluationReport, RunAggregateMetrics, TestCaseComparisonRow, TraceMetrics } from '@/types';
-import { ENV_CONFIG } from '@/lib/config';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+import { Category, Benchmark, BenchmarkRun, EvaluationReport, RunAggregateMetrics, TestCaseComparisonRow, TraceMetrics, TestCase } from '@/types';
 
 type StatusFilter = 'all' | 'passed' | 'failed' | 'mixed';
+
+const getAgentName = (key: string) =>
+  DEFAULT_CONFIG.agents.find(a => a.key === key)?.name || key;
+
+
+// ─── Run Multi-Select Dropdown ───────────────────────────────────────────────
+
+function RunMultiSelect({
+  runs,
+  selectedIds,
+  onToggle,
+  onSelectAll,
+}: {
+  runs: BenchmarkRun[];
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+  onSelectAll: (ids: string[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selectedCount = selectedIds.length;
+  const allSelected = selectedCount === runs.length;
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="h-8 gap-2 text-xs font-normal w-[280px] justify-between">
+            <span>{selectedCount} of {runs.length} runs selected</span>
+            <ChevronDown size={12} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[340px] p-0" align="start">
+          <div className="p-2 border-b flex items-center justify-between">
+            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Select runs to compare</span>
+            <button
+              onClick={() => onSelectAll(allSelected ? [] : runs.map(r => r.id))}
+              className="text-[10px] text-primary hover:underline"
+            >
+              {allSelected ? 'Deselect all' : 'Select all'}
+            </button>
+          </div>
+          <div className="max-h-[240px] overflow-y-auto p-1">
+            {runs.map(run => {
+              const isSelected = selectedIds.includes(run.id);
+              const canDeselect = selectedIds.length > 2;
+              return (
+                <button
+                  key={run.id}
+                  onClick={() => {
+                    if (isSelected && !canDeselect) return;
+                    onToggle(run.id);
+                  }}
+                  disabled={isSelected && !canDeselect}
+                  className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-muted/50 transition-colors text-left ${
+                    isSelected ? 'bg-primary/5' : ''
+                  } ${isSelected && !canDeselect ? 'opacity-60' : ''}`}
+                >
+                  <div className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
+                    isSelected ? 'bg-primary border-primary text-primary-foreground' : 'border-muted-foreground/40'
+                  }`}>
+                    {isSelected && <Check size={10} />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate">{run.name}</div>
+                    <div className="text-[10px] text-muted-foreground">
+                      {getAgentName(run.agentKey)} · {getModelName(run.modelId)} · {formatRelativeTime(run.createdAt)}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {selectedIds.length <= 2 && (
+            <div className="p-2 border-t text-[10px] text-muted-foreground">Min 2 runs required</div>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* Selected run badges */}
+      <div className="flex flex-wrap gap-1.5">
+        {runs.filter(r => selectedIds.includes(r.id)).map(run => (
+          <Badge
+            key={run.id}
+            variant="secondary"
+            className="text-[10px] gap-1 px-2 py-0.5 font-normal"
+          >
+            {run.name}
+            {selectedIds.length > 2 && (
+              <button
+                onClick={() => onToggle(run.id)}
+                className="hover:text-foreground ml-0.5"
+                aria-label={`Remove ${run.name}`}
+              >
+                <X size={10} />
+              </button>
+            )}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
 
 export const ComparisonPage: React.FC = () => {
   const { benchmarkId } = useParams<{ benchmarkId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+
+  // All benchmarks for the selector
+  const [allBenchmarks, setAllBenchmarks] = useState<Benchmark[]>([]);
+
+  // All test cases for name lookup
+  const [allTestCases, setAllTestCases] = useState<TestCase[]>([]);
 
   // State for benchmark and data
   const [benchmark, setBenchmark] = useState<Benchmark | null>(null);
@@ -67,6 +176,32 @@ export const ComparisonPage: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [rowStatusFilter, setRowStatusFilter] = useState<RowStatus | 'all'>('all');
 
+  // Evaluator visibility
+  const ALL_EVALUATORS: EvaluatorType[] = ['accuracy', 'faithfulness', 'trajectory', 'latency', 'annotations'];
+  const [visibleEvaluators, setVisibleEvaluators] = useState<Set<EvaluatorType>>(new Set(ALL_EVALUATORS));
+  const [evalPopoverOpen, setEvalPopoverOpen] = useState(false);
+
+  // Load all benchmarks and test cases
+  useEffect(() => {
+    (async () => {
+      try {
+        const [bms, tcs] = await Promise.all([
+          asyncBenchmarkStorage.getAll(),
+          asyncTestCaseStorage.getAll(),
+        ]);
+        setAllBenchmarks(bms);
+        setAllTestCases(tcs);
+      } catch (err) {
+        console.error('Failed to load benchmarks/test cases:', err);
+      }
+    })();
+  }, []);
+
+  // Helper: pick last 2 runs by date
+  const pickLastTwoRuns = (runs: BenchmarkRun[]) => {
+    const sorted = [...runs].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return sorted.slice(0, 2).map(r => r.id);
+  };
 
   // Load benchmark data
   useEffect(() => {
@@ -84,14 +219,10 @@ export const ComparisonPage: React.FC = () => {
 
       const runs = bench.runs || [];
 
-      // Build reports map BEFORE setting state to avoid intermediate render
-      // where benchmark is set but reports are still empty
       const reportIds = new Set<string>();
       runs.forEach(run => {
         Object.values(run.results || {}).forEach(result => {
-          if (result.reportId) {
-            reportIds.add(result.reportId);
-          }
+          if (result.reportId) reportIds.add(result.reportId);
         });
       });
 
@@ -99,35 +230,30 @@ export const ComparisonPage: React.FC = () => {
       await Promise.all(
         Array.from(reportIds).map(async (reportId) => {
           const report = await asyncRunStorage.getReportById(reportId);
-          if (report) {
-            reportsMap[reportId] = report;
-          }
+          if (report) reportsMap[reportId] = report;
         })
       );
 
-      // Set all states together - React 18+ batches these automatically
       setBenchmark(bench);
       setAllRuns(runs);
       setReports(reportsMap);
 
-      // Initialize selected runs from URL or default to all
+      // Initialize selected runs from URL or default to last 2
       const urlRunIds = searchParams.get('runs')?.split(',').filter(Boolean) || [];
       if (urlRunIds.length > 0) {
-        // Filter to only valid run IDs
         const validRunIds = urlRunIds.filter(id => runs.some(r => r.id === id));
-        setSelectedRunIds(validRunIds.length > 0 ? validRunIds : runs.map(r => r.id));
+        setSelectedRunIds(validRunIds.length >= 2 ? validRunIds : pickLastTwoRuns(runs));
       } else {
-        // Default: select all runs
-        setSelectedRunIds(runs.map(r => r.id));
+        setSelectedRunIds(pickLastTwoRuns(runs));
       }
 
       setIsLoading(false);
     };
 
     loadBenchmark();
-  }, [benchmarkId, navigate]); // Note: removed searchParams from deps to avoid re-running on URL update
+  }, [benchmarkId, navigate]);
 
-  // Sync selectedRunIds when URL changes externally (e.g., browser back/forward navigation)
+  // Sync selectedRunIds when URL changes externally
   useEffect(() => {
     const urlRunIds = searchParams.get('runs')?.split(',').filter(Boolean) || [];
     if (urlRunIds.length > 0 && allRuns.length > 0) {
@@ -138,425 +264,305 @@ export const ComparisonPage: React.FC = () => {
     }
   }, [searchParams, allRuns, selectedRunIds]);
 
-  // Fetch trace metrics for all reports
+  // Fetch trace metrics
   useEffect(() => {
     const loadTraceMetrics = async () => {
       const runIds = collectRunIdsFromReports(allRuns, reports);
-      if (runIds.length === 0) {
-        setTraceMetricsMap(new Map());
-        return;
-      }
-
+      if (runIds.length === 0) { setTraceMetricsMap(new Map()); return; }
       try {
         const { metrics } = await fetchBatchMetrics(runIds);
         const map = new Map<string, TraceMetrics>();
-        metrics.forEach(m => {
-          if (m.runId && !('error' in m)) {
-            map.set(m.runId, m as TraceMetrics);
-          }
-        });
+        metrics.forEach(m => { if (m.runId && !('error' in m)) map.set(m.runId, m as TraceMetrics); });
         setTraceMetricsMap(map);
       } catch (error) {
         console.warn('[ComparisonPage] Failed to fetch trace metrics:', error);
       }
     };
-
-    if (allRuns.length > 0 && Object.keys(reports).length > 0) {
-      loadTraceMetrics();
-    }
+    if (allRuns.length > 0 && Object.keys(reports).length > 0) loadTraceMetrics();
   }, [allRuns, reports]);
 
   // Update URL when selection changes
   const updateSelection = (runIds: string[]) => {
     setSelectedRunIds(runIds);
     if (runIds.length > 0 && runIds.length < allRuns.length) {
-      // Only update URL if not all runs are selected
       setSearchParams({ runs: runIds.join(',') }, { replace: true });
     } else if (runIds.length === allRuns.length) {
-      // Clear URL param if all are selected (default state)
       setSearchParams({}, { replace: true });
     }
   };
 
-  // Get selected runs
-  const selectedRuns = useMemo((): BenchmarkRun[] => {
-    return allRuns.filter(r => selectedRunIds.includes(r.id));
-  }, [allRuns, selectedRunIds]);
-
-  // Calculate aggregate metrics for selected runs (with trace metrics)
-  const runAggregates = useMemo((): RunAggregateMetrics[] => {
-    return selectedRuns.map(run => {
-      const baseAggregates = calculateRunAggregates(run, reports);
-
-      // Aggregate trace metrics from all reports in this run
-      let totalTokens = 0;
-      let totalInputTokens = 0;
-      let totalOutputTokens = 0;
-      let totalCostUsd = 0;
-      let totalDurationMs = 0;
-      let totalLlmCalls = 0;
-      let totalToolCalls = 0;
-      let metricsCount = 0;
-
-      for (const result of Object.values(run.results)) {
-        const report = reports[result.reportId];
-        if (report?.runId) {
-          const traceMetrics = traceMetricsMap.get(report.runId);
-          if (traceMetrics) {
-            totalTokens += traceMetrics.totalTokens || 0;
-            totalInputTokens += traceMetrics.inputTokens || 0;
-            totalOutputTokens += traceMetrics.outputTokens || 0;
-            totalCostUsd += traceMetrics.costUsd || 0;
-            totalDurationMs += traceMetrics.durationMs || 0;
-            totalLlmCalls += traceMetrics.llmCalls || 0;
-            totalToolCalls += traceMetrics.toolCalls || 0;
-            metricsCount++;
-          }
-        }
-      }
-
-      return {
-        ...baseAggregates,
-        totalTokens: metricsCount > 0 ? totalTokens : undefined,
-        totalInputTokens: metricsCount > 0 ? totalInputTokens : undefined,
-        totalOutputTokens: metricsCount > 0 ? totalOutputTokens : undefined,
-        totalCostUsd: metricsCount > 0 ? totalCostUsd : undefined,
-        avgDurationMs: metricsCount > 0 ? Math.round(totalDurationMs / metricsCount) : undefined,
-        totalLlmCalls: metricsCount > 0 ? totalLlmCalls : undefined,
-        totalToolCalls: metricsCount > 0 ? totalToolCalls : undefined,
-      };
-    });
-  }, [selectedRuns, reports, traceMetricsMap]);
-
-  // Build comparison rows
-  const allComparisonRows = useMemo((): TestCaseComparisonRow[] => {
-    return buildTestCaseComparisonRows(selectedRuns, reports, getRealTestCaseMeta);
-  }, [selectedRuns, reports]);
-
-  // Derive the reference run automatically: oldest run by createdAt
-  const referenceRunId = useMemo(() => {
-    const sorted = [...selectedRuns].sort((a, b) =>
-      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-    );
-    return sorted[0]?.id ?? '';
-  }, [selectedRuns]);
-
-  // Count rows by status for summary banner
-  const rowStatusCounts = useMemo(() => {
-    return countRowsByStatus(allComparisonRows, referenceRunId);
-  }, [allComparisonRows, referenceRunId]);
-
-  // Apply filters
-  const filteredRows = useMemo((): TestCaseComparisonRow[] => {
-    let rows = allComparisonRows;
-    rows = filterRowsByCategory(rows, categoryFilter);
-    rows = filterRowsByStatus(rows, statusFilter, selectedRunIds);
-
-    // Apply row status filter (regression/improvement/mixed/neutral)
-    if (rowStatusFilter !== 'all') {
-      rows = rows.filter(row => calculateRowStatus(row, referenceRunId) === rowStatusFilter);
-    }
-
-    return rows;
-  }, [allComparisonRows, categoryFilter, statusFilter, selectedRunIds, rowStatusFilter, referenceRunId]);
-
-  // Get unique categories from rows
-  const categories = useMemo(() => {
-    const cats = new Set(allComparisonRows.map(r => r.category));
-    return Array.from(cats).sort();
-  }, [allComparisonRows]);
-
-  // Toggle run selection
+  // Toggle run
   const toggleRun = (runId: string) => {
     const newSelection = selectedRunIds.includes(runId)
       ? selectedRunIds.filter(id => id !== runId)
       : [...selectedRunIds, runId];
-
-    // Don't allow less than 2 runs
     if (newSelection.length >= 2 || newSelection.length > selectedRunIds.length) {
       updateSelection(newSelection);
     }
   };
 
-  // Capture current page as a self-contained HTML string
-  const capturePageHtml = (): string => {
-    const content = document.querySelector('[data-testid="comparison-page"]');
-    if (!content) return '';
+  // Handle benchmark change — navigate to new URL
+  const handleBenchmarkChange = (newBmId: string) => {
+    if (newBmId !== benchmarkId) {
+      navigate(`/compare/${newBmId}`, { replace: true });
+    }
+  };
 
-    // Preserve the <html> element's classes (includes "dark" for theme)
-    const htmlClasses = document.documentElement.className;
+  const selectedRuns = useMemo((): BenchmarkRun[] => allRuns.filter(r => selectedRunIds.includes(r.id)), [allRuns, selectedRunIds]);
 
-    // Collect all stylesheets into inline <style> blocks
-    const styles: string[] = [];
-    for (const sheet of Array.from(document.styleSheets)) {
-      try {
-        const rules = Array.from(sheet.cssRules).map((r) => r.cssText).join('\n');
-        styles.push(rules);
-      } catch {
-        // Skip cross-origin stylesheets
-        if (sheet.href) {
-          styles.push(`@import url("${sheet.href}");`);
+  const runAggregates = useMemo((): RunAggregateMetrics[] => {
+    return selectedRuns.map(run => {
+      const base = calculateRunAggregates(run, reports);
+      let totalTokens = 0, totalInputTokens = 0, totalOutputTokens = 0, totalCostUsd = 0, totalDurationMs = 0, totalLlmCalls = 0, totalToolCalls = 0, mc = 0;
+      for (const result of Object.values(run.results)) {
+        const report = reports[result.reportId];
+        if (report?.runId) {
+          const tm = traceMetricsMap.get(report.runId);
+          if (tm) { totalTokens += tm.totalTokens || 0; totalInputTokens += tm.inputTokens || 0; totalOutputTokens += tm.outputTokens || 0; totalCostUsd += tm.costUsd || 0; totalDurationMs += tm.durationMs || 0; totalLlmCalls += tm.llmCalls || 0; totalToolCalls += tm.toolCalls || 0; mc++; }
         }
       }
+      return { ...base, totalTokens: mc > 0 ? totalTokens : undefined, totalInputTokens: mc > 0 ? totalInputTokens : undefined, totalOutputTokens: mc > 0 ? totalOutputTokens : undefined, totalCostUsd: mc > 0 ? totalCostUsd : undefined, avgDurationMs: mc > 0 ? Math.round(totalDurationMs / mc) : undefined, totalLlmCalls: mc > 0 ? totalLlmCalls : undefined, totalToolCalls: mc > 0 ? totalToolCalls : undefined };
+    });
+  }, [selectedRuns, reports, traceMetricsMap]);
+
+  // Test case name lookup — checks loaded test cases first, falls back to getRealTestCaseMeta (static data)
+  const getTestCaseMeta = useCallback((testCaseId: string) => {
+    const tc = allTestCases.find(t => t.id === testCaseId);
+    if (tc) {
+      return {
+        id: tc.id,
+        name: tc.name,
+        labels: tc.labels,
+        category: tc.category,
+        difficulty: tc.difficulty,
+        version: `v${tc.currentVersion}`,
+      };
     }
+    return getRealTestCaseMeta(testCaseId);
+  }, [allTestCases]);
 
-    // Clone content and remove interactive elements
-    const clone = content.cloneNode(true) as HTMLElement;
-    clone.querySelectorAll('[data-testid="back-button"]').forEach((el) => el.remove());
-    clone.querySelectorAll('[data-testid="download-report-menu"]').forEach((el) => el.remove());
+  const allComparisonRows = useMemo((): TestCaseComparisonRow[] => buildTestCaseComparisonRows(selectedRuns, reports, getTestCaseMeta), [selectedRuns, reports, getTestCaseMeta]);
 
-    const title = benchmark?.name || 'Benchmark Report';
-    return `<!DOCTYPE html>
-<html lang="en" class="${htmlClasses}">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title} - Report</title>
-  <style>${styles.join('\n')}</style>
-  <style>
-    body { margin: 0; padding: 2rem; }
-    @media print {
-      html { color-scheme: light; }
-      body { background: white; color: black; }
-    }
-  </style>
-</head>
-<body>
-  ${clone.outerHTML}
-  <footer style="margin-top:2rem;padding-top:1rem;border-top:1px solid #333;font-size:0.75rem;color:#888;">
-    Generated from AgentHealth on ${new Date().toLocaleString()}
-  </footer>
-</body>
-</html>`;
-  };
-
-  // Download report in specified format
-  const downloadReport = async (format: string) => {
-    if (!benchmarkId) return;
-    const safeName = (benchmark?.name || 'report').replace(/[^a-zA-Z0-9_-]/g, '_');
-
-    // HTML: capture the current page DOM directly
-    if (format === 'html') {
-      const html = capturePageHtml();
-      if (!html) return;
-      const blob = new Blob([html], { type: 'text/html' });
-      const blobUrl = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = blobUrl;
-      a.download = `${safeName}_report.html`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(blobUrl);
-      return;
-    }
-
-    // JSON + PDF: fetch from server API
-    const params = new URLSearchParams({ format });
-    if (selectedRunIds.length < allRuns.length) {
-      params.set('runIds', selectedRunIds.join(','));
-    }
-    const url = `${ENV_CONFIG.backendUrl}/api/storage/benchmarks/${encodeURIComponent(benchmarkId)}/report?${params.toString()}`;
-
-    try {
-      const response = await fetch(url);
-      if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({ error: response.statusText }));
-        alert(`Report download failed: ${errorBody.error || response.statusText}`);
-        return;
+  // Detect which evaluators have data and auto-select them
+  const evaluatorsWithData = useMemo((): Set<EvaluatorType> => {
+    const found = new Set<EvaluatorType>();
+    found.add('accuracy'); // always present
+    for (const row of allComparisonRows) {
+      for (const result of Object.values(row.results)) {
+        if (result.faithfulness !== undefined) found.add('faithfulness');
+        if (result.trajectoryAlignment !== undefined) found.add('trajectory');
+        if (result.latencyScore !== undefined) found.add('latency');
       }
-
-      const contentDisposition = response.headers.get('content-disposition') || '';
-      const filenameMatch = contentDisposition.match(/filename="([^"]+)"/);
-      const filename = filenameMatch?.[1] || `${safeName}_report.${format}`;
-
-      const blob = await response.blob();
-      const blobUrl = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = blobUrl;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(blobUrl);
-    } catch (error) {
-      console.error('Report download failed:', error);
     }
-  };
+    // Check annotations from reports
+    for (const run of selectedRuns) {
+      for (const res of Object.values(run.results)) {
+        const report = reports[res.reportId];
+        if (report?.annotations && report.annotations.length > 0) found.add('annotations');
+      }
+    }
+    return found;
+  }, [allComparisonRows, selectedRuns, reports]);
+
+  // Auto-update visible evaluators when data changes (only pre-select ones with data)
+  useEffect(() => {
+    setVisibleEvaluators(new Set(evaluatorsWithData));
+  }, [evaluatorsWithData]);
+
+  const referenceRunId = useMemo(() => {
+    const sorted = [...selectedRuns].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return sorted[0]?.id ?? '';
+  }, [selectedRuns]);
+
+  const rowStatusCounts = useMemo(() => countRowsByStatus(allComparisonRows, referenceRunId), [allComparisonRows, referenceRunId]);
+
+  const filteredRows = useMemo((): TestCaseComparisonRow[] => {
+    let rows = allComparisonRows;
+    rows = filterRowsByCategory(rows, categoryFilter);
+    rows = filterRowsByStatus(rows, statusFilter, selectedRunIds);
+    if (rowStatusFilter !== 'all') rows = rows.filter(row => calculateRowStatus(row, referenceRunId) === rowStatusFilter);
+    return rows;
+  }, [allComparisonRows, categoryFilter, statusFilter, selectedRunIds, rowStatusFilter, referenceRunId]);
+
+  const categories = useMemo(() => Array.from(new Set(allComparisonRows.map(r => r.category))).sort(), [allComparisonRows]);
+
+  // Collapsible state
+  const [summaryOpen, setSummaryOpen] = useState(false);
 
   if (isLoading) {
-    return (
-      <div className="p-6 flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Loading...</p>
-      </div>
-    );
+    return <div className="p-6 flex items-center justify-center h-full"><p className="text-muted-foreground">Loading...</p></div>;
   }
 
   if (!benchmark) {
-    return (
-      <div className="p-6 flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Benchmark not found</p>
-      </div>
-    );
+    return <div className="p-6 flex items-center justify-center h-full"><p className="text-muted-foreground">Benchmark not found</p></div>;
   }
 
   return (
-    <div className="p-6 space-y-6" data-testid="comparison-page">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => navigate(`/benchmarks/${benchmarkId}/runs`)}
-            data-testid="back-button"
-          >
-            <ArrowLeft size={18} />
+    <div className="h-full flex flex-col" data-testid="comparison-page">
+      {/* ── Sticky Header + Toolbar ─────────────────────────────── */}
+      <div className="sticky top-0 z-20 bg-background border-b border-border">
+        {/* Title row */}
+        <div className="flex items-center gap-3 px-4 py-2">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)} data-testid="back-button" className="h-7 w-7">
+            <ArrowLeft size={14} />
           </Button>
-          <GitCompare className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-2xl font-semibold" data-testid="comparison-title">Compare Runs</h1>
-            <p className="text-xs text-muted-foreground">{benchmark.name}</p>
-          </div>
+          <GitCompare className="h-4 w-4 text-primary" />
+          <h1 className="text-sm font-semibold" data-testid="comparison-title">Compare Runs</h1>
         </div>
-        <div className="flex items-center gap-3">
-          <Badge variant="outline" className="text-xs">
-            {selectedRunIds.length} of {allRuns.length} runs selected
-          </Badge>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild data-testid="download-report-menu">
-              <Button variant="outline" size="sm" data-testid="download-report-button">
-                <Download size={16} className="mr-2" />
-                Download Report
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem onClick={() => downloadReport('json')}>JSON</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => downloadReport('html')}>HTML</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => downloadReport('pdf')}>PDF</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+
+        {/* Selector toolbar — always visible, thin */}
+        <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 border-t border-border/50">
+          <Select value={benchmarkId || ''} onValueChange={handleBenchmarkChange}>
+            <SelectTrigger className="w-[220px] h-7 text-xs"><SelectValue placeholder="Select benchmark" /></SelectTrigger>
+            <SelectContent>
+              {allBenchmarks.map(bm => (
+                <SelectItem key={bm.id} value={bm.id}>
+                  <span>{bm.name}</span>
+                  <span className="text-[10px] text-muted-foreground ml-1">({bm.runs?.length || 0})</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="h-4 w-px bg-border" />
+
+          <RunMultiSelect runs={allRuns} selectedIds={selectedRunIds} onToggle={toggleRun} onSelectAll={(ids) => updateSelection(ids.length >= 2 ? ids : pickLastTwoRuns(allRuns))} />
         </div>
       </div>
 
-      {/* Run Selector */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium">Select Runs to Compare</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-4">
-            {allRuns.map((run) => {
-              const isSelected = selectedRunIds.includes(run.id);
-              const canDeselect = selectedRunIds.length > 2;
-
-              return (
-                <div key={run.id} className="flex items-center gap-2">
-                  <Checkbox
-                    id={run.id}
-                    checked={isSelected}
-                    onCheckedChange={() => toggleRun(run.id)}
-                    disabled={isSelected && !canDeselect}
-                  />
-                  <Label
-                    htmlFor={run.id}
-                    className="text-sm cursor-pointer"
-                  >
-                    {run.name}
-                  </Label>
+      {/* ── Scrollable Results Area ─────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto">
+        {selectedRuns.length >= 2 ? (
+          <div className="p-4 space-y-3">
+            {/* Run Summary + Metrics — collapsible, collapsed by default */}
+            <Collapsible open={summaryOpen} onOpenChange={setSummaryOpen}>
+              <CollapsibleTrigger asChild>
+                <button className="flex items-center gap-2 w-full text-left">
+                  <ChevronRight size={14} className={`text-muted-foreground transition-transform ${summaryOpen ? 'rotate-90' : ''}`} />
+                  <span className="text-xs font-medium text-muted-foreground">Run Summary & Metrics</span>
+                  {!summaryOpen && (
+                    <span className="text-[10px] text-muted-foreground ml-1">
+                      {runAggregates.map(a => `${a.runName}: ${a.passRatePercent}%`).join(' · ')}
+                    </span>
+                  )}
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="space-y-3 mt-2">
+                <RunSummaryTable runs={runAggregates} referenceRunId={referenceRunId} />
+                <div className="flex flex-col md:flex-row gap-4">
+                  <div className="w-full md:w-[400px] flex-shrink-0">
+                    <AggregateMetricsChart runs={runAggregates} height={240} referenceRunId={referenceRunId} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <MetricsTimeSeriesChart runs={runAggregates} height={240} />
+                  </div>
                 </div>
-              );
-            })}
+              </CollapsibleContent>
+            </Collapsible>
+
+            {/* ── Results Section — primary content ──────────────── */}
+            <section>
+              {/* Results header with filters */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-sm font-semibold">Results</h2>
+                  <span className="text-[10px] text-muted-foreground">{allComparisonRows.length} test cases</span>
+                  {/* Inline status badges */}
+                  <div className="flex items-center gap-1 ml-2">
+                    <Badge
+                      variant="outline"
+                      className={`cursor-pointer text-[9px] px-1.5 py-0 transition-colors ${rowStatusFilter === 'all' ? 'bg-primary/20 border-primary text-primary' : 'hover:bg-muted'}`}
+                      onClick={() => setRowStatusFilter('all')}
+                    >
+                      All
+                    </Badge>
+                    {rowStatusCounts.regression > 0 && (
+                      <Badge variant="outline" className={`cursor-pointer text-[9px] px-1.5 py-0 border-red-500/30 ${rowStatusFilter === 'regression' ? 'bg-red-500/10 text-red-400' : 'hover:bg-red-500/5'}`} onClick={() => setRowStatusFilter('regression')}>
+                        ↓{rowStatusCounts.regression}
+                      </Badge>
+                    )}
+                    {rowStatusCounts.improvement > 0 && (
+                      <Badge variant="outline" className={`cursor-pointer text-[9px] px-1.5 py-0 border-blue-500/30 ${rowStatusFilter === 'improvement' ? 'bg-blue-500/10 text-blue-400' : 'hover:bg-blue-500/5'}`} onClick={() => setRowStatusFilter('improvement')}>
+                        ↑{rowStatusCounts.improvement}
+                      </Badge>
+                    )}
+                    {rowStatusCounts.mixed > 0 && (
+                      <Badge variant="outline" className={`cursor-pointer text-[9px] px-1.5 py-0 border-amber-500/30 ${rowStatusFilter === 'mixed' ? 'bg-amber-500/10 text-amber-400' : 'hover:bg-amber-500/5'}`} onClick={() => setRowStatusFilter('mixed')}>
+                        ↔{rowStatusCounts.mixed}
+                      </Badge>
+                    )}
+                    <Badge variant="outline" className={`cursor-pointer text-[9px] px-1.5 py-0 ${rowStatusFilter === 'neutral' ? 'bg-muted text-muted-foreground' : 'hover:bg-muted/50'}`} onClick={() => setRowStatusFilter('neutral')}>
+                      ={rowStatusCounts.neutral}
+                    </Badge>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select value={categoryFilter} onValueChange={(v) => setCategoryFilter(v as Category | 'all')}>
+                    <SelectTrigger className="w-36 h-7 text-xs"><SelectValue placeholder="Category" /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Categories</SelectItem>
+                      {categories.map(cat => <SelectItem key={cat} value={cat}>{cat}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as StatusFilter)}>
+                    <SelectTrigger className="w-28 h-7 text-xs"><SelectValue placeholder="Status" /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Status</SelectItem>
+                      <SelectItem value="passed">Passed</SelectItem>
+                      <SelectItem value="failed">Failed</SelectItem>
+                      <SelectItem value="mixed">Mixed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Popover open={evalPopoverOpen} onOpenChange={setEvalPopoverOpen}>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" size="sm" className="h-7 gap-1 text-xs font-normal">
+                        <Eye size={11} />
+                        Evaluators ({visibleEvaluators.size})
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[200px] p-2" align="end">
+                      <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-2 flex items-center justify-between">
+                        <span>Show evaluators</span>
+                        <button
+                          onClick={() => setVisibleEvaluators(prev => prev.size === ALL_EVALUATORS.length ? new Set<EvaluatorType>() : new Set(ALL_EVALUATORS))}
+                          className="text-[10px] text-primary hover:underline font-normal normal-case tracking-normal"
+                        >
+                          {visibleEvaluators.size === ALL_EVALUATORS.length ? 'Deselect all' : 'Select all'}
+                        </button>
+                      </div>
+                      <div className="space-y-1">
+                        {ALL_EVALUATORS.map(ev => {
+                          const hasData = evaluatorsWithData.has(ev);
+                          const isVisible = visibleEvaluators.has(ev);
+                          const labels: Record<EvaluatorType, string> = { accuracy: 'Accuracy', faithfulness: 'Faithfulness', trajectory: 'Trajectory Alignment', latency: 'Latency Score', annotations: 'Human Annotations' };
+                          return (
+                            <label key={ev} className={`flex items-center gap-2 text-xs cursor-pointer px-1 py-0.5 rounded hover:bg-muted/50 ${!hasData ? 'opacity-40' : ''}`}>
+                              <input type="checkbox" checked={isVisible} onChange={() => { setVisibleEvaluators(prev => { const n = new Set(prev); n.has(ev) ? n.delete(ev) : n.add(ev); return n; }); }} className="h-3 w-3 rounded" />
+                              <span>{labels[ev]}</span>
+                              {!hasData && <span className="text-[9px] text-muted-foreground ml-auto">no data</span>}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </div>
+
+              {/* Comparison table */}
+              <UseCaseComparisonTable rows={filteredRows} runs={selectedRuns} reports={reports} referenceRunId={referenceRunId} visibleEvaluators={visibleEvaluators} />
+              {filteredRows.length === 0 && allComparisonRows.length > 0 && (
+                <p className="text-sm text-muted-foreground text-center mt-3">No test cases match the current filters</p>
+              )}
+            </section>
           </div>
-          {selectedRunIds.length <= 2 && (
-            <p className="text-xs text-muted-foreground mt-2">
-              At least 2 runs must be selected for comparison
-            </p>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Run Summary Cards */}
-      {selectedRuns.length >= 2 && (
-        <>
-          <section>
-            <h2 className="text-lg font-medium mb-4">Run Summary</h2>
-            <RunSummaryTable runs={runAggregates} referenceRunId={referenceRunId} />
-          </section>
-
-          {/* Metrics Section - Side by Side */}
-          <section>
-            <h2 className="text-lg font-medium mb-4">Metrics</h2>
-            <div className="flex flex-col md:flex-row gap-6">
-              <div className="w-full md:w-[420px] flex-shrink-0">
-                <AggregateMetricsChart runs={runAggregates} height={300} referenceRunId={referenceRunId} />
-              </div>
-              <div className="flex-1 min-w-0">
-                <MetricsTimeSeriesChart runs={runAggregates} height={300} />
-              </div>
-            </div>
-          </section>
-
-          {/* Summary Banner with regression/improvement counts */}
-          <ComparisonSummaryBanner
-            counts={rowStatusCounts}
-            onFilterClick={(status) => setRowStatusFilter(status)}
-            activeFilter={rowStatusFilter}
-          />
-
-          {/* Per Use Case Comparison */}
-          <section>
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-medium">Per Use Case Comparison</h2>
-              <div className="flex items-center gap-4">
-                <Select
-                  value={categoryFilter}
-                  onValueChange={(v) => setCategoryFilter(v as Category | 'all')}
-                >
-                  <SelectTrigger className="w-48">
-                    <SelectValue placeholder="Filter by category" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Categories</SelectItem>
-                    {categories.map(cat => (
-                      <SelectItem key={cat} value={cat}>{cat}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={statusFilter}
-                  onValueChange={(v) => setStatusFilter(v as StatusFilter)}
-                >
-                  <SelectTrigger className="w-36">
-                    <SelectValue placeholder="Filter by status" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Status</SelectItem>
-                    <SelectItem value="passed">All Passed</SelectItem>
-                    <SelectItem value="failed">Has Failed</SelectItem>
-                    <SelectItem value="mixed">Mixed Results</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <UseCaseComparisonTable rows={filteredRows} runs={selectedRuns} reports={reports} referenceRunId={referenceRunId} />
-            {filteredRows.length === 0 && allComparisonRows.length > 0 && (
-              <p className="text-sm text-muted-foreground text-center mt-4">
-                No use cases match the current filters
-              </p>
-            )}
-          </section>
-        </>
-      )}
-
-      {selectedRuns.length < 2 && (
-        <Card className="border-dashed">
-          <CardContent className="py-12 text-center text-muted-foreground">
-            <GitCompare className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p>Select at least 2 runs to compare</p>
-          </CardContent>
-        </Card>
-      )}
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center py-20 text-muted-foreground">
+            <GitCompare className="h-10 w-10 mb-3 opacity-50" />
+            <p className="text-sm">Select at least 2 runs to compare</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/comparison/MetricCell.tsx
+++ b/components/comparison/MetricCell.tsx
@@ -4,21 +4,51 @@
  */
 
 import React from 'react';
-import { CheckCircle2, XCircle, Minus } from 'lucide-react';
+import { CheckCircle2, XCircle, Minus, MessageSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TestCaseRunResult } from '@/types';
+
+/** Which evaluator metrics to show in the cell */
+export type EvaluatorType = 'accuracy' | 'faithfulness' | 'trajectory' | 'latency' | 'annotations';
 
 interface MetricCellProps {
   result: TestCaseRunResult;
   isReference?: boolean;
   baselineAccuracy?: number;
+  baselineFaithfulness?: number;
+  annotationCount?: number;
+  visibleEvaluators?: Set<EvaluatorType>;
+}
+
+function DeltaValue({ value, baseline, label }: { value?: number; baseline?: number; label: string }) {
+  if (value === undefined) return null;
+  const delta = baseline !== undefined ? value - baseline : undefined;
+  return (
+    <div className="flex items-center justify-between text-[10px]">
+      <span className="text-muted-foreground">{label}</span>
+      <span>
+        <span className="font-medium">{value}%</span>
+        {delta !== undefined && delta !== 0 && (
+          <span className={cn('ml-0.5', delta > 0 ? 'text-opensearch-blue' : 'text-red-400')}>
+            ({delta > 0 ? '+' : ''}{delta})
+          </span>
+        )}
+      </span>
+    </div>
+  );
 }
 
 export const MetricCell: React.FC<MetricCellProps> = ({
   result,
   isReference = false,
   baselineAccuracy,
+  baselineFaithfulness,
+  annotationCount = 0,
+  visibleEvaluators,
 }) => {
+  // Default: show all
+  const show = (type: EvaluatorType) => !visibleEvaluators || visibleEvaluators.has(type);
+
   if (result.status === 'missing') {
     return (
       <div className="text-center py-2 text-muted-foreground">
@@ -30,45 +60,68 @@ export const MetricCell: React.FC<MetricCellProps> = ({
 
   const isPassed = result.passFailStatus === 'passed';
   const accuracy = result.accuracy ?? 0;
-
-  // Calculate delta if not the reference run and reference value exists
-  const delta = !isReference && baselineAccuracy !== undefined
-    ? accuracy - baselineAccuracy
-    : undefined;
+  const accDelta = !isReference && baselineAccuracy !== undefined ? accuracy - baselineAccuracy : undefined;
 
   return (
-    <div className="text-center py-2 px-2 group relative">
-      {/* Pass/Fail Status */}
-      <div
-        className={cn(
-          'inline-flex items-center gap-1.5 text-sm font-medium',
-          isPassed ? 'text-opensearch-blue' : 'text-red-400'
-        )}
-      >
-        {isPassed ? (
-          <CheckCircle2 size={14} />
-        ) : (
-          <XCircle size={14} />
-        )}
-        <span>{isPassed ? 'Passed' : 'Failed'}</span>
+    <div className="py-2 px-2.5 group relative">
+      {/* Pass/Fail + Accuracy (primary row) */}
+      <div className="flex items-center justify-center gap-1.5">
+        <div className={cn('inline-flex items-center gap-1 text-xs font-medium', isPassed ? 'text-opensearch-blue' : 'text-red-400')}>
+          {isPassed ? <CheckCircle2 size={13} /> : <XCircle size={13} />}
+          <span>{isPassed ? 'Passed' : 'Failed'}</span>
+        </div>
       </div>
 
-      {/* Accuracy with delta */}
-      <div className="text-xs mt-1">
-        <span className="text-muted-foreground">Acc: </span>
-        <span className="font-medium">{accuracy}%</span>
-        {delta !== undefined && delta !== 0 && (
-          <span
-            className={cn(
-              'ml-1',
-              delta > 0 ? 'text-opensearch-blue' : 'text-red-400'
+      {/* Metrics grid */}
+      <div className="mt-1 space-y-0.5">
+        {/* Accuracy — always shown */}
+        {show('accuracy') && (
+        <div className="flex items-center justify-between text-[10px]">
+          <span className="text-muted-foreground">Acc</span>
+          <span>
+            <span className="font-medium">{accuracy}%</span>
+            {accDelta !== undefined && accDelta !== 0 && (
+              <span className={cn('ml-0.5', accDelta > 0 ? 'text-opensearch-blue' : 'text-red-400')}>
+                ({accDelta > 0 ? '+' : ''}{accDelta})
+              </span>
             )}
-          >
-            ({delta > 0 ? '+' : ''}{delta})
           </span>
+        </div>
+        )}
+
+        {/* Faithfulness — show if available and visible */}
+        {show('faithfulness') && (
+        <DeltaValue
+          value={result.faithfulness}
+          baseline={!isReference ? baselineFaithfulness : undefined}
+          label="Faith"
+        />
+        )}
+
+        {/* Trajectory Alignment — show if available and visible */}
+        {show('trajectory') && result.trajectoryAlignment !== undefined && (
+          <div className="flex items-center justify-between text-[10px]">
+            <span className="text-muted-foreground">Traj</span>
+            <span className="font-medium">{result.trajectoryAlignment}%</span>
+          </div>
+        )}
+
+        {/* Latency Score — show if available and visible */}
+        {show('latency') && result.latencyScore !== undefined && (
+          <div className="flex items-center justify-between text-[10px]">
+            <span className="text-muted-foreground">Lat</span>
+            <span className="font-medium">{result.latencyScore}%</span>
+          </div>
         )}
       </div>
 
+      {/* Annotation indicator */}
+      {show('annotations') && annotationCount > 0 && (
+        <div className="flex items-center justify-center gap-1 mt-1.5 text-[9px] text-amber-500">
+          <MessageSquare size={10} />
+          <span>{annotationCount} annotation{annotationCount > 1 ? 's' : ''}</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/comparison/UseCaseComparisonTable.tsx
+++ b/components/comparison/UseCaseComparisonTable.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Table,
   TableBody,
@@ -16,7 +17,7 @@ import { Badge } from '@/components/ui/badge';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { TestCaseComparisonRow, BenchmarkRun, EvaluationReport } from '@/types';
-import { MetricCell } from './MetricCell';
+import { MetricCell, EvaluatorType } from './MetricCell';
 import { VersionIndicator } from './VersionIndicator';
 import { UseCaseExpandedRow } from './UseCaseExpandedRow';
 import { cn, getLabelColor } from '@/lib/utils';
@@ -34,6 +35,7 @@ interface UseCaseComparisonTableProps {
   runs: BenchmarkRun[];
   reports: Record<string, EvaluationReport>;
   referenceRunId?: string;
+  visibleEvaluators?: Set<EvaluatorType>;
 }
 
 const rowStatusStyles: Record<RowStatus, string> = {
@@ -48,6 +50,7 @@ export const UseCaseComparisonTable: React.FC<UseCaseComparisonTableProps> = ({
   runs,
   reports,
   referenceRunId: propReferenceRunId,
+  visibleEvaluators,
 }) => {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
 
@@ -74,7 +77,7 @@ export const UseCaseComparisonTable: React.FC<UseCaseComparisonTableProps> = ({
     );
   }
 
-  const columnCount = runs.length + 1; // +1 for the use case column
+  const columnCount = runs.length + 1; // +1 for the test case column
 
   return (
     <ScrollArea className="rounded-md border border-border">
@@ -83,7 +86,7 @@ export const UseCaseComparisonTable: React.FC<UseCaseComparisonTableProps> = ({
           <TableHeader>
             <TableRow>
               <TableHead className="w-72 sticky left-0 bg-background z-10">
-                Use Case
+                Test Case
               </TableHead>
               {runs.map((run) => (
                 <TableHead key={run.id} className="text-center min-w-32">
@@ -123,12 +126,19 @@ export const UseCaseComparisonTable: React.FC<UseCaseComparisonTableProps> = ({
                         </div>
                         <div className="space-y-1 min-w-0">
                           <div className="flex items-center gap-2">
-                            <span className="font-medium truncate max-w-40">
+                            <Link
+                              to={`/evals3/test-cases/${row.testCaseId}`}
+                              className="font-medium truncate max-w-48 hover:underline text-foreground"
+                              onClick={(e) => e.stopPropagation()}
+                            >
                               {row.testCaseName}
-                            </span>
+                            </Link>
                             {row.hasVersionDifference && (
                               <VersionIndicator versions={row.versions} />
                             )}
+                          </div>
+                          <div className="text-[10px] text-muted-foreground font-mono truncate max-w-48">
+                            {row.testCaseId}
                           </div>
                           <div className="flex items-center gap-2 flex-wrap">
                             {(row.labels || []).slice(0, 2).map((label) => (
@@ -153,12 +163,20 @@ export const UseCaseComparisonTable: React.FC<UseCaseComparisonTableProps> = ({
                       const result = row.results[run.id] || { status: 'missing' as const };
                       const isReference = run.id === referenceRunId;
 
+                      // Look up annotation count from report
+                      const reportId = result.reportId;
+                      const report = reportId ? reports[reportId] : undefined;
+                      const annotationCount = report?.annotations?.length ?? 0;
+
                       return (
                         <TableCell key={run.id} className="p-0">
                           <MetricCell
                             result={result}
                             isReference={isReference}
                             baselineAccuracy={referenceAccuracy}
+                            baselineFaithfulness={referenceResult?.faithfulness}
+                            annotationCount={annotationCount}
+                            visibleEvaluators={visibleEvaluators}
                           />
                         </TableCell>
                       );

--- a/components/evals3/BenchmarkRunDetailPage.tsx
+++ b/components/evals3/BenchmarkRunDetailPage.tsx
@@ -1,0 +1,310 @@
+/*
+ * BenchmarkRunDetailPage — Evals 3: Benchmark Run drill-down
+ *
+ * Layout (Option A: Entity Card + Dense Results Table):
+ *   1. Purple-accent entity card: "BENCHMARK RUN" badge, run name, benchmark name,
+ *      agent/model/timestamp metadata, pass/fail/rate stats
+ *   2. Collapsible "Run Config" section
+ *   3. Full-width test case results table — click row → /runs/:reportId
+ *
+ * Route: /evaluations/benchmarks/:benchmarkId/runs/:runId
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft, CheckCircle2, XCircle, Loader2, Clock, ChevronDown,
+  ChevronRight, Calendar, Ban,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { asyncBenchmarkStorage, asyncTestCaseStorage, asyncRunStorage } from '@/services/storage';
+import { Benchmark, BenchmarkRun, TestCase, EvaluationReport } from '@/types';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { getLabelColor, formatDate, getModelName } from '@/lib/utils';
+import { RunDetailsFlyout } from './RunDetailsFlyout';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type ResultStatus = 'passed' | 'failed' | 'running' | 'pending';
+
+interface TestCaseResult {
+  testCaseId: string;
+  testCase: TestCase | null;
+  reportId: string | null;
+  report: EvaluationReport | null;
+  status: ResultStatus;
+  accuracy: number | null;
+}
+
+function getResultStatus(runResult: { status: string }, report: EvaluationReport | null): ResultStatus {
+  if (runResult.status === 'running') return 'running';
+  if (runResult.status === 'pending') return 'pending';
+  if (report?.passFailStatus === 'passed') return 'passed';
+  if (report?.passFailStatus === 'failed') return 'failed';
+  if (runResult.status === 'completed') return report ? 'passed' : 'pending';
+  return 'failed';
+}
+
+
+function StatusIcon({ status }: { status: ResultStatus }) {
+  switch (status) {
+    case 'passed': return <CheckCircle2 size={14} className="text-green-500" />;
+    case 'failed': return <XCircle size={14} className="text-red-500" />;
+    case 'running': return <Loader2 size={14} className="text-blue-600 dark:text-blue-400 animate-spin" />;
+    case 'pending': return <Clock size={14} className="text-muted-foreground" />;
+  }
+}
+
+function StatusLabel({ status }: { status: ResultStatus }) {
+  const config: Record<ResultStatus, { label: string; cls: string }> = {
+    passed: { label: 'PASS', cls: 'text-green-500' },
+    failed: { label: 'FAIL', cls: 'text-red-500' },
+    running: { label: 'RUNNING', cls: 'text-blue-600 dark:text-blue-400' },
+    pending: { label: 'PENDING', cls: 'text-muted-foreground' },
+  };
+  const c = config[status];
+  return <span className={`text-[11px] font-semibold ${c.cls}`}>{c.label}</span>;
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const BenchmarkRunDetailPage: React.FC = () => {
+  const { benchmarkId, runId } = useParams<{ benchmarkId: string; runId: string }>();
+  const navigate = useNavigate();
+
+  const [benchmark, setBenchmark] = useState<Benchmark | null>(null);
+  const [run, setRun] = useState<BenchmarkRun | null>(null);
+  const [results, setResults] = useState<TestCaseResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [configOpen, setConfigOpen] = useState(false);
+
+  // Flyout state
+  const [flyoutResult, setFlyoutResult] = useState<TestCaseResult | null>(null);
+
+  const loadData = useCallback(async () => {
+    if (!benchmarkId || !runId) return;
+    setLoading(true);
+    try {
+      const bm = await asyncBenchmarkStorage.getById(benchmarkId);
+      if (!bm) { navigate('/evaluations/benchmarks'); return; }
+      setBenchmark(bm);
+
+      const bmRun = bm.runs?.find(r => r.id === runId);
+      if (!bmRun) { navigate(`/evaluations/benchmarks/${benchmarkId}/runs`); return; }
+      setRun(bmRun);
+
+      // Load test cases and reports for this run
+      const tcIds = Object.keys(bmRun.results || {});
+      const [testCases, reports] = await Promise.all([
+        asyncTestCaseStorage.getByIds(tcIds),
+        asyncRunStorage.getByBenchmarkRun(benchmarkId, runId),
+      ]);
+
+      const tcMap = new Map(testCases.map(tc => [tc.id, tc]));
+      const reportMap = new Map(reports.map(r => [r.id, r]));
+
+      const resultRows: TestCaseResult[] = tcIds.map(tcId => {
+        const runResult = bmRun.results[tcId];
+        const report = runResult?.reportId ? (reportMap.get(runResult.reportId) || null) : null;
+        return {
+          testCaseId: tcId,
+          testCase: tcMap.get(tcId) || null,
+          reportId: runResult?.reportId || null,
+          report,
+          status: getResultStatus(runResult, report),
+          accuracy: report?.metrics?.accuracy ?? null,
+        };
+      });
+
+      setResults(resultRows);
+    } catch (error) {
+      console.error('Failed to load benchmark run:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [benchmarkId, runId, navigate]);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  // Stats
+  const passCount = results.filter(r => r.status === 'passed').length;
+  const failCount = results.filter(r => r.status === 'failed').length;
+  const totalCount = results.length;
+  const passRate = totalCount > 0 ? Math.round((passCount / totalCount) * 100) : 0;
+  const avgAccuracy = results.filter(r => r.accuracy !== null).length > 0
+    ? Math.round(results.reduce((s, r) => s + (r.accuracy ?? 0), 0) / results.filter(r => r.accuracy !== null).length)
+    : null;
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!benchmark || !run) return null;
+
+  const agentName = DEFAULT_CONFIG.agents.find(a => a.key === run.agentKey)?.name || run.agentKey;
+  const modelName = getModelName(run.modelId);
+
+
+  return (
+    <div className="p-6 h-full overflow-y-auto">
+      {/* Back */}
+      <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="gap-1.5 mb-4">
+        <ArrowLeft size={16} /> Back to {benchmark.name}
+      </Button>
+
+      {/* ── Entity Card ────────────────────────────────────────────── */}
+      <div className="rounded-lg border border-border bg-card overflow-hidden mb-6">
+        <div className="flex">
+          <div className="w-1.5 bg-purple-500 shrink-0" />
+          <div className="flex-1 p-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-2">
+                  <Badge className="text-[10px] px-2 py-0.5 bg-muted text-muted-foreground border-border font-medium uppercase tracking-widest rounded">
+                    Benchmark Run
+                  </Badge>
+                  {run.benchmarkVersion && (
+                    <span className="text-[10px] text-muted-foreground">v{run.benchmarkVersion}</span>
+                  )}
+                  {run.status === 'running' && (
+                    <Badge className="text-[10px] px-1.5 py-0 bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-500/15 dark:text-blue-400 dark:border-blue-500/30 animate-pulse">
+                      <Loader2 size={10} className="mr-1 animate-spin" /> Running
+                    </Badge>
+                  )}
+                </div>
+                <h1 className="text-xl font-bold mb-1">{run.name}</h1>
+                <p className="text-sm text-muted-foreground mb-2">{benchmark.name}</p>
+                {run.description && (
+                  <p className="text-xs text-muted-foreground mb-3">{run.description}</p>
+                )}
+                <div className="flex items-center gap-4 text-[11px] text-muted-foreground">
+                  <span className="flex items-center gap-1"><Calendar size={11} /> {formatDate(run.createdAt)}</span>
+                  <span>Agent: {agentName}</span>
+                  <span>Model: {modelName}</span>
+                  <span>{totalCount} test case{totalCount !== 1 ? 's' : ''}</span>
+                </div>
+              </div>
+              {/* Stats */}
+              <div className="flex items-center gap-5 ml-4 shrink-0">
+                <div className="text-center">
+                  <div className="text-lg font-bold text-green-500">{passCount}</div>
+                  <div className="text-[10px] text-muted-foreground">Passed</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-lg font-bold text-red-500">{failCount}</div>
+                  <div className="text-[10px] text-muted-foreground">Failed</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-lg font-bold">{passRate}%</div>
+                  <div className="text-[10px] text-muted-foreground">Pass Rate</div>
+                </div>
+                {avgAccuracy !== null && (
+                  <div className="text-center">
+                    <div className="text-lg font-bold text-blue-600 dark:text-blue-400">{avgAccuracy}%</div>
+                    <div className="text-[10px] text-muted-foreground">Avg Accuracy</div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+
+      {/* ── Collapsible Run Config ─────────────────────────────────── */}
+      <div className="mb-6">
+        <button
+          onClick={() => setConfigOpen(!configOpen)}
+          className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors mb-2"
+        >
+          {configOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <span className="uppercase tracking-wider">Run Configuration</span>
+        </button>
+        {configOpen && (
+          <div className="grid grid-cols-2 gap-3 pl-5 border-l-2 border-border ml-1">
+            <div className="bg-muted/30 rounded-md p-3 border border-border">
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Agent</div>
+              <div className="text-sm font-medium">{agentName}</div>
+              {run.agentEndpoint && <div className="text-[10px] text-muted-foreground mt-0.5">{run.agentEndpoint}</div>}
+            </div>
+            <div className="bg-muted/30 rounded-md p-3 border border-border">
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1">Judge Model</div>
+              <div className="text-sm font-medium">{modelName}</div>
+              <div className="text-[10px] text-muted-foreground mt-0.5">{run.modelId}</div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Test Case Results Table ────────────────────────────────── */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+          Test Case Results ({totalCount})
+        </h3>
+        <div className="border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-2 bg-muted/30 border-b border-border text-[10px] uppercase tracking-wider text-muted-foreground font-medium sticky top-0 z-10">
+            <span className="w-8 shrink-0" />
+            <span className="flex-1 min-w-0">Test Case</span>
+            <span className="w-24 shrink-0">Labels</span>
+            <span className="w-20 shrink-0 text-right">Accuracy</span>
+            <span className="w-16 shrink-0 text-right">Result</span>
+          </div>
+
+          {results.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <p className="text-sm">No test case results</p>
+            </div>
+          ) : (
+            results.map(r => (
+              <div
+                key={r.testCaseId}
+                className="flex items-center gap-2 px-3 py-3 border-b border-border/40 hover:bg-muted/20 cursor-pointer transition-colors"
+                onClick={() => r.report && setFlyoutResult(r)}
+              >
+                <div className="w-8 shrink-0 flex justify-center">
+                  <StatusIcon status={r.status} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{r.testCase?.name || r.testCaseId}</div>
+                  {r.testCase?.difficulty && (
+                    <span className="text-[10px] text-muted-foreground">{r.testCase.difficulty}</span>
+                  )}
+                </div>
+                <div className="w-24 shrink-0 flex flex-wrap gap-1">
+                  {r.testCase?.labels?.slice(0, 2).map(l => (
+                    <Badge key={l} variant="outline" className={`text-[9px] px-1 py-0 ${getLabelColor(l)}`}>{l}</Badge>
+                  ))}
+                </div>
+                <div className="w-20 shrink-0 text-right">
+                  {r.accuracy !== null
+                    ? <span className={`text-sm font-semibold tabular-nums ${r.accuracy >= 50 ? 'text-green-500' : 'text-red-500'}`}>{r.accuracy}%</span>
+                    : <span className="text-xs text-muted-foreground">—</span>}
+                </div>
+                <div className="w-16 shrink-0 text-right">
+                  <StatusLabel status={r.status} />
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* ── Run Details Flyout ─────────────────────────────────────── */}
+      {flyoutResult?.report && (
+        <RunDetailsFlyout
+          report={flyoutResult.report}
+          testCase={flyoutResult.testCase}
+          onClose={() => setFlyoutResult(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/components/evals3/BenchmarkRunsPage.tsx
+++ b/components/evals3/BenchmarkRunsPage.tsx
@@ -1,0 +1,823 @@
+/*
+ * BenchmarkRunsPage V2 — Evals 3: Tabbed layout (Option B)
+ *
+ * Replaces the confusing two-panel resizable split with two tabs:
+ *   - "Runs" (default) — full-width runs list with version filter
+ *   - "Test Cases" — full-width test case list with version selector
+ *
+ * Benchmark summary header stays above both tabs.
+ * Same data model + backend as V1 (asyncBenchmarkStorage).
+ * Wired to Evals 3 only.
+ */
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import {
+  ArrowLeft, GitCompare, Calendar, CheckCircle2, XCircle, Play,
+  Trash2, Plus, X, Loader2, Circle, Check, ChevronRight, Clock,
+  StopCircle, Ban,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Progress } from '@/components/ui/progress';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { asyncBenchmarkStorage, asyncTestCaseStorage } from '@/services/storage';
+import { executeBenchmarkRun } from '@/services/client';
+import { useBenchmarkCancellation } from '@/hooks/useBenchmarkCancellation';
+import { Benchmark, BenchmarkRun, TestCase, BenchmarkProgress, BenchmarkStartedEvent, RunStats } from '@/types';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { getLabelColor, formatDate, getModelName } from '@/lib/utils';
+import {
+  computeVersionData,
+  getSelectedVersionData,
+  getVersionTestCases,
+  filterRunsByVersion,
+  VersionData,
+} from '@/lib/benchmarkVersionUtils';
+import { RunConfigForExecution } from '../BenchmarkEditor';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface UseCaseRunStatus {
+  id: string;
+  name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const getEffectiveRunStatus = (run: BenchmarkRun): BenchmarkRun['status'] => {
+  if (run.status) return run.status;
+  const results = Object.values(run.results || {});
+  if (results.some(r => r.status === 'running')) return 'running';
+  if (results.some(r => r.status === 'pending') &&
+      !results.some(r => r.status === 'completed' || r.status === 'failed')) return 'running';
+  if (results.some(r => r.status === 'completed') || results.some(r => r.status === 'failed')) return 'completed';
+  return 'failed';
+};
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const BenchmarkRunsPage2: React.FC = () => {
+  const { benchmarkId } = useParams<{ benchmarkId: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const parentPath = location.pathname.startsWith('/evals3') ? '/evaluations/benchmarks' : '/evaluations/benchmarks';
+
+  const [benchmark, setBenchmark] = useState<Benchmark | null>(null);
+  const [testCases, setTestCases] = useState<TestCase[]>([]);
+
+  // Run pagination
+  const [totalRuns, setTotalRuns] = useState(0);
+  const [hasMoreRuns, setHasMoreRuns] = useState(false);
+  const [isLoadingMoreRuns, setIsLoadingMoreRuns] = useState(false);
+  const isInitialLoadDone = useRef(false);
+  const cachedVersions = useRef<Benchmark['versions'] | null>(null);
+
+  // Run config dialog
+  const [isRunConfigOpen, setIsRunConfigOpen] = useState(false);
+  const [runConfigValues, setRunConfigValues] = useState<RunConfigForExecution>({
+    name: '', description: '', agentKey: '', modelId: '',
+  });
+
+  // Running state
+  const [isRunning, setIsRunning] = useState(false);
+  const [runProgress, setRunProgress] = useState<BenchmarkProgress | null>(null);
+  const [useCaseStatuses, setUseCaseStatuses] = useState<UseCaseRunStatus[]>([]);
+  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Selection for comparison
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
+
+  // Delete state
+  const [deleteState, setDeleteState] = useState<{
+    isDeleting: boolean; deletingId: string | null;
+    status: 'idle' | 'success' | 'error'; message: string;
+  }>({ isDeleting: false, deletingId: null, status: 'idle', message: '' });
+
+  // Version state
+  const [testCaseVersion, setTestCaseVersion] = useState<number | null>(null);
+  const [runVersionFilter, setRunVersionFilter] = useState<number | 'all'>('all');
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState<string>('runs');
+
+  const { isCancelling, handleCancelRun } = useBenchmarkCancellation();
+
+  // ─── Data Loading ────────────────────────────────────────────────────────
+
+  const loadBenchmark = useCallback(async () => {
+    if (!benchmarkId) return;
+    try {
+      const isPolling = isInitialLoadDone.current;
+      const options = isPolling
+        ? { fields: 'polling' as const, runsSize: 100 }
+        : { runsSize: 100 };
+      const exp = await asyncBenchmarkStorage.getById(benchmarkId, options);
+      if (!exp) { navigate(parentPath); return; }
+
+      const expAny = exp as any;
+      if (expAny.totalRuns !== undefined) {
+        setTotalRuns(expAny.totalRuns);
+        setHasMoreRuns(expAny.hasMoreRuns ?? false);
+      }
+      if (isPolling && cachedVersions.current) {
+        exp.versions = cachedVersions.current;
+      } else {
+        cachedVersions.current = exp.versions;
+      }
+      setBenchmark(exp);
+
+      if (!isPolling) {
+        try {
+          const benchmarkTcs = await asyncTestCaseStorage.getByIds(exp.testCaseIds);
+          setTestCases(benchmarkTcs);
+        } catch (error) {
+          console.error('Failed to load test cases:', error);
+        }
+        isInitialLoadDone.current = true;
+      }
+    } catch (error) {
+      console.error('Failed to load benchmark:', error);
+      navigate(parentPath);
+    }
+  }, [benchmarkId, navigate, parentPath]);
+
+  const loadMoreRuns = useCallback(async () => {
+    if (!benchmarkId || !benchmark || isLoadingMoreRuns) return;
+    setIsLoadingMoreRuns(true);
+    try {
+      const currentRunCount = benchmark.runs?.length || 0;
+      const exp = await asyncBenchmarkStorage.getById(benchmarkId, {
+        runsSize: 100, runsOffset: currentRunCount,
+      });
+      if (exp) {
+        setBenchmark(prev => {
+          if (!prev) return exp;
+          return { ...prev, runs: [...(prev.runs || []), ...(exp.runs || [])] };
+        });
+        const expAny = exp as any;
+        if (expAny.totalRuns !== undefined) {
+          setTotalRuns(expAny.totalRuns);
+          setHasMoreRuns(expAny.hasMoreRuns ?? false);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load more runs:', error);
+    } finally {
+      setIsLoadingMoreRuns(false);
+    }
+  }, [benchmarkId, benchmark, isLoadingMoreRuns]);
+
+  useEffect(() => { loadBenchmark(); }, [loadBenchmark]);
+
+  // ─── Derived Data ────────────────────────────────────────────────────────
+
+  const benchmarkTestCases = useMemo(() =>
+    testCases.filter(tc => benchmark?.testCaseIds.includes(tc.id)),
+    [testCases, benchmark]
+  );
+
+  const versionData = useMemo<VersionData[]>(
+    () => computeVersionData(benchmark), [benchmark]
+  );
+
+  const selectedVersionData = useMemo(
+    () => getSelectedVersionData(versionData, testCaseVersion), [versionData, testCaseVersion]
+  );
+
+  const versionTestCases = useMemo(
+    () => getVersionTestCases(testCases, selectedVersionData), [selectedVersionData, testCases]
+  );
+
+  const filteredRuns = useMemo(
+    () => filterRunsByVersion(benchmark?.runs, runVersionFilter), [benchmark?.runs, runVersionFilter]
+  );
+
+  const hasMultipleVersions = versionData.length > 1;
+
+  // ─── Run Stats ───────────────────────────────────────────────────────────
+
+  const getRunStats = useCallback((run: BenchmarkRun): RunStats & { running: number } => {
+    let running = 0;
+    Object.values(run.results || {}).forEach(r => { if (r.status === 'running') running++; });
+
+    if (run.stats && typeof run.stats.passed === 'number') {
+      return {
+        passed: run.stats.passed, failed: run.stats.failed,
+        pending: run.stats.pending - running, running,
+        total: run.stats.total,
+      };
+    }
+    let passed = 0, failed = 0, pending = 0;
+    Object.values(run.results || {}).forEach(r => {
+      if (r.status === 'running') return;
+      else if (r.status === 'completed') pending++;
+      else if (r.status === 'failed' || r.status === 'cancelled') failed++;
+      else pending++;
+    });
+    return { passed, failed, pending, running, total: Object.keys(run.results || {}).length };
+  }, []);
+
+  const hasPendingEvaluations = useMemo(() => {
+    if (!benchmark?.runs) return false;
+    return benchmark.runs.some(run => run.stats?.pending && run.stats.pending > 0);
+  }, [benchmark?.runs]);
+
+  const hasServerInProgressRuns = useMemo(() => {
+    if (!benchmark?.runs) return false;
+    return benchmark.runs.some(run => getEffectiveRunStatus(run) === 'running');
+  }, [benchmark?.runs]);
+
+  // Polling
+  useEffect(() => {
+    const shouldPoll = isRunning || hasPendingEvaluations || hasServerInProgressRuns;
+    if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
+    if (shouldPoll) {
+      const interval = isRunning ? POLL_INTERVAL_MS : 5000;
+      pollIntervalRef.current = setInterval(() => { loadBenchmark(); }, interval);
+    }
+    return () => { if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; } };
+  }, [isRunning, hasPendingEvaluations, hasServerInProgressRuns, loadBenchmark]);
+
+  // ─── Actions ─────────────────────────────────────────────────────────────
+
+  const getLatestRun = (exp: Benchmark): BenchmarkRun | null => {
+    if (!exp.runs || exp.runs.length === 0) return null;
+    return exp.runs.reduce((latest, run) =>
+      new Date(run.createdAt) > new Date(latest.createdAt) ? run : latest
+    );
+  };
+
+  const handleAddRun = () => {
+    if (!benchmark) return;
+    if (isRunning) { alert('A run is already in progress.'); return; }
+    const latestRun = getLatestRun(benchmark);
+    const runNumber = (benchmark.runs?.length || 0) + 1;
+    setRunConfigValues({
+      name: `Run ${runNumber}`, description: '',
+      agentKey: latestRun?.agentKey || DEFAULT_CONFIG.agents[0]?.key || '',
+      modelId: latestRun?.modelId || Object.keys(DEFAULT_CONFIG.models)[0] || '',
+      headers: latestRun?.headers,
+    });
+    setIsRunConfigOpen(true);
+  };
+
+  const handleStartRun = async () => {
+    if (!benchmark) return;
+    setIsRunConfigOpen(false);
+    const initialStatuses: UseCaseRunStatus[] = benchmark.testCaseIds.map(id => {
+      const testCase = testCases.find(tc => tc.id === id);
+      return { id, name: testCase?.name || id, status: 'pending' as const };
+    });
+    setUseCaseStatuses(initialStatuses);
+    setIsRunning(true);
+    setRunProgress(null);
+    try {
+      await executeBenchmarkRun(
+        benchmark.id, runConfigValues,
+        (progress: BenchmarkProgress) => {
+          setRunProgress(progress);
+          setUseCaseStatuses(prev => prev.map((uc, index) => {
+            if (index < progress.currentTestCaseIndex) return { ...uc, status: 'completed' as const };
+            if (index === progress.currentTestCaseIndex) {
+              const statusMap: Record<BenchmarkProgress['status'], UseCaseRunStatus['status']> = {
+                running: 'running', completed: 'completed', failed: 'failed', cancelled: 'cancelled',
+              };
+              return { ...uc, status: statusMap[progress.status] };
+            }
+            return uc;
+          }));
+        },
+        (startedEvent: BenchmarkStartedEvent) => {
+          setUseCaseStatuses(prev => prev.map(uc => {
+            const serverTc = startedEvent.testCases.find(tc => tc.id === uc.id);
+            return serverTc ? { ...uc, name: serverTc.name } : uc;
+          }));
+        }
+      );
+      setUseCaseStatuses(prev => prev.map(uc => ({ ...uc, status: 'completed' as const })));
+      loadBenchmark();
+    } catch (error) {
+      console.error('Error running benchmark:', error);
+      setUseCaseStatuses(prev => prev.map(uc =>
+        uc.status === 'pending' || uc.status === 'running' ? { ...uc, status: 'failed' as const } : uc
+      ));
+    } finally {
+      setIsRunning(false);
+      setRunProgress(null);
+    }
+  };
+
+  const handleDeleteRun = async (run: BenchmarkRun) => {
+    if (!benchmarkId) return;
+    if (!window.confirm(`Delete run "${run.name}"? This cannot be undone.`)) return;
+    setDeleteState({ isDeleting: true, deletingId: run.id, status: 'idle', message: '' });
+    try {
+      const success = await asyncBenchmarkStorage.deleteRun(benchmarkId, run.id);
+      if (success) {
+        setDeleteState({ isDeleting: false, deletingId: null, status: 'success', message: `"${run.name}" deleted` });
+        setTimeout(() => setDeleteState(s => ({ ...s, status: 'idle', message: '' })), 3000);
+        loadBenchmark();
+      } else {
+        setDeleteState({ isDeleting: false, deletingId: null, status: 'error', message: `Failed to delete "${run.name}"` });
+      }
+    } catch (error) {
+      setDeleteState({ isDeleting: false, deletingId: null, status: 'error',
+        message: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` });
+    }
+  };
+
+  const toggleRunSelection = (runId: string) => {
+    setSelectedRunIds(prev => prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId]);
+  };
+
+  const handleToggleSelectAll = () => {
+    const allRunIds = (benchmark?.runs || []).map(r => r.id);
+    setSelectedRunIds(prev => prev.length === allRunIds.length ? [] : allRunIds);
+  };
+
+  const handleCompareSelected = () => {
+    if (selectedRunIds.length >= 2) navigate(`/compare/${benchmarkId}?runs=${selectedRunIds.join(',')}`);
+  };
+
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  if (!benchmark) {
+    return (
+      <div className="p-6 flex items-center justify-center h-full">
+        <Loader2 size={24} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const runs = benchmark.runs || [];
+  const hasMultipleRuns = runs.length >= 2;
+
+  return (
+    <div className="p-6 h-full flex flex-col">
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <ArrowLeft size={18} />
+          </Button>
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-2xl font-bold">{benchmark.name}</h2>
+              {hasMultipleVersions && (
+                <Badge variant="outline" className="text-xs">v{benchmark.currentVersion}</Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {runs.length} run{runs.length !== 1 ? 's' : ''}
+              {hasMultipleVersions && ` · ${versionData.length} versions`}
+              {runs.length > 0 && ` · Latest: ${formatDate(filteredRuns[0]?.createdAt || runs[0]?.createdAt)}`}
+              {benchmark.description && ` · ${benchmark.description}`}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasMultipleRuns && (
+            <>
+              <Button variant="outline" onClick={handleToggleSelectAll}>
+                {selectedRunIds.length === runs.length
+                  ? <><X size={16} className="mr-2" />Deselect All</>
+                  : <><Check size={16} className="mr-2" />Select All</>}
+              </Button>
+              <Button variant="outline" onClick={handleCompareSelected} disabled={selectedRunIds.length < 2}>
+                <GitCompare size={16} className="mr-2" />Compare ({selectedRunIds.length})
+              </Button>
+            </>
+          )}
+          <Button onClick={handleAddRun} disabled={isRunning} className="bg-opensearch-blue hover:bg-blue-600">
+            {isRunning
+              ? <><Loader2 size={16} className="mr-2 animate-spin" />Running...</>
+              : <><Plus size={16} className="mr-2" />Add Run</>}
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Tabs ───────────────────────────────────────────────────────── */}
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between mb-3">
+          <TabsList>
+            <TabsTrigger value="runs" className="text-xs">
+              Runs {filteredRuns.length > 0 && <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">{filteredRuns.length}</Badge>}
+            </TabsTrigger>
+            <TabsTrigger value="test-cases" className="text-xs">
+              Test Cases {versionTestCases.length > 0 && <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">{versionTestCases.length}</Badge>}
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Version filter — context-aware per tab */}
+          {hasMultipleVersions && activeTab === 'runs' && (
+            <Select
+              value={runVersionFilter === 'all' ? 'all' : String(runVersionFilter)}
+              onValueChange={val => setRunVersionFilter(val === 'all' ? 'all' : Number(val))}
+            >
+              <SelectTrigger className="w-[160px] h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Versions ({runs.length})</SelectItem>
+                {versionData.map(v => (
+                  <SelectItem key={v.version} value={String(v.version)}>
+                    v{v.version} ({v.runCount} run{v.runCount !== 1 ? 's' : ''})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {hasMultipleVersions && activeTab === 'test-cases' && (
+            <Select
+              value={testCaseVersion === null ? 'latest' : String(testCaseVersion)}
+              onValueChange={val => setTestCaseVersion(val === 'latest' ? null : Number(val))}
+            >
+              <SelectTrigger className="w-[140px] h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {versionData.map(v => (
+                  <SelectItem key={v.version} value={v.isLatest ? 'latest' : String(v.version)}>
+                    v{v.version}{v.isLatest ? ' (latest)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        {/* ── Runs Tab ─────────────────────────────────────────────────── */}
+        <TabsContent value="runs" className="flex-1 overflow-y-auto mt-0">
+          {/* Running Progress */}
+          {isRunning && useCaseStatuses.length > 0 && (
+            <Card className="mb-4 border-blue-500/50">
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium flex items-center gap-2">
+                    <Loader2 size={14} className="animate-spin" /> Running...
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {useCaseStatuses.filter(uc => uc.status === 'completed').length} / {useCaseStatuses.length}
+                  </span>
+                </div>
+                <Progress
+                  value={(useCaseStatuses.filter(uc => uc.status === 'completed' || uc.status === 'failed' || uc.status === 'cancelled').length / useCaseStatuses.length) * 100}
+                  className="h-2 mb-3"
+                />
+                <div className="space-y-1 max-h-32 overflow-y-auto">
+                  {useCaseStatuses.map(uc => (
+                    <div key={uc.id} className="flex items-center gap-2 text-xs">
+                      {uc.status === 'pending' && <Circle size={12} className="text-muted-foreground" />}
+                      {uc.status === 'running' && <Loader2 size={12} className="text-blue-700 dark:text-blue-400 animate-spin" />}
+                      {uc.status === 'completed' && <CheckCircle2 size={12} className="text-green-700 dark:text-green-400" />}
+                      {uc.status === 'failed' && <XCircle size={12} className="text-red-700 dark:text-red-400" />}
+                      {uc.status === 'cancelled' && <Ban size={12} className="text-amber-700 dark:text-amber-400" />}
+                      <span className={uc.status === 'running' ? 'text-blue-700 dark:text-blue-400' : uc.status === 'cancelled' ? 'text-amber-700 dark:text-amber-400' : 'text-muted-foreground'}>
+                        {uc.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Delete Feedback */}
+          {deleteState.message && (
+            <div className={`flex items-center gap-2 text-sm mb-4 p-3 rounded-lg ${
+              deleteState.status === 'success'
+                ? 'bg-green-100 text-green-700 border border-green-300 dark:bg-green-500/10 dark:text-green-400 dark:border-green-500/20'
+                : 'bg-red-100 text-red-700 border border-red-300 dark:bg-red-500/10 dark:text-red-400 dark:border-red-500/20'
+            }`}>
+              {deleteState.status === 'success' ? <CheckCircle2 size={16} /> : <XCircle size={16} />}
+              <span>{deleteState.message}</span>
+              {deleteState.status === 'error' && (
+                <Button variant="ghost" size="sm" onClick={() => setDeleteState(s => ({ ...s, status: 'idle', message: '' }))} className="ml-auto h-6 px-2">
+                  <X size={14} />
+                </Button>
+              )}
+            </div>
+          )}
+
+          {/* Runs List — full width */}
+          <div className="space-y-3">
+            {filteredRuns.length === 0 ? (
+              <Card className="border-dashed">
+                <CardContent className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                  <Play size={48} className="mb-4 opacity-20" />
+                  <p className="text-lg font-medium">
+                    {runVersionFilter === 'all' ? 'No runs yet' : `No runs for v${runVersionFilter}`}
+                  </p>
+                  <p className="text-sm">
+                    {runVersionFilter === 'all'
+                      ? 'Run this benchmark to see results here'
+                      : 'Try selecting a different version or "All Versions"'}
+                  </p>
+                </CardContent>
+              </Card>
+            ) : (
+              filteredRuns.map((run, index) => {
+                const stats = getRunStats(run);
+                const isLatestRun = index === 0 && runVersionFilter === 'all';
+                const isSelected = selectedRunIds.includes(run.id);
+
+                return (
+                  <Card
+                    key={run.id}
+                    className={`transition-colors cursor-pointer ${
+                      isSelected ? 'border-primary bg-primary/5' : 'hover:border-primary/50'
+                    }`}
+                    onClick={() => {
+                      const runDetailPath = `/evaluations/benchmarks/${benchmarkId}/runs/${run.id}/inspect`;
+                      navigate(runDetailPath);
+                    }}
+                  >
+                    <CardContent className="p-4">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3 flex-1">
+                          {hasMultipleRuns && (
+                            <Checkbox
+                              checked={isSelected}
+                              onCheckedChange={() => toggleRunSelection(run.id)}
+                              onClick={e => e.stopPropagation()}
+                              className="h-5 w-5"
+                            />
+                          )}
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              <h3 className="font-semibold">{run.name}</h3>
+                              {getEffectiveRunStatus(run) === 'running' && (
+                                <Badge className="text-xs bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-500/20 dark:text-blue-400 dark:border-blue-500/30 animate-pulse">
+                                  <Loader2 size={12} className="mr-1 animate-spin" /> Running
+                                </Badge>
+                              )}
+                              {getEffectiveRunStatus(run) === 'cancelled' && (
+                                <Badge className="text-xs bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-500/20 dark:text-gray-400 dark:border-gray-500/30">
+                                  <XCircle size={12} className="mr-1" /> Cancelled
+                                </Badge>
+                              )}
+                              {isLatestRun && (
+                                <Badge variant="outline" className="text-xs bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-500/10 dark:text-blue-400 dark:border-blue-500/30">
+                                  Latest
+                                </Badge>
+                              )}
+                              {run.benchmarkVersion && benchmark && (
+                                <Badge
+                                  variant="outline"
+                                  className={`text-xs ${
+                                    run.benchmarkVersion < benchmark.currentVersion
+                                      ? 'bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-500/10 dark:text-yellow-400 dark:border-yellow-500/30'
+                                      : 'text-muted-foreground'
+                                  }`}
+                                  title={run.benchmarkVersion < (benchmark.currentVersion || 1)
+                                    ? `Run used v${run.benchmarkVersion}, current is v${benchmark.currentVersion}`
+                                    : `Run used v${run.benchmarkVersion}`}
+                                >
+                                  v{run.benchmarkVersion}
+                                  {run.benchmarkVersion < (benchmark.currentVersion || 1) && ' (outdated)'}
+                                </Badge>
+                              )}
+                            </div>
+                            {run.description && (
+                              <p className="text-sm text-muted-foreground mb-2">{run.description}</p>
+                            )}
+                            <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                              <span className="flex items-center gap-1"><Calendar size={12} />{formatDate(run.createdAt)}</span>
+                              <span>Agent: {DEFAULT_CONFIG.agents.find(a => a.key === run.agentKey)?.name || run.agentKey}</span>
+                              <span>Model: {getModelName(run.modelId)}</span>
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* Stats and Actions */}
+                        <div className="flex items-center gap-4">
+                          {(stats.total > 0 || getEffectiveRunStatus(run) === 'running') && (
+                            <div className="flex items-center gap-4 text-sm">
+                              {stats.running > 0 && (
+                                <span className="flex items-center gap-1 text-blue-700 dark:text-blue-400" title="Running">
+                                  <Loader2 size={14} className="animate-spin" /> {stats.running}
+                                </span>
+                              )}
+                              {stats.pending > 0 && (
+                                <span className="flex items-center gap-1 text-amber-700 dark:text-amber-400" title="Pending">
+                                  <Clock size={14} /> {stats.pending}
+                                </span>
+                              )}
+                              <span className="flex items-center gap-1 text-green-700 dark:text-green-400">
+                                <CheckCircle2 size={14} /> {stats.passed}
+                              </span>
+                              <span className="flex items-center gap-1 text-red-700 dark:text-red-400">
+                                <XCircle size={14} /> {stats.failed}
+                              </span>
+                              <span className="text-muted-foreground">/ {stats.total}</span>
+                            </div>
+                          )}
+                          {getEffectiveRunStatus(run) === 'running' && (
+                            <Button
+                              variant="outline" size="sm"
+                              disabled={isCancelling(run.id)}
+                              onClick={e => { e.stopPropagation(); if (benchmarkId) handleCancelRun(benchmarkId, run.id, loadBenchmark); }}
+                              className="text-red-700 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-500/10 border-red-500/30 disabled:opacity-50"
+                            >
+                              {isCancelling(run.id) ? <Loader2 size={14} className="mr-1 animate-spin" /> : <StopCircle size={14} className="mr-1" />}
+                              {isCancelling(run.id) ? 'Cancelling...' : 'Cancel'}
+                            </Button>
+                          )}
+                          <Button
+                            variant="ghost" size="icon"
+                            onClick={e => { e.stopPropagation(); handleDeleteRun(run); }}
+                            disabled={deleteState.isDeleting && deleteState.deletingId === run.id}
+                            className="text-red-700 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-500/10"
+                            title="Delete run"
+                          >
+                            {deleteState.isDeleting && deleteState.deletingId === run.id
+                              ? <Loader2 size={14} className="animate-spin" />
+                              : <Trash2 size={14} />}
+                          </Button>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+
+          {/* Load More */}
+          {hasMoreRuns && !isLoadingMoreRuns && (
+            <div className="flex justify-center pt-4">
+              <Button variant="outline" onClick={loadMoreRuns}>Load More Runs</Button>
+            </div>
+          )}
+          {isLoadingMoreRuns && (
+            <div className="flex justify-center pt-4">
+              <Loader2 size={20} className="animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {runs.length === 1 && (
+            <p className="text-xs text-muted-foreground text-center mt-4">Add more runs to enable comparison</p>
+          )}
+        </TabsContent>
+
+
+        {/* ── Test Cases Tab ───────────────────────────────────────────── */}
+        <TabsContent value="test-cases" className="flex-1 overflow-y-auto mt-0">
+          {/* Version Metadata */}
+          {selectedVersionData && (
+            <div className="mb-4 p-3 rounded-lg border border-border bg-muted/20">
+              <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1"><Calendar size={12} /> Created {formatDate(selectedVersionData.createdAt)}</span>
+                <span className="font-medium text-foreground">
+                  {versionTestCases.length} test case{versionTestCases.length !== 1 ? 's' : ''}
+                </span>
+                {(selectedVersionData.added.length > 0 || selectedVersionData.removed.length > 0) && (
+                  <>
+                    {selectedVersionData.added.length > 0 && (
+                      <span className="text-green-700 dark:text-green-400">+{selectedVersionData.added.length} added</span>
+                    )}
+                    {selectedVersionData.removed.length > 0 && (
+                      <span className="text-red-700 dark:text-red-400">-{selectedVersionData.removed.length} removed</span>
+                    )}
+                    <span>from v{selectedVersionData.version - 1}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Test Cases List — full width */}
+          <div className="space-y-2">
+            {versionTestCases.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                <p className="text-sm">No test cases in this version</p>
+              </div>
+            ) : (
+              versionTestCases.map(tc => {
+                const isAddedInThisVersion = selectedVersionData?.added.includes(tc.id);
+                return (
+                  <Card
+                    key={tc.id}
+                    className={`cursor-pointer hover:border-primary/50 transition-colors ${
+                      isAddedInThisVersion ? 'border-green-500/30 bg-green-50 dark:bg-green-500/5' : ''
+                    }`}
+                    onClick={() => {
+                      const tcPath = `/evaluations/test-cases/${tc.id}`;
+                      navigate(tcPath);
+                    }}
+                  >
+                    <CardContent className="p-3">
+                      <div className="flex items-center justify-between">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium truncate">{tc.name}</p>
+                            {isAddedInThisVersion && (
+                              <Badge className="text-xs bg-green-100 text-green-700 border-green-300 dark:bg-green-500/20 dark:text-green-400 dark:border-green-500/30">
+                                new
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-2 mt-1 flex-wrap">
+                            {(tc.labels || []).slice(0, 3).map(label => (
+                              <Badge key={label} className={`text-xs ${getLabelColor(label)}`}>{label}</Badge>
+                            ))}
+                            {(tc.labels || []).length > 3 && (
+                              <span className="text-xs text-muted-foreground">+{(tc.labels || []).length - 3}</span>
+                            )}
+                            {tc.category && (
+                              <span className="text-xs text-muted-foreground">· {tc.category}</span>
+                            )}
+                            {tc.difficulty && (
+                              <Badge variant="outline" className="text-[10px]">{tc.difficulty}</Badge>
+                            )}
+                          </div>
+                        </div>
+                        <ChevronRight size={16} className="text-muted-foreground flex-shrink-0" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      {/* ── Run Configuration Dialog ───────────────────────────────────── */}
+      {isRunConfigOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <Card className="w-full max-w-md">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-lg">Configure Run</CardTitle>
+              <Button variant="ghost" size="icon" onClick={() => setIsRunConfigOpen(false)}>
+                <X size={18} />
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="run-name">Run Name</Label>
+                <Input
+                  id="run-name"
+                  value={runConfigValues.name}
+                  onChange={e => setRunConfigValues(prev => ({ ...prev, name: e.target.value }))}
+                  placeholder="e.g., Baseline, With Fix, Claude 4 Test"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="run-description">Description (optional)</Label>
+                <Textarea
+                  id="run-description"
+                  value={runConfigValues.description || ''}
+                  onChange={e => setRunConfigValues(prev => ({ ...prev, description: e.target.value || undefined }))}
+                  placeholder="Describe what this run tests or changes..."
+                  rows={2}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>Agent</Label>
+                  <Select value={runConfigValues.agentKey} onValueChange={val => setRunConfigValues(prev => ({ ...prev, agentKey: val }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {DEFAULT_CONFIG.agents.map(agent => (
+                        <SelectItem key={agent.key} value={agent.key}>{agent.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Judge Model</Label>
+                  <Select value={runConfigValues.modelId} onValueChange={val => setRunConfigValues(prev => ({ ...prev, modelId: val }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(DEFAULT_CONFIG.models).map(([key, model]) => (
+                        <SelectItem key={key} value={key}>{model.display_name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="ghost" onClick={() => setIsRunConfigOpen(false)}>Cancel</Button>
+                <Button onClick={handleStartRun} disabled={!runConfigValues.name.trim()} className="bg-opensearch-blue hover:bg-blue-600">
+                  <Play size={16} className="mr-1" /> Start Run
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/evals3/BenchmarksPage.tsx
+++ b/components/evals3/BenchmarksPage.tsx
@@ -1,0 +1,521 @@
+/*
+ * BenchmarksPage4 — Evals 3: Benchmarks
+ *
+ * Two tabs:
+ *   Tab 1 "Benchmarks" — leaderboard with trend columns, summary cards, last run link
+ *   Tab 2 "Runs" — flattened test case results (click → run detail)
+ *
+ * Agent Traces-style filter bar + sticky table headers + sortable columns.
+ * Global time filter in header scopes everything.
+ */
+
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Play, CheckCircle2, XCircle, Loader2, Clock, Search, X, RefreshCw,
+  Activity, BarChart3, Layers, TrendingUp, TrendingDown, Minus, AlertTriangle,
+  SlidersHorizontal, ChevronDown, Upload, Plus,
+} from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { asyncBenchmarkStorage, asyncTestCaseStorage } from '@/services/storage';
+import { Benchmark, BenchmarkRun, TestCase } from '@/types';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+import { BenchmarkEditor } from '../BenchmarkEditor';
+import { validateTestCasesArrayJson } from '@/lib/testCaseValidation';
+
+// ─── Time Filter ─────────────────────────────────────────────────────────────
+
+type TimeRange = '1h' | '6h' | '1d' | '7d' | '30d' | 'all';
+const TIME_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: '1h', label: 'Last 1h' },
+  { value: '6h', label: 'Last 6h' },
+  { value: '1d', label: 'Last 1d' },
+  { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' },
+  { value: 'all', label: 'All time' },
+];
+
+function getTimeThreshold(range: TimeRange): Date | null {
+  if (range === 'all') return null;
+  const now = new Date();
+  const ms: Record<string, number> = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 };
+  return new Date(now.getTime() - ms[range]);
+}
+
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function computeScore(run: BenchmarkRun): number | null {
+  if (run.stats && run.stats.total > 0) return Math.round((run.stats.passed / run.stats.total) * 100);
+  const results = Object.values(run.results || {});
+  if (results.length === 0) return null;
+  const completed = results.filter(r => r.status === 'completed').length;
+  return Math.round((completed / results.length) * 100);
+}
+
+function ScoreBadge({ score }: { score: number | null }) {
+  if (score === null) return <span className="text-xs text-muted-foreground">—</span>;
+  const cls = score >= 80 ? 'text-green-700 dark:text-green-400' : score >= 50 ? 'text-amber-700 dark:text-amber-400' : 'text-red-700 dark:text-red-400';
+  return <span className={`text-xs font-semibold tabular-nums ${cls}`}>{score}%</span>;
+}
+
+type TrendDir = 'improving' | 'stable' | 'regressing' | 'unknown';
+
+function getTrend(runs: BenchmarkRun[]): TrendDir {
+  if (runs.length < 2) return 'unknown';
+  const sorted = [...runs].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const latest = computeScore(sorted[0]);
+  const prev = computeScore(sorted[1]);
+  if (latest === null || prev === null) return 'unknown';
+  const diff = latest - prev;
+  if (diff > 5) return 'improving';
+  if (diff < -5) return 'regressing';
+  return 'stable';
+}
+
+function TrendBadge({ trend }: { trend: TrendDir }) {
+  const config: Record<TrendDir, { icon: React.ReactNode; label: string; cls: string }> = {
+    improving: { icon: <TrendingUp size={12} />, label: 'Improving', cls: 'text-green-600 dark:text-green-400' },
+    stable: { icon: <Minus size={12} />, label: 'Stable', cls: 'text-muted-foreground' },
+    regressing: { icon: <TrendingDown size={12} />, label: 'Regressing', cls: 'text-red-600 dark:text-red-400' },
+    unknown: { icon: <Minus size={12} />, label: '—', cls: 'text-muted-foreground' },
+  };
+  const c = config[trend];
+  return <span className={`inline-flex items-center gap-1 text-[11px] font-medium ${c.cls}`}>{c.icon} {c.label}</span>;
+}
+
+interface FlatResult {
+  benchmarkId: string; benchmarkName: string; runId: string; runName: string;
+  runCreatedAt: string; agentName: string; testCaseId: string; testCaseName: string;
+  reportId: string | null; resultStatus: string; passed: boolean | null;
+}
+
+interface BenchmarkStats {
+  runCount: number; latestRun: BenchmarkRun | null; latestScore: number | null;
+  bestScore: number | null; worstScore: number | null; trend: TrendDir;
+  passRateHistory: number[]; // pass rates of last N runs, oldest first
+}
+
+// Sort types
+type BmSortField = 'name' | 'tcs' | 'runs' | 'score' | 'best' | 'worst' | 'trend';
+type RunSortField = 'testCase' | 'benchmark' | 'run' | 'agent' | 'timestamp' | 'result';
+type SortDir = 'asc' | 'desc';
+
+/** Tiny inline sparkline for pass rate trend */
+function MiniSparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return <span className="text-[9px] text-muted-foreground">—</span>;
+  const max = 100;
+  const w = 48;
+  const h = 16;
+  const points = values.map((v, i) => `${(i / (values.length - 1)) * w},${h - (v / max) * h}`).join(' ');
+  const lastVal = values[values.length - 1];
+  const prevVal = values[values.length - 2];
+  const color = lastVal >= prevVal ? '#22c55e' : '#ef4444';
+  return (
+    <svg width={w} height={h} className="inline-block">
+      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function SortHeader({ label, active, dir, onClick, className }: {
+  label: string; active: boolean; dir: SortDir; onClick: () => void; className?: string;
+}) {
+  return (
+    <th
+      className={`h-8 px-3 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b cursor-pointer select-none hover:text-foreground transition-colors whitespace-nowrap ${className || ''}`}
+      onClick={onClick}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {active && <ChevronDown size={10} className={dir === 'asc' ? 'rotate-180' : ''} />}
+      </span>
+    </th>
+  );
+}
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const BenchmarksPage4: React.FC = () => {
+  const navigate = useNavigate();
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [testCases, setTestCases] = useState<TestCase[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [timeRange, setTimeRange] = useState<TimeRange>('all');
+  const [selectedAgent, setSelectedAgent] = useState<string>('all');
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Editor/Import state
+  const [showEditor, setShowEditor] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+
+  // Sort state for Benchmarks tab
+  const [bmSort, setBmSort] = useState<{ field: BmSortField; dir: SortDir }>({ field: 'runs', dir: 'desc' });
+  // Sort state for Runs tab
+  const [runSort, setRunSort] = useState<{ field: RunSortField; dir: SortDir }>({ field: 'timestamp', dir: 'desc' });
+
+  const loadData = useCallback(async () => {
+    try {
+      const [bms, tcs] = await Promise.all([
+        asyncBenchmarkStorage.getAll(),
+        asyncTestCaseStorage.getAll(),
+      ]);
+      setBenchmarks(bms);
+      setTestCases(tcs as TestCase[]);
+    } catch (err) {
+      console.error('Failed to load:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  // Scroll detection for sticky header shadow
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const handler = () => setIsScrolled(el.scrollTop > 10);
+    el.addEventListener('scroll', handler);
+    return () => el.removeEventListener('scroll', handler);
+  }, []);
+
+  const tcMap = useMemo(() => new Map(testCases.map(tc => [tc.id, tc])), [testCases]);
+
+  // Agent options from config
+  const agentOptions = useMemo(() => {
+    const agents = DEFAULT_CONFIG.agents.filter(a => a.enabled !== false).map(a => ({ value: a.key, label: a.name }));
+    return [{ value: 'all', label: 'All Agents' }, ...agents];
+  }, []);
+
+  // Time-filter + agent-filter runs
+  const timeFilteredBenchmarks = useMemo(() => {
+    const threshold = getTimeThreshold(timeRange);
+    return benchmarks.map(bm => {
+      let runs = bm.runs || [];
+      if (threshold) runs = runs.filter(r => new Date(r.createdAt) >= threshold);
+      if (selectedAgent !== 'all') runs = runs.filter(r => r.agentKey === selectedAgent);
+      return { ...bm, runs };
+    });
+  }, [benchmarks, timeRange, selectedAgent]);
+
+  // Per-benchmark stats
+  const benchmarkStats = useMemo(() => {
+    const map = new Map<string, BenchmarkStats>();
+    for (const bm of timeFilteredBenchmarks) {
+      const runs = bm.runs || [];
+      const scores = runs.map(r => computeScore(r)).filter((s): s is number => s !== null);
+      const sorted = [...runs].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      map.set(bm.id, {
+        runCount: runs.length, latestRun: sorted[0] || null,
+        latestScore: sorted[0] ? computeScore(sorted[0]) : null,
+        bestScore: scores.length > 0 ? Math.max(...scores) : null,
+        worstScore: scores.length > 0 ? Math.min(...scores) : null,
+        trend: getTrend(runs),
+        passRateHistory: sorted.slice(0, 10).reverse().map(r => computeScore(r) ?? 0),
+      });
+    }
+    return map;
+  }, [timeFilteredBenchmarks]);
+
+  // Summary cards
+  const totalBenchmarks = benchmarks.length;
+  const totalRuns = Array.from(benchmarkStats.values()).reduce((s, bs) => s + bs.runCount, 0);
+  const allScores = Array.from(benchmarkStats.values()).map(bs => bs.latestScore).filter((s): s is number => s !== null);
+  const avgPassRate = allScores.length > 0 ? Math.round(allScores.reduce((a, b) => a + b, 0) / allScores.length) : 0;
+
+  const worstTestCase = useMemo(() => {
+    let worst: { name: string; benchmarkName: string } | null = null;
+    for (const bm of timeFilteredBenchmarks) {
+      const stats = benchmarkStats.get(bm.id);
+      if (!stats?.latestRun) continue;
+      for (const [tcId, result] of Object.entries(stats.latestRun.results || {})) {
+        if (result.status === 'failed') {
+          const tc = tcMap.get(tcId);
+          if (!worst) worst = { name: tc?.name || tcId, benchmarkName: bm.name };
+        }
+      }
+    }
+    return worst;
+  }, [timeFilteredBenchmarks, benchmarkStats, tcMap]);
+
+  // Filtered + sorted benchmarks
+  const sortedBenchmarks = useMemo(() => {
+    let list = timeFilteredBenchmarks;
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(b => b.name.toLowerCase().includes(q));
+    }
+    const dir = bmSort.dir === 'asc' ? 1 : -1;
+    return [...list].sort((a, b) => {
+      const sa = benchmarkStats.get(a.id);
+      const sb = benchmarkStats.get(b.id);
+      switch (bmSort.field) {
+        case 'name': return dir * a.name.localeCompare(b.name);
+        case 'tcs': return dir * (a.testCaseIds.length - b.testCaseIds.length);
+        case 'runs': return dir * ((sa?.runCount || 0) - (sb?.runCount || 0));
+        case 'score': return dir * ((sa?.latestScore ?? -1) - (sb?.latestScore ?? -1));
+        case 'best': return dir * ((sa?.bestScore ?? -1) - (sb?.bestScore ?? -1));
+        case 'worst': return dir * ((sa?.worstScore ?? -1) - (sb?.worstScore ?? -1));
+        case 'trend': return dir * ((sa?.trend || '').localeCompare(sb?.trend || ''));
+        default: return 0;
+      }
+    });
+  }, [timeFilteredBenchmarks, search, bmSort, benchmarkStats]);
+
+  const handleBmSort = (field: BmSortField) => {
+    setBmSort(prev => prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'desc' });
+  };
+
+
+  // Flattened test case results for Runs tab
+  const allFlatResults = useMemo<FlatResult[]>(() => {
+    const rows: FlatResult[] = [];
+    for (const bm of timeFilteredBenchmarks) {
+      for (const run of bm.runs || []) {
+        const agent = DEFAULT_CONFIG.agents.find(a => a.key === run.agentKey)?.name || run.agentKey || 'Unknown';
+        for (const [tcId, result] of Object.entries(run.results || {})) {
+          rows.push({
+            benchmarkId: bm.id, benchmarkName: bm.name, runId: run.id, runName: run.name,
+            runCreatedAt: run.createdAt, agentName: agent, testCaseId: tcId,
+            testCaseName: tcMap.get(tcId)?.name || tcId, reportId: result.reportId || null,
+            resultStatus: result.status,
+            passed: result.status === 'completed' ? true : result.status === 'failed' ? false : null,
+          });
+        }
+      }
+    }
+    return rows;
+  }, [timeFilteredBenchmarks, tcMap]);
+
+  const sortedResults = useMemo(() => {
+    let list = allFlatResults;
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(r => r.benchmarkName.toLowerCase().includes(q) || r.testCaseName.toLowerCase().includes(q) || r.agentName.toLowerCase().includes(q));
+    }
+    const dir = runSort.dir === 'asc' ? 1 : -1;
+    return [...list].sort((a, b) => {
+      switch (runSort.field) {
+        case 'testCase': return dir * a.testCaseName.localeCompare(b.testCaseName);
+        case 'benchmark': return dir * a.benchmarkName.localeCompare(b.benchmarkName);
+        case 'run': return dir * a.runName.localeCompare(b.runName);
+        case 'agent': return dir * a.agentName.localeCompare(b.agentName);
+        case 'timestamp': return dir * (new Date(a.runCreatedAt).getTime() - new Date(b.runCreatedAt).getTime());
+        case 'result': {
+          const order = (p: boolean | null) => p === true ? 0 : p === false ? 1 : 2;
+          return dir * (order(a.passed) - order(b.passed));
+        }
+        default: return 0;
+      }
+    });
+  }, [allFlatResults, search, runSort]);
+
+  const handleRunSort = (field: RunSortField) => {
+    setRunSort(prev => prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'desc' });
+  };
+
+  const totalResults = allFlatResults.length;
+  const passedResults = allFlatResults.filter(r => r.passed === true).length;
+  const resultsPassRate = totalResults > 0 ? Math.round((passedResults / totalResults) * 100) : 0;
+
+  // Import JSON handler
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setIsImporting(true);
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      const validation = validateTestCasesArrayJson(json);
+      if (!validation.valid || !validation.data) return;
+      const result = await asyncTestCaseStorage.bulkCreate(validation.data);
+      if (result.created > 0) {
+        const allTcs = await asyncTestCaseStorage.getAll();
+        const createdIds = (allTcs as TestCase[]).filter(tc => validation.data!.some(d => d.name === tc.name)).map(tc => tc.id);
+        const bm = await asyncBenchmarkStorage.create({
+          name: file.name.replace(/\.json$/i, '') || 'Imported Benchmark',
+          description: `Auto-created from import of ${result.created} test case(s)`,
+          currentVersion: 1,
+          versions: [{ version: 1, createdAt: new Date().toISOString(), testCaseIds: createdIds }],
+          testCaseIds: createdIds, runs: [],
+        });
+        navigate(`/evaluations/benchmarks/${bm.id}/runs`);
+      }
+    } catch (err) { console.error('Import failed:', err); }
+    finally { setIsImporting(false); event.target.value = ''; }
+  };
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 size={24} className="animate-spin text-muted-foreground" /></div>;
+  }
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-xl font-bold">Benchmarks</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">Collections of test cases to run evaluations against your agents</p>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Search */}
+          <div className="w-[200px] relative">
+            <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <Input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)}
+              className="pl-7 h-7 text-xs md:text-xs" />
+          </div>
+          {/* Agent filter */}
+          <Select value={selectedAgent} onValueChange={setSelectedAgent}>
+            <SelectTrigger className="w-[120px] h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {agentOptions.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          {/* Time filter */}
+          <Select value={timeRange} onValueChange={v => setTimeRange(v as TimeRange)}>
+            <SelectTrigger className="w-[85px] h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {TIME_OPTIONS.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          {/* Import JSON */}
+          <input ref={fileInputRef} type="file" accept=".json" className="hidden" onChange={handleImportFile} />
+          <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isImporting} className="h-7 gap-1.5 text-xs font-normal">
+            <Upload size={12} /> {isImporting ? 'Importing...' : 'Import JSON'}
+          </Button>
+          {/* New Benchmark */}
+          <Button size="sm" onClick={() => setShowEditor(true)} className="h-7 gap-1.5 text-xs">
+            <Plus size={12} /> New Benchmark
+          </Button>
+          {/* Refresh */}
+          <Button variant="outline" size="sm" onClick={loadData} disabled={loading} className="h-7">
+            <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          </Button>
+        </div>
+      </div>
+
+
+      {/* ── Inline Metrics Bar ──────────────────────────────────────── */}
+      <div className="flex items-center gap-6 mb-3 text-xs">
+        <div className="flex items-center gap-1.5">
+          <Layers size={13} className="text-purple-500" />
+          <span className="font-semibold">{totalBenchmarks}</span>
+          <span className="text-muted-foreground">benchmarks</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Activity size={13} className="text-blue-500" />
+          <span className="font-semibold">{totalRuns}</span>
+          <span className="text-muted-foreground">runs</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <BarChart3 size={13} className="text-green-500" />
+          <span className={`font-semibold ${avgPassRate >= 50 ? 'text-green-500' : 'text-red-500'}`}>{avgPassRate}%</span>
+          <span className="text-muted-foreground">avg pass rate</span>
+        </div>
+      </div>
+
+      {/* ── Benchmarks Table ──────────────────────────────────────── */}
+      <div className="flex-1 overflow-hidden">
+          <div ref={scrollRef} className="h-full overflow-y-auto rounded-lg border border-border">
+            <table className="w-full caption-bottom text-sm">
+              <thead className={`sticky top-0 z-10 bg-background transition-shadow duration-200 ${isScrolled ? 'shadow-sm' : ''}`}>
+                <tr className="border-b">
+                  <SortHeader label="Name" active={bmSort.field === 'name'} dir={bmSort.dir} onClick={() => handleBmSort('name')} />
+                  <SortHeader label="# TCs" active={bmSort.field === 'tcs'} dir={bmSort.dir} onClick={() => handleBmSort('tcs')} className="text-center" />
+                  <SortHeader label="Runs" active={bmSort.field === 'runs'} dir={bmSort.dir} onClick={() => handleBmSort('runs')} className="text-center" />
+                  <th className="h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Last Run</th>
+                  <SortHeader label="Latest Result" active={bmSort.field === 'score'} dir={bmSort.dir} onClick={() => handleBmSort('score')} className="text-center" />
+                  <th className="h-7 px-2 text-center align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Trend</th>
+                  <th className="h-7 px-2 text-right align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="[&_tr:last-child]:border-0">
+                {sortedBenchmarks.length === 0 ? (
+                  <tr><td colSpan={8} className="py-12 text-center text-sm text-muted-foreground">No benchmarks found</td></tr>
+                ) : (
+                  sortedBenchmarks.map(bm => {
+                    const stats = benchmarkStats.get(bm.id);
+                    const lr = stats?.latestRun;
+                    return (
+                      <tr key={bm.id} className="border-b hover:bg-muted/50 cursor-pointer transition-colors"
+                        onClick={() => navigate(`/evaluations/benchmarks/${bm.id}/runs`)}>
+                        <td className="px-2 py-1.5 align-middle">
+                          <div className="text-xs font-medium truncate max-w-[220px]">{bm.name}</div>
+                          {bm.description && <div className="text-[9px] text-muted-foreground truncate max-w-[220px]">{bm.description}</div>}
+                        </td>
+                        <td className="px-2 py-1.5 align-middle text-center text-[11px]">{bm.testCaseIds.length}</td>
+                        <td className="px-2 py-1.5 align-middle text-center text-[11px]">{stats?.runCount || 0}</td>
+                        <td className="px-2 py-1.5 align-middle">
+                          {lr ? (
+                            <button className="text-[10px] text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
+                              onClick={e => { e.stopPropagation(); navigate(`/evaluations/benchmarks/${bm.id}/runs/${lr.id}`); }}>
+                              {formatRelativeTime(lr.createdAt)}
+                            </button>
+                          ) : <span className="text-[10px] text-muted-foreground">—</span>}
+                        </td>
+                        <td className="px-2 py-1.5 align-middle text-center">
+                          {lr ? (() => {
+                            const passed = lr.stats?.passed ?? 0;
+                            const failed = lr.stats?.failed ?? 0;
+                            const total = lr.stats?.total ?? Object.keys(lr.results || {}).length;
+                            return (
+                              <div className="inline-flex items-center gap-1.5 text-[11px]">
+                                <span className="inline-flex items-center gap-0.5">
+                                  <CheckCircle2 size={11} className="text-green-500" />
+                                  <span className="text-green-500 font-medium">{passed}</span>
+                                </span>
+                                <span className="inline-flex items-center gap-0.5">
+                                  <XCircle size={11} className="text-red-400" />
+                                  <span className="text-red-400 font-medium">{failed}</span>
+                                </span>
+                                <span className="text-muted-foreground">/ {total}</span>
+                              </div>
+                            );
+                          })() : <span className="text-[11px] text-muted-foreground">—</span>}
+                        </td>
+                        <td className="px-2 py-1.5 align-middle text-center">
+                          <div className="inline-flex items-center gap-1.5">
+                            <MiniSparkline values={stats?.passRateHistory || []} />
+                            <TrendBadge trend={stats?.trend || 'unknown'} />
+                          </div>
+                        </td>
+                        <td className="px-2 py-1.5 align-middle text-right">
+                          <button className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded border border-border hover:bg-muted transition-colors"
+                            onClick={e => { e.stopPropagation(); navigate(`/evaluations/benchmarks/${bm.id}/runs`); }}>
+                            <Play size={9} /> Run
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      {/* Benchmark Editor Modal */}
+      {showEditor && (
+        <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm">
+          <div className="fixed inset-4 z-50 overflow-auto bg-background border rounded-lg shadow-lg">
+            <BenchmarkEditor
+              benchmark={null}
+              onSave={(bm) => { setShowEditor(false); navigate(`/evaluations/benchmarks/${bm.id}/runs`); }}
+              onCancel={() => setShowEditor(false)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/evals3/ComparePage.tsx
+++ b/components/evals3/ComparePage.tsx
@@ -1,0 +1,600 @@
+/*
+ * ComparePage — Diff-First Compare View (Option A)
+ *
+ * Leads with what changed between runs. Think "git diff for eval runs."
+ * - Top: benchmark selector + run picker
+ * - Change summary strip: regressions / improvements / unchanged (clickable filters)
+ * - Compact run summary bar (not full cards)
+ * - Diff table: only changed rows by default, toggle to show all
+ * - Each row: clear ↑↓= indicator with delta prominently displayed
+ *
+ * Route: /evaluations/compare
+ */
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  GitCompare, ChevronDown, ChevronRight, CheckCircle2, XCircle,
+  TrendingDown, TrendingUp, Minus, ArrowRightLeft, Eye, EyeOff,
+  ArrowLeft, Loader2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { asyncBenchmarkStorage, asyncRunStorage } from '@/services/storage';
+import {
+  calculateRunAggregates,
+  buildTestCaseComparisonRows,
+  getRealTestCaseMeta,
+  countRowsByStatus,
+  calculateRowStatus,
+  RowStatus,
+} from '@/services/comparisonService';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+import type {
+  Benchmark, BenchmarkRun, EvaluationReport,
+  RunAggregateMetrics, TestCaseComparisonRow,
+} from '@/types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const getAgentName = (key: string) =>
+  DEFAULT_CONFIG.agents.find(a => a.key === key)?.name || key;
+
+type DiffFilter = 'all' | RowStatus;
+
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+/** Compact run bar — one row per run showing key stats */
+function RunBar({ agg, isBaseline }: { agg: RunAggregateMetrics; isBaseline: boolean }) {
+  return (
+    <div className={`flex items-center gap-4 px-4 py-2 rounded-lg border text-xs ${
+      isBaseline ? 'border-primary/30 bg-primary/5' : 'border-border bg-card'
+    }`}>
+      {isBaseline && (
+        <Badge variant="outline" className="text-[9px] px-1.5 py-0 border-primary/40 text-primary">
+          Baseline
+        </Badge>
+      )}
+      <span className="font-medium truncate max-w-[180px]">{agg.runName}</span>
+      <span className="text-muted-foreground">{getAgentName(agg.agentKey)}</span>
+      <span className="text-muted-foreground">{getModelName(agg.modelId)}</span>
+      <span className="text-muted-foreground">{formatRelativeTime(agg.createdAt)}</span>
+      <div className="ml-auto flex items-center gap-3">
+        <span>
+          <span className="text-green-500 font-medium">{agg.passedCount}</span>
+          <span className="text-muted-foreground"> / </span>
+          <span className="text-red-500 font-medium">{agg.failedCount}</span>
+          <span className="text-muted-foreground"> / {agg.totalTestCases}</span>
+        </span>
+        <span className="font-medium">{agg.passRatePercent}%</span>
+        <span className="text-muted-foreground">Acc {agg.avgAccuracy}%</span>
+      </div>
+    </div>
+  );
+}
+
+/** Change summary strip — clickable chips */
+function ChangeSummary({
+  counts,
+  activeFilter,
+  onFilterClick,
+}: {
+  counts: Record<RowStatus, number>;
+  activeFilter: DiffFilter;
+  onFilterClick: (f: DiffFilter) => void;
+}) {
+  const total = counts.regression + counts.improvement + counts.mixed + counts.neutral;
+  const items: Array<{
+    key: DiffFilter;
+    label: string;
+    count: number;
+    icon: React.ReactNode;
+    color: string;
+    activeColor: string;
+  }> = [
+    { key: 'all', label: 'All', count: total, icon: null, color: '', activeColor: 'bg-primary/20 border-primary text-primary' },
+    { key: 'regression', label: 'Regressions', count: counts.regression, icon: <TrendingDown size={12} />, color: 'text-red-400', activeColor: 'bg-red-500/10 border-red-500/30 text-red-400' },
+    { key: 'improvement', label: 'Improvements', count: counts.improvement, icon: <TrendingUp size={12} />, color: 'text-blue-400', activeColor: 'bg-blue-500/10 border-blue-500/30 text-blue-400' },
+    { key: 'mixed', label: 'Mixed', count: counts.mixed, icon: <ArrowRightLeft size={12} />, color: 'text-amber-400', activeColor: 'bg-amber-500/10 border-amber-500/30 text-amber-400' },
+    { key: 'neutral', label: 'Unchanged', count: counts.neutral, icon: <Minus size={12} />, color: 'text-muted-foreground', activeColor: 'bg-muted border-muted text-muted-foreground' },
+  ];
+
+  return (
+    <div className="flex items-center gap-2">
+      {items.map(item => (
+        <button
+          key={item.key}
+          onClick={() => onFilterClick(item.key)}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
+            activeFilter === item.key ? item.activeColor : 'border-border hover:bg-muted/50 text-muted-foreground'
+          }`}
+        >
+          {item.icon && <span className={activeFilter === item.key ? '' : item.color}>{item.icon}</span>}
+          {item.label}
+          <span className="opacity-70">({item.count})</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+
+/** Delta indicator — shows ↑↓= with value */
+function DeltaIndicator({ value, baseline }: { value?: number; baseline?: number }) {
+  if (value === undefined || baseline === undefined) return <span className="text-muted-foreground">—</span>;
+  const delta = value - baseline;
+  if (delta === 0) return <span className="text-muted-foreground text-xs">=</span>;
+  const isPositive = delta > 0;
+  return (
+    <span className={`inline-flex items-center gap-0.5 text-xs font-medium ${isPositive ? 'text-blue-500' : 'text-red-400'}`}>
+      {isPositive ? <TrendingUp size={11} /> : <TrendingDown size={11} />}
+      {isPositive ? '+' : ''}{delta}
+    </span>
+  );
+}
+
+/** Single diff row for a test case */
+function DiffRow({
+  row,
+  runs,
+  baselineRunId,
+  rowStatus,
+  isExpanded,
+  onToggle,
+}: {
+  row: TestCaseComparisonRow;
+  runs: BenchmarkRun[];
+  baselineRunId: string;
+  rowStatus: RowStatus;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const baselineResult = row.results[baselineRunId];
+  const statusStyles: Record<RowStatus, string> = {
+    regression: 'border-l-4 border-l-red-500/50',
+    improvement: 'border-l-4 border-l-blue-500/50',
+    mixed: 'border-l-4 border-l-amber-500/50',
+    neutral: 'border-l-4 border-l-transparent',
+  };
+  const statusIcons: Record<RowStatus, React.ReactNode> = {
+    regression: <TrendingDown size={13} className="text-red-400" />,
+    improvement: <TrendingUp size={13} className="text-blue-500" />,
+    mixed: <ArrowRightLeft size={13} className="text-amber-400" />,
+    neutral: <Minus size={13} className="text-muted-foreground" />,
+  };
+
+  return (
+    <>
+      <tr
+        className={`border-b hover:bg-muted/30 cursor-pointer transition-colors ${statusStyles[rowStatus]}`}
+        onClick={onToggle}
+      >
+        {/* Status icon */}
+        <td className="px-3 py-2.5 w-8 text-center">{statusIcons[rowStatus]}</td>
+        {/* Test case name */}
+        <td className="px-3 py-2.5">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">
+              {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            </span>
+            <span className="text-sm font-medium truncate max-w-[240px]">{row.testCaseName}</span>
+            {row.labels?.slice(0, 2).map(l => (
+              <Badge key={l} variant="outline" className="text-[9px] px-1 py-0">{l}</Badge>
+            ))}
+          </div>
+        </td>
+        {/* Per-run results */}
+        {runs.map(run => {
+          const result = row.results[run.id];
+          const isBaseline = run.id === baselineRunId;
+          if (!result || result.status === 'missing') {
+            return <td key={run.id} className="px-3 py-2.5 text-center text-xs text-muted-foreground">—</td>;
+          }
+          const isPassed = result.passFailStatus === 'passed';
+          return (
+            <td key={run.id} className="px-3 py-2.5 text-center">
+              <div className="flex flex-col items-center gap-0.5">
+                <div className={`inline-flex items-center gap-1 text-xs font-medium ${isPassed ? 'text-green-500' : 'text-red-400'}`}>
+                  {isPassed ? <CheckCircle2 size={12} /> : <XCircle size={12} />}
+                  {result.accuracy ?? 0}%
+                </div>
+                {!isBaseline && (
+                  <DeltaIndicator value={result.accuracy} baseline={baselineResult?.accuracy} />
+                )}
+                {isBaseline && <span className="text-[9px] text-muted-foreground">baseline</span>}
+              </div>
+            </td>
+          );
+        })}
+      </tr>
+      {/* Expanded detail */}
+      {isExpanded && (
+        <tr className="bg-muted/20">
+          <td colSpan={2 + runs.length} className="px-6 py-3">
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 text-xs">
+              {runs.map(run => {
+                const result = row.results[run.id];
+                if (!result || result.status === 'missing') return null;
+                const isBaseline = run.id === baselineRunId;
+                return (
+                  <div key={run.id} className={`p-3 rounded-lg border ${isBaseline ? 'border-primary/30 bg-primary/5' : 'border-border bg-card'}`}>
+                    <div className="font-medium mb-2 truncate">{run.name}</div>
+                    <div className="space-y-1 text-muted-foreground">
+                      <div className="flex justify-between">
+                        <span>Status</span>
+                        <span className={result.passFailStatus === 'passed' ? 'text-green-500' : 'text-red-400'}>
+                          {result.passFailStatus === 'passed' ? 'Passed' : 'Failed'}
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>Accuracy</span>
+                        <span className="text-foreground">{result.accuracy ?? 0}%</span>
+                      </div>
+                      {result.testCaseVersion && (
+                        <div className="flex justify-between">
+                          <span>Version</span>
+                          <span className="text-foreground">{result.testCaseVersion}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const ComparePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Data
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reports, setReports] = useState<Record<string, EvaluationReport>>({});
+  const [reportsLoading, setReportsLoading] = useState(false);
+
+  // Selection
+  const [selectedBenchmarkId, setSelectedBenchmarkId] = useState<string>('');
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
+
+  // View state
+  const [diffFilter, setDiffFilter] = useState<DiffFilter>('all');
+  const [showUnchanged, setShowUnchanged] = useState(true);
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  // Load all benchmarks
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const bms = await asyncBenchmarkStorage.getAll();
+        setBenchmarks(bms);
+
+        // Initialize from URL params
+        const urlBm = searchParams.get('benchmark');
+        const urlRuns = searchParams.get('runs')?.split(',').filter(Boolean) || [];
+
+        // Helper: pick the last 2 runs by date from a benchmark
+        const pickLastTwoRuns = (bm: Benchmark) => {
+          const sorted = [...(bm.runs || [])].sort(
+            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
+          return sorted.slice(0, 2).map(r => r.id);
+        };
+
+        if (urlBm && bms.some(b => b.id === urlBm)) {
+          setSelectedBenchmarkId(urlBm);
+          const bm = bms.find(b => b.id === urlBm)!;
+          const validRuns = urlRuns.filter(id => bm.runs.some(r => r.id === id));
+          setSelectedRunIds(validRuns.length >= 2 ? validRuns : pickLastTwoRuns(bm));
+        } else if (bms.length > 0) {
+          // Default: benchmark with the most recent run, last 2 runs selected
+          const sorted = [...bms]
+            .filter(b => (b.runs?.length || 0) >= 2)
+            .sort((a, b) => {
+              const latestA = Math.max(...(a.runs || []).map(r => new Date(r.createdAt).getTime()));
+              const latestB = Math.max(...(b.runs || []).map(r => new Date(r.createdAt).getTime()));
+              return latestB - latestA;
+            });
+          const defaultBm = sorted[0] || bms.find(b => (b.runs?.length || 0) >= 2) || bms[0];
+          setSelectedBenchmarkId(defaultBm.id);
+          setSelectedRunIds(pickLastTwoRuns(defaultBm));
+        }
+      } catch (err) {
+        console.error('Failed to load benchmarks:', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Current benchmark
+  const benchmark = useMemo(
+    () => benchmarks.find(b => b.id === selectedBenchmarkId) || null,
+    [benchmarks, selectedBenchmarkId]
+  );
+
+  // Load reports when benchmark/runs change
+  useEffect(() => {
+    if (!benchmark) return;
+    (async () => {
+      setReportsLoading(true);
+      const reportIds = new Set<string>();
+      for (const run of benchmark.runs) {
+        if (!selectedRunIds.includes(run.id)) continue;
+        Object.values(run.results || {}).forEach(r => {
+          if (r.reportId) reportIds.add(r.reportId);
+        });
+      }
+      const map: Record<string, EvaluationReport> = {};
+      await Promise.all(
+        Array.from(reportIds).map(async id => {
+          const report = await asyncRunStorage.getReportById(id);
+          if (report) map[id] = report;
+        })
+      );
+      setReports(map);
+      setReportsLoading(false);
+    })();
+  }, [benchmark, selectedRunIds]);
+
+  // Update URL when selection changes
+  const updateUrl = useCallback((bmId: string, runIds: string[]) => {
+    const params: Record<string, string> = {};
+    if (bmId) params.benchmark = bmId;
+    if (runIds.length > 0) params.runs = runIds.join(',');
+    setSearchParams(params, { replace: true });
+  }, [setSearchParams]);
+
+  // Handle benchmark change
+  const handleBenchmarkChange = (bmId: string) => {
+    setSelectedBenchmarkId(bmId);
+    const bm = benchmarks.find(b => b.id === bmId);
+    // Default to last 2 runs by date
+    const sorted = [...(bm?.runs || [])].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+    const newRunIds = sorted.slice(0, 2).map(r => r.id);
+    setSelectedRunIds(newRunIds);
+    setDiffFilter('all');
+    setExpandedRows(new Set());
+    updateUrl(bmId, newRunIds);
+  };
+
+  // Toggle run selection
+  const toggleRun = (runId: string) => {
+    setSelectedRunIds(prev => {
+      const next = prev.includes(runId)
+        ? prev.filter(id => id !== runId)
+        : [...prev, runId];
+      if (next.length < 2 && next.length < prev.length) return prev; // keep min 2
+      updateUrl(selectedBenchmarkId, next);
+      return next;
+    });
+  };
+
+  // Selected runs
+  const selectedRuns = useMemo(
+    () => (benchmark?.runs || []).filter(r => selectedRunIds.includes(r.id)),
+    [benchmark, selectedRunIds]
+  );
+
+  // Aggregates
+  const runAggregates = useMemo(
+    () => selectedRuns.map(run => calculateRunAggregates(run, reports)),
+    [selectedRuns, reports]
+  );
+
+  // Baseline = oldest selected run
+  const baselineRunId = useMemo(() => {
+    const sorted = [...selectedRuns].sort((a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+    return sorted[0]?.id ?? '';
+  }, [selectedRuns]);
+
+  // Comparison rows
+  const allRows = useMemo(
+    () => buildTestCaseComparisonRows(selectedRuns, reports, getRealTestCaseMeta),
+    [selectedRuns, reports]
+  );
+
+  // Status counts
+  const statusCounts = useMemo(
+    () => countRowsByStatus(allRows, baselineRunId),
+    [allRows, baselineRunId]
+  );
+
+  // Filtered rows
+  const filteredRows = useMemo(() => {
+    if (diffFilter === 'all') {
+      return showUnchanged ? allRows : allRows.filter(r => calculateRowStatus(r, baselineRunId) !== 'neutral');
+    }
+    return allRows.filter(r => calculateRowStatus(r, baselineRunId) === diffFilter);
+  }, [allRows, diffFilter, showUnchanged, baselineRunId]);
+
+  const toggleExpand = (id: string) => {
+    setExpandedRows(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 size={24} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="p-4 h-full flex flex-col">
+        {/* ── Header ─────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" onClick={() => navigate(-1)} className="h-8 w-8">
+              <ArrowLeft size={16} />
+            </Button>
+            <GitCompare className="h-5 w-5 text-primary" />
+            <div>
+              <h2 className="text-xl font-bold">Compare Runs</h2>
+              <p className="text-[11px] text-muted-foreground mt-0.5">Diff-first comparison across benchmark runs</p>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Benchmark + Run Selector ───────────────────────────── */}
+        <div className="flex items-start gap-4 mb-4 p-4 rounded-lg border border-border bg-card">
+          <div className="space-y-1.5">
+            <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Benchmark</label>
+            <Select value={selectedBenchmarkId} onValueChange={handleBenchmarkChange}>
+              <SelectTrigger className="w-[260px] h-8 text-xs">
+                <SelectValue placeholder="Select benchmark" />
+              </SelectTrigger>
+              <SelectContent>
+                {benchmarks.map(bm => (
+                  <SelectItem key={bm.id} value={bm.id}>
+                    <div className="flex items-center gap-2">
+                      <span>{bm.name}</span>
+                      <span className="text-[10px] text-muted-foreground">({bm.runs?.length || 0} runs)</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex-1 space-y-1.5">
+            <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+              Runs to compare ({selectedRunIds.length} selected)
+            </label>
+            <div className="flex flex-wrap gap-3">
+              {(benchmark?.runs || []).map(run => {
+                const isSelected = selectedRunIds.includes(run.id);
+                const canDeselect = selectedRunIds.length > 2;
+                return (
+                  <div key={run.id} className="flex items-center gap-1.5">
+                    <Checkbox
+                      id={`run-${run.id}`}
+                      checked={isSelected}
+                      onCheckedChange={() => toggleRun(run.id)}
+                      disabled={isSelected && !canDeselect}
+                      className="h-3.5 w-3.5"
+                    />
+                    <Label htmlFor={`run-${run.id}`} className="text-xs cursor-pointer">
+                      {run.name}
+                    </Label>
+                  </div>
+                );
+              })}
+            </div>
+            {selectedRunIds.length <= 2 && (
+              <p className="text-[10px] text-muted-foreground">At least 2 runs must be selected</p>
+            )}
+          </div>
+        </div>
+
+        {/* ── Content (needs 2+ runs) ────────────────────────────── */}
+        {selectedRuns.length >= 2 && !reportsLoading ? (
+          <>
+            {/* Compact run bars */}
+            <div className="space-y-1.5 mb-4">
+              {runAggregates.map(agg => (
+                <RunBar key={agg.runId} agg={agg} isBaseline={agg.runId === baselineRunId} />
+              ))}
+            </div>
+
+            {/* Change summary strip */}
+            <div className="flex items-center justify-between mb-4">
+              <ChangeSummary counts={statusCounts} activeFilter={diffFilter} onFilterClick={setDiffFilter} />
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setShowUnchanged(!showUnchanged)}
+                  className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-xs transition-colors ${
+                    showUnchanged ? 'border-border text-muted-foreground hover:bg-muted/50' : 'border-primary/30 bg-primary/5 text-primary'
+                  }`}
+                >
+                  {showUnchanged ? <Eye size={12} /> : <EyeOff size={12} />}
+                  {showUnchanged ? 'Showing all' : 'Changes only'}
+                </button>
+              </div>
+            </div>
+
+            {/* Diff table */}
+            <div className="flex-1 overflow-y-auto rounded-lg border border-border">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 z-10 bg-background">
+                  <tr className="border-b">
+                    <th className="h-8 w-8 px-3 bg-background border-b" />
+                    <th className="h-8 px-3 text-left font-medium text-xs text-muted-foreground bg-background border-b">
+                      Test Case
+                    </th>
+                    {selectedRuns.map(run => (
+                      <th key={run.id} className="h-8 px-3 text-center font-medium text-xs text-muted-foreground bg-background border-b min-w-[120px]">
+                        <div className="truncate">{run.name}</div>
+                        {run.id === baselineRunId && (
+                          <span className="text-[8px] text-primary font-normal">(baseline)</span>
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredRows.length === 0 ? (
+                    <tr>
+                      <td colSpan={2 + selectedRuns.length} className="py-12 text-center text-sm text-muted-foreground">
+                        {diffFilter !== 'all'
+                          ? `No ${diffFilter} test cases found`
+                          : 'No test cases to compare'}
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredRows.map(row => (
+                      <DiffRow
+                        key={row.testCaseId}
+                        row={row}
+                        runs={selectedRuns}
+                        baselineRunId={baselineRunId}
+                        rowStatus={calculateRowStatus(row, baselineRunId)}
+                        isExpanded={expandedRows.has(row.testCaseId)}
+                        onToggle={() => toggleExpand(row.testCaseId)}
+                      />
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : reportsLoading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 size={20} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
+            <GitCompare className="h-12 w-12 mb-4 opacity-50" />
+            <p className="text-sm">Select a benchmark with at least 2 runs to compare</p>
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/components/evals3/ComparePage2.tsx
+++ b/components/evals3/ComparePage2.tsx
@@ -1,0 +1,400 @@
+/*
+ * ComparePage2 — Scorecard Compare View (Option B)
+ *
+ * Vertical scorecard columns per run. Each run gets a column with:
+ * - Header card: overall stats (pass rate, accuracy, model, agent, timestamp)
+ * - Test case rows: colored status dots (green/red/gray)
+ * - Delta gutter between columns showing arrows and % changes
+ * - Baseline run gets a subtle highlight
+ * - Bottom: mini bar chart showing pass rate per run
+ *
+ * Route: /evaluations/compare2
+ */
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  GitCompare, CheckCircle2, XCircle, Minus,
+  TrendingDown, TrendingUp, ArrowLeft, Loader2, ChevronDown,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { asyncBenchmarkStorage, asyncRunStorage } from '@/services/storage';
+import {
+  calculateRunAggregates,
+  buildTestCaseComparisonRows,
+  getRealTestCaseMeta,
+} from '@/services/comparisonService';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+import type {
+  Benchmark, BenchmarkRun, EvaluationReport,
+  RunAggregateMetrics, TestCaseComparisonRow,
+} from '@/types';
+
+const getAgentName = (key: string) =>
+  DEFAULT_CONFIG.agents.find(a => a.key === key)?.name || key;
+
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+/** Scorecard header for a single run */
+function ScorecardHeader({ agg, isBaseline }: { agg: RunAggregateMetrics; isBaseline: boolean }) {
+  const passRate = agg.passRatePercent;
+  const barColor = passRate >= 80 ? 'bg-green-500' : passRate >= 50 ? 'bg-amber-500' : 'bg-red-500';
+
+  return (
+    <div className={`p-3 rounded-lg border ${isBaseline ? 'border-primary/40 bg-primary/5' : 'border-border bg-card'}`}>
+      {isBaseline && (
+        <Badge variant="outline" className="text-[8px] px-1 py-0 border-primary/40 text-primary mb-1.5">
+          Baseline
+        </Badge>
+      )}
+      <div className="text-sm font-semibold truncate mb-1">{agg.runName}</div>
+      <div className="text-[10px] text-muted-foreground space-y-0.5">
+        <div>{getAgentName(agg.agentKey)}</div>
+        <div>{getModelName(agg.modelId)}</div>
+        <div>{formatRelativeTime(agg.createdAt)}</div>
+      </div>
+      {/* Pass rate bar */}
+      <div className="mt-2">
+        <div className="flex items-center justify-between text-[10px] mb-0.5">
+          <span className="text-muted-foreground">Pass Rate</span>
+          <span className="font-semibold">{passRate}%</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+          <div className={`h-full rounded-full ${barColor} transition-all`} style={{ width: `${passRate}%` }} />
+        </div>
+      </div>
+      {/* Stats row */}
+      <div className="flex items-center gap-2 mt-2 text-[10px]">
+        <span className="text-green-500 font-medium">{agg.passedCount}P</span>
+        <span className="text-red-400 font-medium">{agg.failedCount}F</span>
+        <span className="text-muted-foreground">/ {agg.totalTestCases}</span>
+        <span className="ml-auto text-muted-foreground">Acc {agg.avgAccuracy}%</span>
+      </div>
+    </div>
+  );
+}
+
+/** Delta gutter between two columns */
+function DeltaGutter({ left, right }: { left?: RunAggregateMetrics; right?: RunAggregateMetrics }) {
+  if (!left || !right) return null;
+  const passRateDelta = right.passRatePercent - left.passRatePercent;
+  const accDelta = right.avgAccuracy - left.avgAccuracy;
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-1 px-1 min-w-[40px]">
+      <DeltaChip value={passRateDelta} label="PR" />
+      <DeltaChip value={accDelta} label="Acc" />
+    </div>
+  );
+}
+
+function DeltaChip({ value, label }: { value: number; label: string }) {
+  if (value === 0) return (
+    <div className="text-[9px] text-muted-foreground text-center">
+      <div>=</div>
+      <div>{label}</div>
+    </div>
+  );
+  const isPositive = value > 0;
+  return (
+    <div className={`text-[9px] text-center font-medium ${isPositive ? 'text-green-500' : 'text-red-400'}`}>
+      <div className="flex items-center gap-0.5 justify-center">
+        {isPositive ? <TrendingUp size={9} /> : <TrendingDown size={9} />}
+        {isPositive ? '+' : ''}{value}
+      </div>
+      <div className="text-muted-foreground font-normal">{label}</div>
+    </div>
+  );
+}
+
+/** Status dot for a test case result */
+function StatusDot({ status, accuracy }: { status?: string; accuracy?: number }) {
+  if (!status || status === 'missing') {
+    return <div className="w-3 h-3 rounded-full bg-muted border border-border" title="Not run" />;
+  }
+  const isPassed = status === 'passed';
+  return (
+    <div
+      className={`w-3 h-3 rounded-full ${isPassed ? 'bg-green-500' : 'bg-red-400'}`}
+      title={`${isPassed ? 'Passed' : 'Failed'}${accuracy !== undefined ? ` — ${accuracy}%` : ''}`}
+    />
+  );
+}
+
+/** Mini pass rate bar chart at the bottom */
+function PassRateChart({ aggregates, baselineRunId }: { aggregates: RunAggregateMetrics[]; baselineRunId: string }) {
+  const maxRate = 100;
+  return (
+    <div className="flex items-end gap-3 h-16 px-2">
+      {aggregates.map(agg => {
+        const height = Math.max(4, (agg.passRatePercent / maxRate) * 100);
+        const isBaseline = agg.runId === baselineRunId;
+        const barColor = agg.passRatePercent >= 80 ? 'bg-green-500' : agg.passRatePercent >= 50 ? 'bg-amber-500' : 'bg-red-400';
+        return (
+          <div key={agg.runId} className="flex flex-col items-center gap-0.5 flex-1">
+            <span className="text-[9px] font-medium">{agg.passRatePercent}%</span>
+            <div
+              className={`w-full rounded-t ${barColor} ${isBaseline ? 'ring-1 ring-primary/50' : ''} transition-all`}
+              style={{ height: `${height}%`, minHeight: '4px' }}
+            />
+            <span className="text-[8px] text-muted-foreground truncate max-w-full text-center">{agg.runName}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const ComparePage2: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reports, setReports] = useState<Record<string, EvaluationReport>>({});
+  const [reportsLoading, setReportsLoading] = useState(false);
+  const [selectedBenchmarkId, setSelectedBenchmarkId] = useState<string>('');
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
+
+  // Load benchmarks
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const bms = await asyncBenchmarkStorage.getAll();
+        setBenchmarks(bms);
+
+        const urlBm = searchParams.get('benchmark');
+        const urlRuns = searchParams.get('runs')?.split(',').filter(Boolean) || [];
+
+        const pickLastTwo = (bm: Benchmark) => {
+          const sorted = [...(bm.runs || [])].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+          return sorted.slice(0, 2).map(r => r.id);
+        };
+
+        if (urlBm && bms.some(b => b.id === urlBm)) {
+          setSelectedBenchmarkId(urlBm);
+          const bm = bms.find(b => b.id === urlBm)!;
+          const valid = urlRuns.filter(id => bm.runs.some(r => r.id === id));
+          setSelectedRunIds(valid.length >= 2 ? valid : pickLastTwo(bm));
+        } else if (bms.length > 0) {
+          const sorted = [...bms].filter(b => (b.runs?.length || 0) >= 2)
+            .sort((a, b) => {
+              const la = Math.max(...(a.runs || []).map(r => new Date(r.createdAt).getTime()));
+              const lb = Math.max(...(b.runs || []).map(r => new Date(r.createdAt).getTime()));
+              return lb - la;
+            });
+          const def = sorted[0] || bms[0];
+          setSelectedBenchmarkId(def.id);
+          setSelectedRunIds(pickLastTwo(def));
+        }
+      } catch (err) { console.error(err); }
+      finally { setLoading(false); }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const benchmark = useMemo(() => benchmarks.find(b => b.id === selectedBenchmarkId) || null, [benchmarks, selectedBenchmarkId]);
+
+  // Load reports
+  useEffect(() => {
+    if (!benchmark) return;
+    (async () => {
+      setReportsLoading(true);
+      const ids = new Set<string>();
+      for (const run of benchmark.runs) {
+        if (!selectedRunIds.includes(run.id)) continue;
+        Object.values(run.results || {}).forEach(r => { if (r.reportId) ids.add(r.reportId); });
+      }
+      const map: Record<string, EvaluationReport> = {};
+      await Promise.all(Array.from(ids).map(async id => {
+        const rpt = await asyncRunStorage.getReportById(id);
+        if (rpt) map[id] = rpt;
+      }));
+      setReports(map);
+      setReportsLoading(false);
+    })();
+  }, [benchmark, selectedRunIds]);
+
+  const updateUrl = useCallback((bmId: string, runIds: string[]) => {
+    const p: Record<string, string> = {};
+    if (bmId) p.benchmark = bmId;
+    if (runIds.length > 0) p.runs = runIds.join(',');
+    setSearchParams(p, { replace: true });
+  }, [setSearchParams]);
+
+  const handleBenchmarkChange = (bmId: string) => {
+    setSelectedBenchmarkId(bmId);
+    const bm = benchmarks.find(b => b.id === bmId);
+    const sorted = [...(bm?.runs || [])].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    const ids = sorted.slice(0, 2).map(r => r.id);
+    setSelectedRunIds(ids);
+    updateUrl(bmId, ids);
+  };
+
+  const toggleRun = (runId: string) => {
+    setSelectedRunIds(prev => {
+      const next = prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId];
+      if (next.length < 2 && next.length < prev.length) return prev;
+      updateUrl(selectedBenchmarkId, next);
+      return next;
+    });
+  };
+
+  const selectedRuns = useMemo(() => (benchmark?.runs || []).filter(r => selectedRunIds.includes(r.id)), [benchmark, selectedRunIds]);
+  const runAggregates = useMemo(() => selectedRuns.map(run => calculateRunAggregates(run, reports)), [selectedRuns, reports]);
+
+  const baselineRunId = useMemo(() => {
+    const sorted = [...selectedRuns].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return sorted[0]?.id ?? '';
+  }, [selectedRuns]);
+
+  const allRows = useMemo(() => buildTestCaseComparisonRows(selectedRuns, reports, getRealTestCaseMeta), [selectedRuns, reports]);
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 size={24} className="animate-spin text-muted-foreground" /></div>;
+  }
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)} className="h-8 w-8"><ArrowLeft size={16} /></Button>
+          <GitCompare className="h-5 w-5 text-primary" />
+          <div>
+            <h2 className="text-xl font-bold">Compare Runs — Scorecard</h2>
+            <p className="text-[11px] text-muted-foreground mt-0.5">Side-by-side scorecard columns per run</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Benchmark + Run Selector */}
+      <div className="flex items-start gap-4 mb-4 p-4 rounded-lg border border-border bg-card">
+        <div className="space-y-1.5">
+          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Benchmark</label>
+          <Select value={selectedBenchmarkId} onValueChange={handleBenchmarkChange}>
+            <SelectTrigger className="w-[260px] h-8 text-xs"><SelectValue placeholder="Select benchmark" /></SelectTrigger>
+            <SelectContent>
+              {benchmarks.map(bm => (
+                <SelectItem key={bm.id} value={bm.id}>
+                  <span>{bm.name}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">({bm.runs?.length || 0} runs)</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex-1 space-y-1.5">
+          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Runs ({selectedRunIds.length} selected)</label>
+          <div className="flex flex-wrap gap-3">
+            {(benchmark?.runs || []).map(run => (
+              <div key={run.id} className="flex items-center gap-1.5">
+                <Checkbox id={`r2-${run.id}`} checked={selectedRunIds.includes(run.id)} onCheckedChange={() => toggleRun(run.id)} disabled={selectedRunIds.includes(run.id) && selectedRunIds.length <= 2} className="h-3.5 w-3.5" />
+                <Label htmlFor={`r2-${run.id}`} className="text-xs cursor-pointer">{run.name}</Label>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Scorecard content */}
+      {selectedRuns.length >= 2 && !reportsLoading ? (
+        <div className="flex-1 overflow-y-auto">
+          {/* Scorecard headers with delta gutters */}
+          <div className="flex items-stretch gap-0 mb-4">
+            {runAggregates.map((agg, i) => (
+              <React.Fragment key={agg.runId}>
+                <div className="flex-1 min-w-[160px]">
+                  <ScorecardHeader agg={agg} isBaseline={agg.runId === baselineRunId} />
+                </div>
+                {i < runAggregates.length - 1 && (
+                  <DeltaGutter left={runAggregates[i]} right={runAggregates[i + 1]} />
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+
+          {/* Test case rows */}
+          <div className="rounded-lg border border-border overflow-hidden">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b bg-muted/30">
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground w-[200px]">Test Case</th>
+                  {selectedRuns.map(run => (
+                    <th key={run.id} className="px-3 py-2 text-center font-medium text-muted-foreground min-w-[100px]">
+                      <span className="truncate block">{run.name}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {allRows.length === 0 ? (
+                  <tr><td colSpan={1 + selectedRuns.length} className="py-8 text-center text-muted-foreground">No test cases</td></tr>
+                ) : (
+                  allRows.map(row => {
+                    const baseResult = row.results[baselineRunId];
+                    return (
+                      <tr key={row.testCaseId} className="border-b hover:bg-muted/20 transition-colors">
+                        <td className="px-3 py-2">
+                          <div className="font-medium truncate max-w-[190px]">{row.testCaseName}</div>
+                          {row.labels?.slice(0, 1).map(l => (
+                            <Badge key={l} variant="outline" className="text-[8px] px-1 py-0 mt-0.5">{l}</Badge>
+                          ))}
+                        </td>
+                        {selectedRuns.map(run => {
+                          const result = row.results[run.id];
+                          const isBase = run.id === baselineRunId;
+                          const acc = result?.accuracy;
+                          const baseAcc = baseResult?.accuracy;
+                          const delta = !isBase && acc !== undefined && baseAcc !== undefined ? acc - baseAcc : undefined;
+
+                          return (
+                            <td key={run.id} className="px-3 py-2 text-center">
+                              <div className="flex flex-col items-center gap-0.5">
+                                <StatusDot status={result?.passFailStatus} accuracy={acc} />
+                                {acc !== undefined && <span className="text-[10px] text-muted-foreground">{acc}%</span>}
+                                {delta !== undefined && delta !== 0 && (
+                                  <span className={`text-[9px] font-medium ${delta > 0 ? 'text-green-500' : 'text-red-400'}`}>
+                                    {delta > 0 ? '+' : ''}{delta}
+                                  </span>
+                                )}
+                              </div>
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mini pass rate chart */}
+          <div className="mt-4 p-3 rounded-lg border border-border bg-card">
+            <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-2">Pass Rate Comparison</div>
+            <PassRateChart aggregates={runAggregates} baselineRunId={baselineRunId} />
+          </div>
+        </div>
+      ) : reportsLoading ? (
+        <div className="flex-1 flex items-center justify-center"><Loader2 size={20} className="animate-spin text-muted-foreground" /></div>
+      ) : (
+        <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
+          <GitCompare className="h-12 w-12 mb-4 opacity-50" />
+          <p className="text-sm">Select a benchmark with at least 2 runs</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/evals3/ComparePage3.tsx
+++ b/components/evals3/ComparePage3.tsx
@@ -1,0 +1,367 @@
+/*
+ * ComparePage3 — Matrix Heatmap Compare View (Option C)
+ *
+ * Rows = test cases, columns = runs, cells = colored heatmap squares.
+ * - Green gradient for high accuracy, red for low/failures
+ * - Group-by toggle: category/label or status (all-passed, has-regression, mixed)
+ * - Hover tooltip with full details (accuracy, pass/fail, delta)
+ * - Sparkline row at top showing pass rate per run
+ * - Same benchmark/run selector + last-2-runs default
+ *
+ * Route: /evaluations/compare3
+ */
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  GitCompare, ArrowLeft, Loader2, Layers, List,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { asyncBenchmarkStorage, asyncRunStorage } from '@/services/storage';
+import {
+  calculateRunAggregates,
+  buildTestCaseComparisonRows,
+  getRealTestCaseMeta,
+  calculateRowStatus,
+  RowStatus,
+} from '@/services/comparisonService';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+import type {
+  Benchmark, BenchmarkRun, EvaluationReport,
+  RunAggregateMetrics, TestCaseComparisonRow,
+} from '@/types';
+
+const getAgentName = (key: string) =>
+  DEFAULT_CONFIG.agents.find(a => a.key === key)?.name || key;
+
+type GroupBy = 'none' | 'category' | 'status';
+
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Get heatmap color based on accuracy (0-100) or missing/failed */
+function getHeatmapColor(accuracy: number | undefined, status?: string): string {
+  if (!status || status === 'missing') return 'bg-muted border-border';
+  if (status === 'failed' && (accuracy === undefined || accuracy === 0))
+    return 'bg-red-500/80 border-red-600/50';
+  if (accuracy === undefined) return 'bg-muted border-border';
+  // Green gradient: 0-40 red, 40-70 amber, 70-90 light green, 90-100 bright green
+  if (accuracy >= 90) return 'bg-green-500 border-green-600/50';
+  if (accuracy >= 70) return 'bg-green-400/70 border-green-500/40';
+  if (accuracy >= 50) return 'bg-amber-400/70 border-amber-500/40';
+  if (accuracy >= 30) return 'bg-orange-400/70 border-orange-500/40';
+  return 'bg-red-400/70 border-red-500/40';
+}
+
+/** Sparkline — tiny inline bar for pass rate */
+function Sparkline({ values }: { values: number[] }) {
+  const max = 100;
+  return (
+    <div className="flex items-end gap-px h-5">
+      {values.map((v, i) => {
+        const h = Math.max(2, (v / max) * 100);
+        const color = v >= 80 ? 'bg-green-500' : v >= 50 ? 'bg-amber-500' : 'bg-red-400';
+        return <div key={i} className={`w-3 rounded-t-sm ${color}`} style={{ height: `${h}%` }} />;
+      })}
+    </div>
+  );
+}
+
+/** Status label for grouping */
+const statusLabels: Record<RowStatus, string> = {
+  regression: '↓ Regressions',
+  improvement: '↑ Improvements',
+  mixed: '↔ Mixed',
+  neutral: '= Unchanged',
+};
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const ComparePage3: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reports, setReports] = useState<Record<string, EvaluationReport>>({});
+  const [reportsLoading, setReportsLoading] = useState(false);
+  const [selectedBenchmarkId, setSelectedBenchmarkId] = useState<string>('');
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
+  const [groupBy, setGroupBy] = useState<GroupBy>('none');
+
+  // Load benchmarks (same pattern as Compare 1/2)
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const bms = await asyncBenchmarkStorage.getAll();
+        setBenchmarks(bms);
+        const urlBm = searchParams.get('benchmark');
+        const urlRuns = searchParams.get('runs')?.split(',').filter(Boolean) || [];
+        const pickLastTwo = (bm: Benchmark) => {
+          const sorted = [...(bm.runs || [])].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+          return sorted.slice(0, 2).map(r => r.id);
+        };
+        if (urlBm && bms.some(b => b.id === urlBm)) {
+          setSelectedBenchmarkId(urlBm);
+          const bm = bms.find(b => b.id === urlBm)!;
+          const valid = urlRuns.filter(id => bm.runs.some(r => r.id === id));
+          setSelectedRunIds(valid.length >= 2 ? valid : pickLastTwo(bm));
+        } else if (bms.length > 0) {
+          const sorted = [...bms].filter(b => (b.runs?.length || 0) >= 2)
+            .sort((a, b) => Math.max(...(b.runs || []).map(r => new Date(r.createdAt).getTime())) - Math.max(...(a.runs || []).map(r => new Date(r.createdAt).getTime())));
+          const def = sorted[0] || bms[0];
+          setSelectedBenchmarkId(def.id);
+          setSelectedRunIds(pickLastTwo(def));
+        }
+      } catch (err) { console.error(err); }
+      finally { setLoading(false); }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const benchmark = useMemo(() => benchmarks.find(b => b.id === selectedBenchmarkId) || null, [benchmarks, selectedBenchmarkId]);
+
+  useEffect(() => {
+    if (!benchmark) return;
+    (async () => {
+      setReportsLoading(true);
+      const ids = new Set<string>();
+      for (const run of benchmark.runs) {
+        if (!selectedRunIds.includes(run.id)) continue;
+        Object.values(run.results || {}).forEach(r => { if (r.reportId) ids.add(r.reportId); });
+      }
+      const map: Record<string, EvaluationReport> = {};
+      await Promise.all(Array.from(ids).map(async id => {
+        const rpt = await asyncRunStorage.getReportById(id);
+        if (rpt) map[id] = rpt;
+      }));
+      setReports(map);
+      setReportsLoading(false);
+    })();
+  }, [benchmark, selectedRunIds]);
+
+  const updateUrl = useCallback((bmId: string, runIds: string[]) => {
+    const p: Record<string, string> = {};
+    if (bmId) p.benchmark = bmId;
+    if (runIds.length > 0) p.runs = runIds.join(',');
+    setSearchParams(p, { replace: true });
+  }, [setSearchParams]);
+
+  const handleBenchmarkChange = (bmId: string) => {
+    setSelectedBenchmarkId(bmId);
+    const bm = benchmarks.find(b => b.id === bmId);
+    const sorted = [...(bm?.runs || [])].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    const ids = sorted.slice(0, 2).map(r => r.id);
+    setSelectedRunIds(ids);
+    updateUrl(bmId, ids);
+  };
+
+  const toggleRun = (runId: string) => {
+    setSelectedRunIds(prev => {
+      const next = prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId];
+      if (next.length < 2 && next.length < prev.length) return prev;
+      updateUrl(selectedBenchmarkId, next);
+      return next;
+    });
+  };
+
+  const selectedRuns = useMemo(() => (benchmark?.runs || []).filter(r => selectedRunIds.includes(r.id)), [benchmark, selectedRunIds]);
+  const runAggregates = useMemo(() => selectedRuns.map(run => calculateRunAggregates(run, reports)), [selectedRuns, reports]);
+  const baselineRunId = useMemo(() => {
+    const sorted = [...selectedRuns].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return sorted[0]?.id ?? '';
+  }, [selectedRuns]);
+  const allRows = useMemo(() => buildTestCaseComparisonRows(selectedRuns, reports, getRealTestCaseMeta), [selectedRuns, reports]);
+
+  // Group rows
+  const groupedRows = useMemo(() => {
+    if (groupBy === 'none') return [{ label: '', rows: allRows }];
+    if (groupBy === 'category') {
+      const groups = new Map<string, TestCaseComparisonRow[]>();
+      for (const row of allRows) {
+        const cat = row.category || 'Uncategorized';
+        if (!groups.has(cat)) groups.set(cat, []);
+        groups.get(cat)!.push(row);
+      }
+      return Array.from(groups.entries()).map(([label, rows]) => ({ label, rows })).sort((a, b) => a.label.localeCompare(b.label));
+    }
+    // group by status
+    const groups = new Map<RowStatus, TestCaseComparisonRow[]>();
+    for (const row of allRows) {
+      const s = calculateRowStatus(row, baselineRunId);
+      if (!groups.has(s)) groups.set(s, []);
+      groups.get(s)!.push(row);
+    }
+    const order: RowStatus[] = ['regression', 'improvement', 'mixed', 'neutral'];
+    return order.filter(s => groups.has(s)).map(s => ({ label: statusLabels[s], rows: groups.get(s)! }));
+  }, [allRows, groupBy, baselineRunId]);
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 size={24} className="animate-spin text-muted-foreground" /></div>;
+  }
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <div className="p-4 h-full flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" onClick={() => navigate(-1)} className="h-8 w-8"><ArrowLeft size={16} /></Button>
+            <GitCompare className="h-5 w-5 text-primary" />
+            <div>
+              <h2 className="text-xl font-bold">Compare Runs — Heatmap</h2>
+              <p className="text-[11px] text-muted-foreground mt-0.5">Matrix heatmap with smart grouping</p>
+            </div>
+          </div>
+          {/* Group by toggle */}
+          <div className="flex items-center border border-border rounded-md overflow-hidden">
+            {([['none', 'Flat', <List size={12} key="f" />], ['category', 'Category', <Layers size={12} key="c" />], ['status', 'Status', null]] as [GroupBy, string, React.ReactNode][]).map(([val, lbl, icon]) => (
+              <button
+                key={val}
+                onClick={() => setGroupBy(val)}
+                className={`px-3 py-1.5 text-xs flex items-center gap-1.5 transition-colors ${groupBy === val ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              >
+                {icon}{lbl}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Benchmark + Run Selector */}
+        <div className="flex items-start gap-4 mb-4 p-4 rounded-lg border border-border bg-card">
+          <div className="space-y-1.5">
+            <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Benchmark</label>
+            <Select value={selectedBenchmarkId} onValueChange={handleBenchmarkChange}>
+              <SelectTrigger className="w-[260px] h-8 text-xs"><SelectValue placeholder="Select benchmark" /></SelectTrigger>
+              <SelectContent>
+                {benchmarks.map(bm => (
+                  <SelectItem key={bm.id} value={bm.id}>
+                    <span>{bm.name}</span>
+                    <span className="text-[10px] text-muted-foreground ml-2">({bm.runs?.length || 0} runs)</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex-1 space-y-1.5">
+            <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Runs ({selectedRunIds.length} selected)</label>
+            <div className="flex flex-wrap gap-3">
+              {(benchmark?.runs || []).map(run => (
+                <div key={run.id} className="flex items-center gap-1.5">
+                  <Checkbox id={`r3-${run.id}`} checked={selectedRunIds.includes(run.id)} onCheckedChange={() => toggleRun(run.id)} disabled={selectedRunIds.includes(run.id) && selectedRunIds.length <= 2} className="h-3.5 w-3.5" />
+                  <Label htmlFor={`r3-${run.id}`} className="text-xs cursor-pointer">{run.name}</Label>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Heatmap content */}
+        {selectedRuns.length >= 2 && !reportsLoading ? (
+          <div className="flex-1 overflow-auto rounded-lg border border-border">
+            <table className="w-full text-xs border-collapse">
+              <thead className="sticky top-0 z-10 bg-background">
+                <tr className="border-b">
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground bg-background border-b w-[200px] sticky left-0 z-20">
+                    Test Case
+                  </th>
+                  {selectedRuns.map((run, i) => (
+                    <th key={run.id} className="px-2 py-2 text-center font-medium text-muted-foreground bg-background border-b min-w-[70px]">
+                      <div className="truncate text-[10px]">{run.name}</div>
+                      <div className="text-[8px] text-muted-foreground font-normal">{getAgentName(run.agentKey)}</div>
+                      {/* Sparkline for this run's pass rate */}
+                      <div className="flex justify-center mt-1">
+                        <div className="h-3 w-5 flex items-end">
+                          <div
+                            className={`w-full rounded-t-sm ${runAggregates[i]?.passRatePercent >= 80 ? 'bg-green-500' : runAggregates[i]?.passRatePercent >= 50 ? 'bg-amber-500' : 'bg-red-400'}`}
+                            style={{ height: `${Math.max(10, runAggregates[i]?.passRatePercent || 0)}%` }}
+                          />
+                        </div>
+                      </div>
+                      <div className="text-[8px] font-medium mt-0.5">{runAggregates[i]?.passRatePercent ?? 0}%</div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {groupedRows.map((group, gi) => (
+                  <React.Fragment key={gi}>
+                    {group.label && (
+                      <tr>
+                        <td colSpan={1 + selectedRuns.length} className="px-3 py-1.5 bg-muted/30 border-b">
+                          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</span>
+                          <span className="text-[9px] text-muted-foreground ml-2">({group.rows.length})</span>
+                        </td>
+                      </tr>
+                    )}
+                    {group.rows.map(row => {
+                      const baseResult = row.results[baselineRunId];
+                      return (
+                        <tr key={row.testCaseId} className="border-b hover:bg-muted/10 transition-colors">
+                          <td className="px-3 py-1.5 sticky left-0 bg-background z-10">
+                            <div className="font-medium truncate max-w-[190px]">{row.testCaseName}</div>
+                          </td>
+                          {selectedRuns.map(run => {
+                            const result = row.results[run.id];
+                            const acc = result?.accuracy;
+                            const pf = result?.passFailStatus;
+                            const isBase = run.id === baselineRunId;
+                            const baseAcc = baseResult?.accuracy;
+                            const delta = !isBase && acc !== undefined && baseAcc !== undefined ? acc - baseAcc : undefined;
+
+                            return (
+                              <td key={run.id} className="px-1 py-1 text-center">
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <div className={`w-8 h-8 mx-auto rounded border flex items-center justify-center text-[9px] font-medium cursor-default transition-colors ${getHeatmapColor(acc, pf || (!result || result.status === 'missing' ? 'missing' : undefined))}`}>
+                                      {acc !== undefined ? acc : !result || result.status === 'missing' ? '—' : '✗'}
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top" className="text-xs max-w-[200px]">
+                                    <div className="space-y-0.5">
+                                      <div className="font-medium">{row.testCaseName}</div>
+                                      <div>Run: {run.name}</div>
+                                      {pf && <div>Status: <span className={pf === 'passed' ? 'text-green-500' : 'text-red-400'}>{pf}</span></div>}
+                                      {acc !== undefined && <div>Accuracy: {acc}%</div>}
+                                      {delta !== undefined && delta !== 0 && (
+                                        <div className={delta > 0 ? 'text-green-500' : 'text-red-400'}>
+                                          Delta: {delta > 0 ? '+' : ''}{delta} vs baseline
+                                        </div>
+                                      )}
+                                      {isBase && <div className="text-primary">Baseline run</div>}
+                                    </div>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      );
+                    })}
+                  </React.Fragment>
+                ))}
+                {allRows.length === 0 && (
+                  <tr><td colSpan={1 + selectedRuns.length} className="py-8 text-center text-muted-foreground">No test cases</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : reportsLoading ? (
+          <div className="flex-1 flex items-center justify-center"><Loader2 size={20} className="animate-spin text-muted-foreground" /></div>
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
+            <GitCompare className="h-12 w-12 mb-4 opacity-50" />
+            <p className="text-sm">Select a benchmark with at least 2 runs</p>
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/components/evals3/EvalRunsPage.tsx
+++ b/components/evals3/EvalRunsPage.tsx
@@ -1,0 +1,828 @@
+/*
+ * EvalRunsPage — Evals 3: Evaluation Runs (Option C — Run-Centric)
+ *
+ * Primary entity = benchmark run (not individual test case results).
+ * Two view modes: Flat table or Grouped by Benchmark.
+ * Default: Grouped by Benchmark.
+ * Click a run row → navigates to BenchmarkRunDetailPage.
+ * Agent Traces-style filter bar.
+ * Route: /evaluations/runs
+ */
+
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CheckCircle2, XCircle, Loader2, Clock, Search, RefreshCw,
+  Activity, BarChart3, SlidersHorizontal, ChevronDown, ChevronRight,
+  Layers, List, GitCompare, AlertTriangle, TrendingDown, Target, X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { asyncBenchmarkStorage, asyncTestCaseStorage, asyncRunStorage } from '@/services/storage';
+import { Benchmark, TestCase, BenchmarkRun } from '@/types';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatRelativeTime, getModelName } from '@/lib/utils';
+
+// ─── Time Filter ─────────────────────────────────────────────────────────────
+
+type TimeRange = '1h' | '6h' | '1d' | '7d' | '30d' | 'all';
+const TIME_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: '1h', label: 'Last 1h' },
+  { value: '6h', label: 'Last 6h' },
+  { value: '1d', label: 'Last 1d' },
+  { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' },
+  { value: 'all', label: 'All time' },
+];
+function getTimeThreshold(range: TimeRange): Date | null {
+  if (range === 'all') return null;
+  const ms: Record<string, number> = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 };
+  return new Date(Date.now() - ms[range]);
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type ViewMode = 'flat' | 'grouped';
+
+/** One benchmark run with its parent benchmark context */
+interface RunRow {
+  run: BenchmarkRun;
+  benchmarkId: string;
+  benchmarkName: string;
+  agentName: string;
+  passed: number;
+  failed: number;
+  total: number;
+}
+
+function SortHeader({ label, active, dir, onClick, className }: {
+  label: string; active: boolean; dir: 'asc' | 'desc'; onClick: () => void; className?: string;
+}) {
+  return (
+    <th
+      className={`h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b cursor-pointer select-none hover:text-foreground transition-colors whitespace-nowrap ${className || ''}`}
+      onClick={onClick}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {active && <ChevronDown size={10} className={dir === 'asc' ? 'rotate-180' : ''} />}
+      </span>
+    </th>
+  );
+}
+
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function computeRunStats(run: BenchmarkRun): { passed: number; failed: number; total: number } {
+  if (run.stats && run.stats.total > 0) {
+    return { passed: run.stats.passed, failed: run.stats.failed, total: run.stats.total };
+  }
+  const results = Object.values(run.results || {});
+  let passed = 0, failed = 0;
+  for (const r of results) {
+    if (r.status === 'completed') passed++;
+    else if (r.status === 'failed' || r.status === 'cancelled') failed++;
+  }
+  const total = results.length;
+  return { passed, failed, total };
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const EvalRunsPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Filters
+  const [search, setSearch] = useState('');
+  const [timeRange, setTimeRange] = useState<TimeRange>('30d');
+  const [selectedAgent, setSelectedAgent] = useState('all');
+
+  // View
+  const [viewMode, setViewMode] = useState<ViewMode>('flat');
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [sort, setSort] = useState<{ field: string; dir: 'asc' | 'desc' }>({ field: 'timestamp', dir: 'desc' });
+  const [showRegressionsOnly, setShowRegressionsOnly] = useState(false);
+
+  // Advanced filters
+  const [filterStatus, setFilterStatus] = useState<'all' | 'passed' | 'failed' | 'mixed'>('all');
+  const [filterBenchmarks, setFilterBenchmarks] = useState<Set<string>>(new Set());
+  const [filterModels, setFilterModels] = useState<Set<string>>(new Set());
+  const [filterPassRateMin, setFilterPassRateMin] = useState<number>(0);
+  const [filterPassRateMax, setFilterPassRateMax] = useState<number>(100);
+  const [filterOpen, setFilterOpen] = useState(false);
+
+  // Scroll
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Compare selection
+  const [selectedRuns, setSelectedRuns] = useState<Set<string>>(new Set());
+
+  // Annotation counts: runId → { totalAnnotations, testCasesWithAnnotations, firstTestCaseId }
+  const [annotationMap, setAnnotationMap] = useState<Map<string, { total: number; tcCount: number; firstTcId: string }>>(new Map());
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const bms = await asyncBenchmarkStorage.getAll();
+      setBenchmarks(bms);
+    } catch (err) {
+      console.error('Failed to load:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  // Load annotation counts for all runs (deferred, non-blocking)
+  useEffect(() => {
+    if (benchmarks.length === 0) return;
+    (async () => {
+      const map = new Map<string, { total: number; tcCount: number; firstTcId: string }>();
+      for (const bm of benchmarks) {
+        for (const run of bm.runs || []) {
+          let totalAnnotations = 0;
+          let tcWithAnnotations = 0;
+          let firstTcId = '';
+          for (const [tcId, result] of Object.entries(run.results || {})) {
+            if (!result.reportId) continue;
+            try {
+              const report = await asyncRunStorage.getReportById(result.reportId);
+              if (report?.annotations && report.annotations.length > 0) {
+                totalAnnotations += report.annotations.length;
+                tcWithAnnotations++;
+                if (!firstTcId) firstTcId = tcId;
+              }
+            } catch { /* skip failed loads */ }
+          }
+          if (totalAnnotations > 0) {
+            map.set(run.id, { total: totalAnnotations, tcCount: tcWithAnnotations, firstTcId });
+          }
+        }
+      }
+      setAnnotationMap(map);
+    })();
+  }, [benchmarks]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const h = () => setIsScrolled(el.scrollTop > 10);
+    el.addEventListener('scroll', h);
+    return () => el.removeEventListener('scroll', h);
+  }, []);
+
+  // Agent options
+  const agentOptions = useMemo(() => {
+    const agents = DEFAULT_CONFIG.agents.filter(a => a.enabled !== false).map(a => ({ value: a.key, label: a.name }));
+    return [{ value: 'all', label: 'All Agents' }, ...agents];
+  }, []);
+
+  // Derive flat run rows from benchmark data
+  const allRunRows = useMemo<RunRow[]>(() => {
+    const threshold = getTimeThreshold(timeRange);
+    const rows: RunRow[] = [];
+
+    for (const bm of benchmarks) {
+      for (const run of bm.runs || []) {
+        if (threshold && new Date(run.createdAt) < threshold) continue;
+        if (selectedAgent !== 'all' && run.agentKey !== selectedAgent) continue;
+
+        const agentName = DEFAULT_CONFIG.agents.find(a => a.key === run.agentKey)?.name || run.agentKey || 'Unknown';
+
+        if (search) {
+          const q = search.toLowerCase();
+          if (
+            !run.name.toLowerCase().includes(q) &&
+            !run.id.toLowerCase().includes(q) &&
+            !bm.name.toLowerCase().includes(q) &&
+            !agentName.toLowerCase().includes(q)
+          ) continue;
+        }
+
+        const stats = computeRunStats(run);
+        rows.push({
+          run,
+          benchmarkId: bm.id,
+          benchmarkName: bm.name,
+          agentName,
+          ...stats,
+        });
+      }
+    }
+
+    return rows;
+  }, [benchmarks, timeRange, selectedAgent, search]);
+
+  // Available filter options (derived from data)
+  const availableBenchmarks = useMemo(() => {
+    const bms = new Map<string, string>();
+    for (const rr of allRunRows) bms.set(rr.benchmarkId, rr.benchmarkName);
+    return Array.from(bms.entries()).map(([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
+  }, [allRunRows]);
+
+  const availableModels = useMemo(() => {
+    const models = new Set<string>();
+    for (const rr of allRunRows) models.add(getModelName(rr.run.modelId));
+    return Array.from(models).sort();
+  }, [allRunRows]);
+
+  // Apply advanced filters
+  const filteredRunRows = useMemo(() => {
+    let rows = allRunRows;
+
+    // Status filter
+    if (filterStatus !== 'all') {
+      rows = rows.filter(rr => {
+        const allPassed = rr.failed === 0 && rr.passed > 0;
+        const allFailed = rr.passed === 0 && rr.failed > 0;
+        if (filterStatus === 'passed') return allPassed;
+        if (filterStatus === 'failed') return rr.failed > 0;
+        if (filterStatus === 'mixed') return rr.passed > 0 && rr.failed > 0;
+        return true;
+      });
+    }
+
+    // Benchmark filter
+    if (filterBenchmarks.size > 0) {
+      rows = rows.filter(rr => filterBenchmarks.has(rr.benchmarkId));
+    }
+
+    // Model filter
+    if (filterModels.size > 0) {
+      rows = rows.filter(rr => filterModels.has(getModelName(rr.run.modelId)));
+    }
+
+    // Pass rate range
+    if (filterPassRateMin > 0 || filterPassRateMax < 100) {
+      rows = rows.filter(rr => {
+        const rate = rr.total > 0 ? Math.round((rr.passed / rr.total) * 100) : 0;
+        return rate >= filterPassRateMin && rate <= filterPassRateMax;
+      });
+    }
+
+    // Regression filter applied separately in table rendering
+
+    return rows;
+  }, [allRunRows, filterStatus, filterBenchmarks, filterModels, filterPassRateMin, filterPassRateMax]);
+
+  const activeFilterCount = (filterStatus !== 'all' ? 1 : 0) + (filterBenchmarks.size > 0 ? 1 : 0) + (filterModels.size > 0 ? 1 : 0) + ((filterPassRateMin > 0 || filterPassRateMax < 100) ? 1 : 0);
+
+  const clearAllFilters = () => {
+    setFilterStatus('all');
+    setFilterBenchmarks(new Set());
+    setFilterModels(new Set());
+    setFilterPassRateMin(0);
+    setFilterPassRateMax(100);
+    setShowRegressionsOnly(false);
+  };
+
+  // Summary metrics (use filteredRunRows for display)
+  const totalRuns = filteredRunRows.length;
+  const totalTestCases = filteredRunRows.reduce((sum, r) => sum + r.total, 0);
+  const totalPassed = filteredRunRows.reduce((sum, r) => sum + r.passed, 0);
+  const overallPassRate = totalTestCases > 0 ? Math.round((totalPassed / totalTestCases) * 100) : 0;
+
+  // Avg accuracy — placeholder (would need report-level accuracy data)
+  // For now, compute from pass rate per run as a proxy
+  const avgAccuracy = totalRuns > 0
+    ? Math.round(filteredRunRows.reduce((sum, r) => sum + (r.total > 0 ? (r.passed / r.total) * 100 : 0), 0) / totalRuns)
+    : 0;
+
+  // Regressions — computed after groupedByBenchmark
+  const regressionCount = 0; // placeholder, computed below
+
+  // Sort
+  const sortRows = useCallback((rows: RunRow[]) => {
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      switch (sort.field) {
+        case 'runId': return dir * a.run.name.localeCompare(b.run.name);
+        case 'benchmark': return dir * a.benchmarkName.localeCompare(b.benchmarkName);
+        case 'agent': return dir * a.agentName.localeCompare(b.agentName);
+        case 'timestamp': return dir * (new Date(a.run.createdAt).getTime() - new Date(b.run.createdAt).getTime());
+        case 'results': return dir * (a.total - b.total);
+        default: return 0;
+      }
+    });
+  }, [sort]);
+
+  const handleSort = (field: string) => {
+    setSort(prev => prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'desc' });
+  };
+
+  const toggleGroup = (id: string) => {
+    setCollapsedGroups(prev => {
+      const n = new Set(prev);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+  };
+
+  // Compare selection helpers
+  const MAX_COMPARE = 10;
+
+  const toggleRunSelection = (runId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedRuns(prev => {
+      const n = new Set(prev);
+      if (n.has(runId)) {
+        n.delete(runId);
+      } else {
+        if (n.size >= MAX_COMPARE) return prev; // cap at 10
+        n.add(runId);
+      }
+      return n;
+    });
+  };
+
+  const atLimit = selectedRuns.size >= MAX_COMPARE;
+
+  // Check if selected runs span multiple benchmarks
+  const isMultiBenchmark = useMemo(() => {
+    if (selectedRuns.size < 2) return false;
+    const benchmarkIds = new Set(allRunRows.filter(rr => selectedRuns.has(rr.run.id)).map(rr => rr.benchmarkId));
+    return benchmarkIds.size > 1;
+  }, [selectedRuns, allRunRows]);
+
+  // Toggle all runs in a benchmark group (bypasses individual limit)
+  const toggleBenchmarkSelection = (groupRunIds: string[], e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedRuns(prev => {
+      const n = new Set(prev);
+      const allSelected = groupRunIds.every(id => n.has(id));
+      if (allSelected) {
+        groupRunIds.forEach(id => n.delete(id));
+      } else {
+        groupRunIds.forEach(id => n.add(id));
+      }
+      return n;
+    });
+  };
+
+  // Grouped by benchmark
+  const groupedByBenchmark = useMemo(() => {
+    const groups = new Map<string, { id: string; name: string; rows: RunRow[] }>();
+    for (const rr of allRunRows) {
+      if (!groups.has(rr.benchmarkId)) groups.set(rr.benchmarkId, { id: rr.benchmarkId, name: rr.benchmarkName, rows: [] });
+      groups.get(rr.benchmarkId)!.rows.push(rr);
+    }
+    return Array.from(groups.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [allRunRows]);
+
+  // Regressions — count benchmarks where latest run is worse than previous
+  const regressionData = useMemo(() => {
+    const regressionRunIds = new Set<string>();
+    for (const group of groupedByBenchmark) {
+      if (group.rows.length < 2) continue;
+      const sorted = [...group.rows].sort((a, b) => new Date(b.run.createdAt).getTime() - new Date(a.run.createdAt).getTime());
+      const latest = sorted[0];
+      const previous = sorted[1];
+      const latestRate = latest.total > 0 ? latest.passed / latest.total : 0;
+      const prevRate = previous.total > 0 ? previous.passed / previous.total : 0;
+      if (latestRate < prevRate) regressionRunIds.add(latest.run.id);
+    }
+    return { count: regressionRunIds.size, runIds: regressionRunIds };
+  }, [groupedByBenchmark]);
+  const regressionCountReal = regressionData.count;
+
+  // Render a run row
+  const renderRunRow = (rr: RunRow, showBenchmark: boolean) => {
+    const isAllPassed = rr.failed === 0 && rr.passed > 0;
+    const isChecked = selectedRuns.has(rr.run.id);
+    return (
+      <tr
+        key={`${rr.benchmarkId}-${rr.run.id}`}
+        className={`border-b hover:bg-muted/50 cursor-pointer transition-colors ${isChecked ? 'bg-primary/5' : ''}`}
+        onClick={() => navigate(`/evaluations/benchmarks/${rr.benchmarkId}/runs/${rr.run.id}/inspect`)}
+      >
+        <td className="px-2 py-1.5 align-middle text-center w-8" onClick={e => e.stopPropagation()}>
+          <button
+            onClick={e => toggleRunSelection(rr.run.id, e)}
+            disabled={!isChecked && atLimit}
+            className={`h-4 w-4 rounded border-2 flex items-center justify-center transition-colors shrink-0
+              ${isChecked
+                ? 'bg-primary border-primary text-primary-foreground'
+                : atLimit
+                  ? 'border-muted-foreground/20 bg-muted/30 cursor-not-allowed'
+                  : 'border-muted-foreground/40 hover:border-muted-foreground/70 bg-transparent cursor-pointer'
+              }`}
+            aria-label={isChecked ? 'Deselect run' : 'Select run for comparison'}
+          >
+            {isChecked && (
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
+                <path d="M2 5L4.5 7.5L8 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </button>
+        </td>
+        <td className="px-2 py-1.5 align-middle text-center w-8">
+          {isAllPassed
+            ? <CheckCircle2 size={12} className="text-green-500" />
+            : rr.failed > 0
+              ? <XCircle size={12} className="text-red-500" />
+              : <Clock size={12} className="text-muted-foreground" />}
+        </td>
+        <td className="px-2 py-1.5 align-middle">
+          <div className="text-xs font-medium">{rr.run.name}</div>
+          <div className="text-[9px] text-muted-foreground font-mono">{rr.run.id.slice(0, 8)}</div>
+        </td>
+        {showBenchmark && (
+          <td className="px-2 py-1.5 align-middle">
+            <button
+              className="text-[10px] text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 hover:underline transition-colors"
+              onClick={e => { e.stopPropagation(); navigate(`/evaluations/benchmarks/${rr.benchmarkId}/runs`); }}
+            >
+              {rr.benchmarkName}
+            </button>
+          </td>
+        )}
+        <td className="px-2 py-1.5 align-middle text-[11px]">{rr.agentName}</td>
+        <td className="px-2 py-1.5 align-middle text-[11px]">{getModelName(rr.run.modelId)}</td>
+        <td className="px-2 py-1.5 align-middle text-[10px] text-muted-foreground whitespace-nowrap">{formatRelativeTime(rr.run.createdAt)}</td>
+        <td className="px-2 py-1.5 align-middle text-center">
+          {(() => {
+            const ann = annotationMap.get(rr.run.id);
+            if (ann && ann.total > 0) {
+              return (
+                <button
+                  className="text-[10px] text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 hover:underline"
+                  onClick={e => { e.stopPropagation(); navigate(`/evaluations/benchmarks/${rr.benchmarkId}/runs/${rr.run.id}/inspect`); }}
+                >
+                  {ann.total} in {ann.tcCount} TC{ann.tcCount !== 1 ? 's' : ''}
+                </button>
+              );
+            }
+            return <span className="text-[10px] text-muted-foreground">—</span>;
+          })()}
+        </td>
+        <td className="px-2 py-1.5 align-middle text-right">
+          <div className="inline-flex items-center gap-1 text-[11px]">
+            <span className="text-green-500 font-medium">{rr.passed}</span>
+            <span className="text-muted-foreground">/</span>
+            <span className="text-red-500 font-medium">{rr.failed}</span>
+            <span className="text-muted-foreground">/</span>
+            <span className="text-muted-foreground">{rr.total}</span>
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 size={24} className="animate-spin text-muted-foreground" /></div>;
+  }
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-xl font-bold">Evaluation Runs</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">Benchmark runs across all evaluations</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-[200px] relative">
+            <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <Input placeholder="Search runs..." value={search} onChange={e => setSearch(e.target.value)} className="pl-7 h-7 text-xs md:text-xs" />
+          </div>
+          <Popover open={filterOpen} onOpenChange={setFilterOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className={`h-7 gap-1.5 text-xs font-normal ${activeFilterCount > 0 ? 'border-primary/50 text-foreground' : ''}`}>
+                <SlidersHorizontal size={12} /> Filter{activeFilterCount > 0 && ` (${activeFilterCount})`}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-3" align="start">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold">Filters</span>
+                  {activeFilterCount > 0 && (
+                    <button className="text-[10px] text-muted-foreground hover:text-foreground underline" onClick={clearAllFilters}>Clear all</button>
+                  )}
+                </div>
+
+                {/* Status */}
+                <div>
+                  <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1 block">Status</label>
+                  <div className="flex gap-1 flex-wrap">
+                    {(['all', 'passed', 'failed', 'mixed'] as const).map(s => (
+                      <button
+                        key={s}
+                        onClick={() => setFilterStatus(s)}
+                        className={`px-2 py-1 text-[10px] rounded-md border transition-colors ${
+                          filterStatus === s ? 'bg-primary text-primary-foreground border-primary' : 'border-border hover:bg-muted'
+                        }`}
+                      >
+                        {s === 'all' ? 'All' : s === 'passed' ? '✓ Passed' : s === 'failed' ? '✗ Failed' : '◐ Mixed'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Benchmark */}
+                <div>
+                  <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1 block">Benchmark</label>
+                  <div className="max-h-24 overflow-y-auto space-y-0.5">
+                    {availableBenchmarks.map(bm => (
+                      <label key={bm.id} className="flex items-center gap-1.5 text-[11px] cursor-pointer hover:bg-muted/50 px-1 py-0.5 rounded">
+                        <input
+                          type="checkbox"
+                          checked={filterBenchmarks.has(bm.id)}
+                          onChange={() => {
+                            setFilterBenchmarks(prev => {
+                              const n = new Set(prev);
+                              n.has(bm.id) ? n.delete(bm.id) : n.add(bm.id);
+                              return n;
+                            });
+                          }}
+                          className="h-3 w-3 rounded"
+                        />
+                        <span className="truncate">{bm.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Model */}
+                <div>
+                  <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1 block">Model</label>
+                  <div className="max-h-24 overflow-y-auto space-y-0.5">
+                    {availableModels.map(model => (
+                      <label key={model} className="flex items-center gap-1.5 text-[11px] cursor-pointer hover:bg-muted/50 px-1 py-0.5 rounded">
+                        <input
+                          type="checkbox"
+                          checked={filterModels.has(model)}
+                          onChange={() => {
+                            setFilterModels(prev => {
+                              const n = new Set(prev);
+                              n.has(model) ? n.delete(model) : n.add(model);
+                              return n;
+                            });
+                          }}
+                          className="h-3 w-3 rounded"
+                        />
+                        <span className="truncate">{model}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Pass Rate Range */}
+                <div>
+                  <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1 block">Pass Rate Range</label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      type="number" min={0} max={100} value={filterPassRateMin}
+                      onChange={e => setFilterPassRateMin(Math.max(0, Math.min(100, Number(e.target.value))))}
+                      className="h-6 w-16 text-[10px] text-center"
+                    />
+                    <span className="text-[10px] text-muted-foreground">to</span>
+                    <Input
+                      type="number" min={0} max={100} value={filterPassRateMax}
+                      onChange={e => setFilterPassRateMax(Math.max(0, Math.min(100, Number(e.target.value))))}
+                      className="h-6 w-16 text-[10px] text-center"
+                    />
+                    <span className="text-[10px] text-muted-foreground">%</span>
+                  </div>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+          <Select value={selectedAgent} onValueChange={setSelectedAgent}>
+            <SelectTrigger className="w-[120px] h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {agentOptions.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Select value={timeRange} onValueChange={v => setTimeRange(v as TimeRange)}>
+            <SelectTrigger className="w-[85px] h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {TIME_OPTIONS.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={loadData} disabled={loading} className="h-7">
+            <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          </Button>
+          {(() => {
+            const selectedRows = allRunRows.filter(rr => selectedRuns.has(rr.run.id));
+            const benchmarkIds = new Set(selectedRows.map(rr => rr.benchmarkId));
+            const multiBenchmark = benchmarkIds.size > 1;
+            const canCompare = selectedRuns.size >= 2 && !multiBenchmark;
+            return (
+              <Button
+                variant="outline"
+                size="sm"
+                className={`h-7 gap-1.5 text-xs ${selectedRuns.size > 0 ? 'border-primary/50' : ''}`}
+                disabled={selectedRuns.size < 2 || multiBenchmark}
+                onClick={() => {
+                  if (!canCompare) return;
+                  const bmId = [...benchmarkIds][0];
+                  const ids = selectedRows.map(rr => rr.run.id).join(',');
+                  navigate(`/compare/${bmId}?runs=${ids}`);
+                }}
+                title={multiBenchmark ? 'Select runs from a single benchmark to compare' : selectedRuns.size < 2 ? 'Select 2+ runs to compare' : `Compare ${selectedRuns.size} runs`}
+              >
+                <GitCompare size={12} />
+                Compare ({selectedRuns.size})
+                {multiBenchmark && <span className="text-amber-500 text-[9px]">⚠</span>}
+              </Button>
+            );
+          })()}
+        </div>
+      </div>
+
+      {/* ── Multi-benchmark warning banner ──────────────────────────── */}
+      {isMultiBenchmark && (
+        <div className="flex items-center gap-2 px-3 py-2 mb-3 rounded-lg border border-amber-300 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 text-amber-800 dark:text-amber-300 text-xs">
+          <AlertTriangle size={14} className="shrink-0" />
+          <span>Compare requires runs from the same benchmark. Deselect runs from other benchmarks or use "Group by Benchmark" to select within one.</span>
+          <button
+            className="ml-auto text-[10px] underline text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 shrink-0"
+            onClick={() => setSelectedRuns(new Set())}
+          >
+            Clear selection
+          </button>
+        </div>
+      )}
+
+      {/* ── Active Filter Pills ──────────────────────────────────── */}
+      {activeFilterCount > 0 && (
+        <div className="flex items-center gap-1.5 mb-3 flex-wrap">
+          <span className="text-[10px] text-muted-foreground">Active filters:</span>
+          {filterStatus !== 'all' && (
+            <Badge variant="secondary" className="text-[9px] gap-1 px-1.5 py-0">
+              Status: {filterStatus}
+              <button onClick={() => setFilterStatus('all')} className="hover:text-foreground"><X size={10} /></button>
+            </Badge>
+          )}
+          {filterBenchmarks.size > 0 && (
+            <Badge variant="secondary" className="text-[9px] gap-1 px-1.5 py-0">
+              {filterBenchmarks.size} benchmark{filterBenchmarks.size > 1 ? 's' : ''}
+              <button onClick={() => setFilterBenchmarks(new Set())} className="hover:text-foreground"><X size={10} /></button>
+            </Badge>
+          )}
+          {filterModels.size > 0 && (
+            <Badge variant="secondary" className="text-[9px] gap-1 px-1.5 py-0">
+              {filterModels.size} model{filterModels.size > 1 ? 's' : ''}
+              <button onClick={() => setFilterModels(new Set())} className="hover:text-foreground"><X size={10} /></button>
+            </Badge>
+          )}
+          {(filterPassRateMin > 0 || filterPassRateMax < 100) && (
+            <Badge variant="secondary" className="text-[9px] gap-1 px-1.5 py-0">
+              Pass rate: {filterPassRateMin}–{filterPassRateMax}%
+              <button onClick={() => { setFilterPassRateMin(0); setFilterPassRateMax(100); }} className="hover:text-foreground"><X size={10} /></button>
+            </Badge>
+          )}
+          <button className="text-[9px] text-muted-foreground hover:text-foreground underline ml-1" onClick={clearAllFilters}>Clear all</button>
+        </div>
+      )}
+
+      {/* ── Inline Metrics Bar ──────────────────────────────────── */}
+      <TooltipProvider delayDuration={200}>
+      <div className="flex items-center gap-6 mb-3 text-xs">
+        <div className="flex items-center gap-1.5">
+          <Activity size={13} className="text-blue-500" />
+          <span className="font-semibold">{totalRuns}</span>
+          <span className="text-muted-foreground">runs</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <CheckCircle2 size={13} className="text-green-500" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="font-semibold border-b border-dotted border-muted-foreground/50 cursor-default">{overallPassRate}%</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">Passed {totalPassed}/{totalTestCases} test cases</TooltipContent>
+          </Tooltip>
+          <span className="text-muted-foreground">pass rate</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Target size={13} className="text-purple-500" />
+          <span className="font-semibold">{avgAccuracy}%</span>
+          <span className="text-muted-foreground">avg accuracy</span>
+        </div>
+        <button
+          className={`flex items-center gap-1.5 ${regressionCountReal > 0 ? 'cursor-pointer' : ''}`}
+          onClick={() => regressionCountReal > 0 && setShowRegressionsOnly(!showRegressionsOnly)}
+        >
+          <TrendingDown size={13} className={regressionCountReal > 0 ? 'text-red-500' : 'text-green-500'} />
+          <span className={`font-semibold ${regressionCountReal > 0 ? 'text-red-500' : 'text-green-500'}`}>
+            {regressionCountReal}
+          </span>
+          <span className={`text-muted-foreground ${regressionCountReal > 0 ? 'underline decoration-dotted' : ''}`}>
+            regressions{showRegressionsOnly ? ' (filtered)' : ''}
+          </span>
+        </button>
+      </div>
+      </TooltipProvider>
+
+      {/* ── View Toggle ────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center border border-border rounded-md overflow-hidden">
+          <button onClick={() => setViewMode('grouped')} className={`px-2 py-1 text-xs flex items-center gap-1 transition-colors ${viewMode === 'grouped' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+            <Layers size={11} /> Grouped
+          </button>
+          <button onClick={() => setViewMode('flat')} className={`px-2 py-1 text-xs flex items-center gap-1 transition-colors ${viewMode === 'flat' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+            <List size={11} /> Flat
+          </button>
+        </div>
+        <span className="text-[10px] text-muted-foreground">{totalRuns} run{totalRuns !== 1 ? 's' : ''}</span>
+      </div>
+
+      {/* ── Table ──────────────────────────────────────────────────── */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto rounded-lg border border-border">
+        <table className="w-full caption-bottom text-sm">
+          <thead className={`sticky top-0 z-10 bg-background transition-shadow duration-200 ${isScrolled ? 'shadow-sm' : ''}`}>
+            <tr className="border-b">
+              <th className="h-7 w-8 px-2 align-middle bg-background border-b" />
+              <th className="h-7 w-8 px-2 align-middle bg-background border-b" />
+              <SortHeader label="Run" active={sort.field === 'runId'} dir={sort.dir} onClick={() => handleSort('runId')} />
+              {viewMode === 'flat' && (
+                <SortHeader label="Benchmark" active={sort.field === 'benchmark'} dir={sort.dir} onClick={() => handleSort('benchmark')} />
+              )}
+              <SortHeader label="Agent" active={sort.field === 'agent'} dir={sort.dir} onClick={() => handleSort('agent')} />
+              <th className="h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Model</th>
+              <SortHeader label="Timestamp" active={sort.field === 'timestamp'} dir={sort.dir} onClick={() => handleSort('timestamp')} />
+              <th className="h-7 px-2 text-center align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Annotations</th>
+              <SortHeader label="Pass/Fail/Total" active={sort.field === 'results'} dir={sort.dir} onClick={() => handleSort('results')} className="text-right" />
+            </tr>
+          </thead>
+          <tbody className="[&_tr:last-child]:border-0">
+            {filteredRunRows.length === 0 ? (
+              <tr>
+                <td colSpan={viewMode === 'flat' ? 9 : 8} className="py-16 text-center text-sm text-muted-foreground">
+                  {activeFilterCount > 0 ? 'No runs match the current filters' : timeRange === 'all' ? 'No evaluation runs found' : `No runs in ${TIME_OPTIONS.find(o => o.value === timeRange)?.label}`}
+                </td>
+              </tr>
+            ) : viewMode === 'flat' ? (
+              sortRows(showRegressionsOnly ? filteredRunRows.filter(rr => regressionData.runIds.has(rr.run.id)) : filteredRunRows).map(rr => renderRunRow(rr, true))
+            ) : (
+              groupedByBenchmark.map(group => {
+                const isCollapsed = collapsedGroups.has(group.id);
+                const sorted = sortRows(group.rows);
+                const groupPassed = group.rows.filter(r => r.failed === 0 && r.passed > 0).length;
+                const groupRunIds = group.rows.map(r => r.run.id);
+                const allGroupSelected = groupRunIds.length > 0 && groupRunIds.every(id => selectedRuns.has(id));
+                const someGroupSelected = groupRunIds.some(id => selectedRuns.has(id));
+                return (
+                  <React.Fragment key={group.id}>
+                    <tr
+                      className="border-b cursor-pointer hover:bg-muted/30 transition-colors bg-purple-50 dark:bg-purple-500/5"
+                      onClick={() => toggleGroup(group.id)}
+                    >
+                      {/* Checkbox cell — aligns with run row checkboxes */}
+                      <td className="px-2 py-1.5 align-middle text-center w-8" onClick={e => e.stopPropagation()}>
+                        <button
+                          onClick={e => toggleBenchmarkSelection(groupRunIds, e)}
+                          className={`h-4 w-4 rounded border-2 flex items-center justify-center transition-colors shrink-0
+                            ${allGroupSelected
+                              ? 'bg-primary border-primary text-primary-foreground'
+                              : someGroupSelected
+                                ? 'bg-primary/40 border-primary/60 text-primary-foreground'
+                                : 'border-muted-foreground/40 hover:border-muted-foreground/70 bg-transparent cursor-pointer'
+                            }`}
+                          aria-label={allGroupSelected ? 'Deselect all runs in benchmark' : 'Select all runs in benchmark'}
+                        >
+                          {allGroupSelected ? (
+                            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" className="shrink-0">
+                              <path d="M2 5L4.5 7.5L8 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          ) : someGroupSelected ? (
+                            <div className="w-2 h-0.5 bg-current rounded-full" />
+                          ) : null}
+                        </button>
+                      </td>
+                      {/* Rest of group header content */}
+                      <td colSpan={7} className="px-1 py-1.5 align-middle">
+                        <div className="flex items-center gap-2">
+                          <span className="text-muted-foreground">
+                            {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                          </span>
+                          <Badge className="text-[9px] px-1 py-0 bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-500/15 dark:text-purple-400 dark:border-purple-500/30 font-semibold uppercase tracking-wider">
+                            Benchmark
+                          </Badge>
+                          <span className="text-xs font-semibold">{group.name}</span>
+                          <span className="text-[10px] text-muted-foreground">({group.rows.length} run{group.rows.length !== 1 ? 's' : ''})</span>
+                          <span className="text-[10px] text-muted-foreground">{groupPassed}/{group.rows.length} all passed</span>
+                        </div>
+                      </td>
+                    </tr>
+                    {!isCollapsed && sorted.map(rr => renderRunRow(rr, false))}
+                  </React.Fragment>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/components/evals3/RunDetailsFlyout.tsx
+++ b/components/evals3/RunDetailsFlyout.tsx
@@ -1,0 +1,70 @@
+/*
+ * RunDetailsFlyout — Evals 3: Test Case Run detail flyout
+ *
+ * Slides in from the right (same pattern as TraceFlyoutContent in Agent Traces).
+ * Shows RunDetailsContent inside a resizable flyout panel.
+ * Triggered from BenchmarkRunDetailPage when clicking a test case result row.
+ */
+
+import React from 'react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { EvaluationReport, TestCase } from '@/types';
+import { TestCaseInspectorPanel } from './TestCaseInspectorPanel';
+
+type ResultStatus = 'passed' | 'failed' | 'running' | 'pending';
+
+function getResultStatus(report: EvaluationReport): ResultStatus {
+  if (report.passFailStatus === 'passed') return 'passed';
+  if (report.passFailStatus === 'failed') return 'failed';
+  if (report.status === 'running') return 'running';
+  return 'pending';
+}
+
+interface RunDetailsFlyoutProps {
+  report: EvaluationReport;
+  testCase: TestCase | null;
+  onClose: () => void;
+}
+
+export const RunDetailsFlyout: React.FC<RunDetailsFlyoutProps> = ({
+  report,
+  testCase,
+  onClose,
+}) => {
+  return (
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <ResizablePanelGroup direction="horizontal" className="h-full pointer-events-none">
+        {/* Left invisible panel — click-through to page below */}
+        <ResizablePanel
+          defaultSize={30}
+          minSize={5}
+          maxSize={60}
+          className="pointer-events-none"
+          onClick={onClose}
+        />
+
+        <ResizableHandle withHandle className="pointer-events-auto" />
+
+        {/* Right panel — flyout content */}
+        <ResizablePanel
+          defaultSize={70}
+          minSize={40}
+          maxSize={95}
+          className="bg-background border-l shadow-2xl pointer-events-auto"
+        >
+          <div className="h-full flex flex-col">
+            {/* ── Body — TestCaseInspectorPanel ───────────────────── */}
+            <div className="flex-1 overflow-hidden">
+              <TestCaseInspectorPanel
+                report={report}
+                testCase={testCase}
+                status={getResultStatus(report)}
+                onClose={onClose}
+              />
+            </div>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+};

--- a/components/evals3/RunInspectorPage.tsx
+++ b/components/evals3/RunInspectorPage.tsx
@@ -1,0 +1,386 @@
+/*
+ * RunInspectorPage — Evals 3: Unified Run Inspection
+ *
+ * Replaces BenchmarkRunDetailPage with a single-screen inspection workflow.
+ * Layout:
+ *   ┌─────────────────────────────────────────────────────────────────┐
+ *   │ Top Summary Bar (run metadata: agent, model, time, score)      │
+ *   ├──────────────────┬──────────────────────────────────────────────┤
+ *   │ Left Panel       │ Right Panel                                  │
+ *   │ Test case list   │ Selected test case detail                    │
+ *   │ with inline      │ Tabs: Conversation | Traces | Judge | Notes │
+ *   │ expand for       │                                              │
+ *   │ input/expected   │                                              │
+ *   └──────────────────┴──────────────────────────────────────────────┘
+ *
+ * Route: /evaluations/benchmarks/:benchmarkId/runs/:runId/inspect
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft, CheckCircle2, XCircle, Loader2, Clock, Calendar,
+  ChevronDown, ChevronRight,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { asyncBenchmarkStorage, asyncTestCaseStorage, asyncRunStorage } from '@/services/storage';
+import { Benchmark, BenchmarkRun, TestCase, EvaluationReport } from '@/types';
+import { DEFAULT_CONFIG } from '@/lib/constants';
+import { formatDate, getModelName, getLabelColor } from '@/lib/utils';
+import { TestCaseInspectorPanel } from './TestCaseInspectorPanel';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type ResultStatus = 'passed' | 'failed' | 'running' | 'pending';
+
+interface TestCaseResult {
+  testCaseId: string;
+  testCase: TestCase | null;
+  reportId: string | null;
+  status: ResultStatus;
+}
+
+function getResultStatus(runResult: { status: string }): ResultStatus {
+  if (runResult.status === 'running') return 'running';
+  if (runResult.status === 'pending') return 'pending';
+  if (runResult.status === 'completed') return 'passed';
+  if (runResult.status === 'failed' || runResult.status === 'cancelled') return 'failed';
+  return 'pending';
+}
+
+function StatusIcon({ status, size = 14 }: { status: ResultStatus; size?: number }) {
+  switch (status) {
+    case 'passed': return <CheckCircle2 size={size} className="text-green-500" />;
+    case 'failed': return <XCircle size={size} className="text-red-500" />;
+    case 'running': return <Loader2 size={size} className="text-blue-600 dark:text-blue-400 animate-spin" />;
+    case 'pending': return <Clock size={size} className="text-muted-foreground" />;
+  }
+}
+
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const RunInspectorPage: React.FC = () => {
+  const { benchmarkId, runId } = useParams<{ benchmarkId: string; runId: string }>();
+  const navigate = useNavigate();
+
+  const [benchmark, setBenchmark] = useState<Benchmark | null>(null);
+  const [run, setRun] = useState<BenchmarkRun | null>(null);
+  const [results, setResults] = useState<TestCaseResult[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Selected test case
+  const [selectedTcId, setSelectedTcId] = useState<string | null>(null);
+  const [selectedReport, setSelectedReport] = useState<EvaluationReport | null>(null);
+  const [reportLoading, setReportLoading] = useState(false);
+  const initialSelectionDone = React.useRef(false);
+
+  // Expanded test cases in left panel (for inline input/expected preview)
+  const [expandedTcs, setExpandedTcs] = useState<Set<string>>(new Set());
+
+  // ─── Data Loading ────────────────────────────────────────────────────────
+
+  const loadData = useCallback(async () => {
+    if (!benchmarkId || !runId) return;
+    setLoading(true);
+    try {
+      const bm = await asyncBenchmarkStorage.getById(benchmarkId);
+      if (!bm) { navigate('/evaluations/benchmarks'); return; }
+      setBenchmark(bm);
+
+      const bmRun = bm.runs?.find(r => r.id === runId);
+      if (!bmRun) { navigate(`/evaluations/benchmarks/${benchmarkId}/runs`); return; }
+      setRun(bmRun);
+
+      const tcIds = Object.keys(bmRun.results || {});
+      const testCases = await asyncTestCaseStorage.getByIds(tcIds);
+      const tcMap = new Map(testCases.map(tc => [tc.id, tc]));
+
+      const resultRows: TestCaseResult[] = tcIds.map(tcId => {
+        const runResult = bmRun.results[tcId];
+        return {
+          testCaseId: tcId,
+          testCase: tcMap.get(tcId) || null,
+          reportId: runResult?.reportId || null,
+          status: getResultStatus(runResult),
+        };
+      });
+
+      setResults(resultRows);
+
+      // Auto-select first test case and expand it (only on initial load)
+      if (resultRows.length > 0 && !initialSelectionDone.current) {
+        setSelectedTcId(resultRows[0].testCaseId);
+        setExpandedTcs(new Set([resultRows[0].testCaseId]));
+        initialSelectionDone.current = true;
+      }
+    } catch (error) {
+      console.error('Failed to load:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [benchmarkId, runId, navigate]);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  // Load report when selection changes
+  useEffect(() => {
+    if (!selectedTcId) { setSelectedReport(null); return; }
+    const result = results.find(r => r.testCaseId === selectedTcId);
+    if (!result?.reportId) { setSelectedReport(null); return; }
+
+    setReportLoading(true);
+    asyncRunStorage.getReportById(result.reportId)
+      .then(report => setSelectedReport(report || null))
+      .catch(() => setSelectedReport(null))
+      .finally(() => setReportLoading(false));
+  }, [selectedTcId, results]);
+
+  // ─── Derived ─────────────────────────────────────────────────────────────
+
+  const passCount = results.filter(r => r.status === 'passed').length;
+  const failCount = results.filter(r => r.status === 'failed').length;
+  const totalCount = results.length;
+  const passRate = totalCount > 0 ? Math.round((passCount / totalCount) * 100) : 0;
+
+  const selectedResult = results.find(r => r.testCaseId === selectedTcId) || null;
+
+  const toggleExpand = (tcId: string) => {
+    setExpandedTcs(prev => {
+      const n = new Set(prev);
+      n.has(tcId) ? n.delete(tcId) : n.add(tcId);
+      return n;
+    });
+  };
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  if (loading || !benchmark || !run) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-10 w-60" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-[calc(100vh-200px)] w-full" />
+      </div>
+    );
+  }
+
+  const agentName = DEFAULT_CONFIG.agents.find(a => a.key === run.agentKey)?.name || run.agentKey;
+  const modelName = getModelName(run.modelId);
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* ── Top Summary Bar ────────────────────────────────────────── */}
+      <div className="px-4 py-3 border-b bg-card shrink-0">
+        {/* Back + Breadcrumb title */}
+        <div className="flex items-center gap-3 mb-2">
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => navigate(-1)}>
+            <ArrowLeft size={16} />
+          </Button>
+          <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <button
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate"
+              onClick={() => navigate(`/evaluations/benchmarks/${benchmarkId}/runs`)}
+            >
+              {benchmark.name}
+            </button>
+            <ChevronRight size={16} className="text-muted-foreground/50 shrink-0" />
+            <h2 className="text-xl font-bold truncate">{run.name}</h2>
+          </div>
+        </div>
+
+        {/* Metadata row — badge + all key info */}
+        <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap ml-10">
+          <Badge className="text-[10px] px-2 py-0.5 bg-muted text-muted-foreground border-border font-medium uppercase tracking-widest rounded shrink-0">
+            Evaluation Run
+          </Badge>
+          <span className="flex items-center gap-1"><Calendar size={11} /> {formatDate(run.createdAt)}</span>
+          <span className="text-muted-foreground/30">·</span>
+          <span>Agent: <span className="text-foreground">{agentName}</span></span>
+          <span className="text-muted-foreground/30">·</span>
+          <span>Model: <span className="text-foreground">{modelName}</span></span>
+          <span className="text-muted-foreground/30">·</span>
+          <span className="flex items-center gap-1.5">
+            <span className="text-green-500 font-medium">{passCount}✓</span>
+            <span className="text-red-500 font-medium">{failCount}✗</span>
+            <span>/ {totalCount}</span>
+          </span>
+          <span className="text-muted-foreground/30">·</span>
+          <span className={`font-medium ${passRate >= 80 ? 'text-green-500' : passRate >= 50 ? 'text-amber-500' : 'text-red-500'}`}>
+            {passRate}% pass rate
+          </span>
+        </div>
+      </div>
+
+      {/* ── Main Content: Left Panel + Right Panel ─────────────────── */}
+      {selectedTcId ? (
+      <ResizablePanelGroup direction="horizontal" className="flex-1">
+        {/* ── Left Panel: Test Case List ──────────────────────────── */}
+        <ResizablePanel defaultSize={35} minSize={25} maxSize={50} className="border-r">
+          <ScrollArea className="h-full">
+            <div className="px-3 pt-2 pb-1 border-b">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Test Cases</span>
+                <span className="text-[10px] text-muted-foreground">{results.length}</span>
+              </div>
+            </div>
+            <div className="p-2 space-y-0.5">
+              {results.map(r => {
+                const isSelected = r.testCaseId === selectedTcId;
+                const isExpanded = expandedTcs.has(r.testCaseId);
+                const tc = r.testCase;
+
+                return (
+                  <div key={r.testCaseId}>
+                    {/* Test case row */}
+                    <div
+                      className={`flex items-start gap-2 px-2.5 py-2 rounded-md cursor-pointer transition-colors ${
+                        isSelected ? 'bg-primary/10 border border-primary/30' : 'hover:bg-muted/50 border border-transparent'
+                      }`}
+                      onClick={() => setSelectedTcId(r.testCaseId)}
+                    >
+                      {/* Expand toggle */}
+                      <button
+                        className="p-0.5 rounded hover:bg-muted text-muted-foreground shrink-0 mt-0.5"
+                        onClick={e => { e.stopPropagation(); toggleExpand(r.testCaseId); }}
+                      >
+                        {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                      </button>
+
+                      <div className="shrink-0 mt-0.5">
+                        <StatusIcon status={r.status} size={14} />
+                      </div>
+
+                      <div className="flex-1 min-w-0">
+                        <div className={`text-xs font-medium leading-snug break-words ${isSelected ? 'text-foreground' : ''}`}>
+                          {tc?.name || r.testCaseId}
+                        </div>
+                        {tc?.labels && tc.labels.length > 0 && (
+                          <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+                            {tc.labels.slice(0, 2).map(l => (
+                              <Badge key={l} variant="outline" className={`text-[7px] px-1 py-0 ${getLabelColor(l)}`}>{l}</Badge>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <span className={`text-[10px] font-semibold shrink-0 mt-0.5 ${
+                        r.status === 'passed' ? 'text-green-500' : r.status === 'failed' ? 'text-red-500' : 'text-muted-foreground'
+                      }`}>
+                        {r.status === 'passed' ? 'PASS' : r.status === 'failed' ? 'FAIL' : r.status.toUpperCase()}
+                      </span>
+                    </div>
+
+                    {/* Inline expand: input + expected output */}
+                    {isExpanded && tc && (
+                      <div className="ml-7 mr-1 mb-1 mt-0.5 space-y-1.5 overflow-hidden">
+                        {/* Input prompt */}
+                        <div>
+                          <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Input</div>
+                          <div className="text-[10px] bg-muted/40 rounded px-2 py-1.5 border border-border max-h-16 overflow-y-auto break-words leading-relaxed">
+                            {tc.initialPrompt || '—'}
+                          </div>
+                        </div>
+                        {/* Expected outcomes */}
+                        {tc.expectedOutcomes && tc.expectedOutcomes.length > 0 && (
+                          <div>
+                            <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Expected</div>
+                            <ul className="space-y-0.5">
+                              {tc.expectedOutcomes.map((o, i) => (
+                                <li key={i} className="text-[10px] text-muted-foreground flex items-start gap-1 leading-snug">
+                                  <CheckCircle2 size={9} className="text-green-500 mt-0.5 shrink-0" />
+                                  <span className="break-words min-w-0">{o}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        {/* Context count */}
+                        {tc.context && tc.context.length > 0 && (
+                          <div className="text-[10px] text-muted-foreground">{tc.context.length} context item{tc.context.length !== 1 ? 's' : ''}</div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        {/* ── Right Panel: Test Case Inspector ────────────────────── */}
+        <ResizablePanel defaultSize={65} minSize={50}>
+          {selectedResult ? (
+            reportLoading ? (
+              <div className="flex items-center justify-center h-full">
+                <Loader2 size={20} className="animate-spin text-muted-foreground" />
+              </div>
+            ) : selectedReport ? (
+              <TestCaseInspectorPanel
+                report={selectedReport}
+                testCase={selectedResult.testCase}
+                status={selectedResult.status}
+                onClose={() => setSelectedTcId(null)}
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                <div className="text-center">
+                  {selectedResult.status === 'running' ? (
+                    <><Loader2 size={32} className="mx-auto mb-3 text-blue-600 dark:text-blue-400 animate-spin" /><p className="text-sm">Running...</p></>
+                  ) : selectedResult.status === 'pending' ? (
+                    <><Clock size={32} className="mx-auto mb-3 text-amber-600 dark:text-amber-400" /><p className="text-sm">Pending</p></>
+                  ) : (
+                    <><XCircle size={32} className="mx-auto mb-3 opacity-20" /><p className="text-sm">No report available</p></>
+                  )}
+                </div>
+              </div>
+            )
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <p className="text-sm">Select a test case to inspect</p>
+            </div>
+          )}
+        </ResizablePanel>
+      </ResizablePanelGroup>
+      ) : (
+        /* Full-width left panel when nothing selected */
+        <div className="flex-1 overflow-hidden">
+          <ScrollArea className="h-full">
+            <div className="px-3 pt-2 pb-1 border-b">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Test Cases</span>
+                <span className="text-[10px] text-muted-foreground">{results.length}</span>
+              </div>
+            </div>
+            <div className="p-2 space-y-0.5">
+              {results.map(r => {
+                const tc = r.testCase;
+                return (
+                  <div
+                    key={r.testCaseId}
+                    className="flex items-center gap-2 px-2.5 py-2 rounded-md cursor-pointer transition-colors hover:bg-muted/50 border border-transparent"
+                    onClick={() => setSelectedTcId(r.testCaseId)}
+                  >
+                    <StatusIcon status={r.status} size={14} />
+                    <span className="text-xs font-medium flex-1 min-w-0 truncate">{tc?.name || r.testCaseId}</span>
+                    <span className={`text-[10px] font-semibold shrink-0 ${
+                      r.status === 'passed' ? 'text-green-500' : r.status === 'failed' ? 'text-red-500' : 'text-muted-foreground'
+                    }`}>
+                      {r.status === 'passed' ? 'PASS' : r.status === 'failed' ? 'FAIL' : r.status.toUpperCase()}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/evals3/TestCaseDetailPage.tsx
+++ b/components/evals3/TestCaseDetailPage.tsx
@@ -1,0 +1,400 @@
+/*
+ * TestCaseDetailPage — Evals 3: Test Case drill-down
+ *
+ * Split-panel layout matching RunInspectorPage:
+ *   ┌─────────────────────────────────────────────────────────────────┐
+ *   │ ← Back to Test Cases   Test Case Name        Edit | Run Test   │
+ *   │ [TEST CASE] · labels · Created date · X runs · pass rate       │
+ *   ├──────────────────┬──────────────────────────────────────────────┤
+ *   │ Left Panel       │ Right Panel                                  │
+ *   │ ▸ DEFINITION     │ TestCaseInspectorPanel for selected run      │
+ *   │   5 expected     │                                              │
+ *   │   3 context      │                                              │
+ *   │ ─────────────    │                                              │
+ *   │ RUNS (timeline)  │                                              │
+ *   │ ✓ PASSED  88%    │                                              │
+ *   │ ✗ FAILED  33%    │                                              │
+ *   └──────────────────┴──────────────────────────────────────────────┘
+ *
+ * Route: /evaluations/test-cases/:testCaseId
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft, Play, Calendar, CheckCircle2, XCircle, Pencil,
+  ChevronDown, ChevronRight, FileText, Target,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { asyncTestCaseStorage, asyncRunStorage } from '@/services/storage';
+import { TestCase, EvaluationReport } from '@/types';
+import { getLabelColor, formatDate, formatRelativeTime, getModelName } from '@/lib/utils';
+import { QuickRunModal } from '../QuickRunModal';
+import { TestCaseEditor } from '../TestCaseEditor';
+import { TestCaseInspectorPanel } from './TestCaseInspectorPanel';
+
+type TimeRange = '1h' | '6h' | '1d' | '7d' | '30d' | 'all';
+const TIME_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' },
+  { value: 'all', label: 'All time' },
+];
+function getTimeThreshold(range: TimeRange): Date | null {
+  if (range === 'all') return null;
+  const ms: Record<string, number> = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 };
+  return new Date(Date.now() - ms[range]);
+}
+
+type ResultStatus = 'passed' | 'failed' | 'running' | 'pending';
+function getStatus(r: EvaluationReport): ResultStatus {
+  if (r.passFailStatus === 'passed') return 'passed';
+  if (r.passFailStatus === 'failed') return 'failed';
+  if (r.status === 'running') return 'running';
+  return 'pending';
+}
+
+export const TestCaseDetailPage: React.FC = () => {
+  const { testCaseId } = useParams<{ testCaseId: string }>();
+  const navigate = useNavigate();
+
+  const [testCase, setTestCase] = useState<TestCase | null>(null);
+  const [runs, setRuns] = useState<EvaluationReport[]>([]);
+  const [totalRuns, setTotalRuns] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // UI state
+  const [definitionOpen, setDefinitionOpen] = useState(false);
+  const [timeRange, setTimeRange] = useState<TimeRange>('all');
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [runningTestCase, setRunningTestCase] = useState<TestCase | null>(null);
+  const [showEditor, setShowEditor] = useState(false);
+  const initialSelectionDone = React.useRef(false);
+
+  const loadData = useCallback(async () => {
+    if (!testCaseId) return;
+    setIsLoading(true);
+    try {
+      const [tc, { reports, total }] = await Promise.all([
+        asyncTestCaseStorage.getById(testCaseId),
+        asyncRunStorage.getReportsByTestCase(testCaseId),
+      ]);
+      if (!tc) { navigate('/evaluations/test-cases'); return; }
+      setTestCase(tc);
+      const sorted = reports.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      setRuns(sorted);
+      setTotalRuns(total);
+      // Auto-select first run, auto-open definition if no runs (only on initial load)
+      if (sorted.length > 0 && !initialSelectionDone.current) {
+        setSelectedRunId(sorted[0].id);
+        initialSelectionDone.current = true;
+      }
+      if (sorted.length === 0) {
+        setDefinitionOpen(true);
+      }
+    } catch (error) {
+      console.error('Failed to load test case:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [testCaseId, navigate]);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  const filteredRuns = useMemo(() => {
+    const threshold = getTimeThreshold(timeRange);
+    if (!threshold) return runs;
+    return runs.filter(r => new Date(r.timestamp) >= threshold);
+  }, [runs, timeRange]);
+
+  const passCount = filteredRuns.filter(r => r.passFailStatus === 'passed').length;
+  const failCount = filteredRuns.filter(r => r.passFailStatus === 'failed').length;
+  const passRate = filteredRuns.length > 0 ? Math.round((passCount / filteredRuns.length) * 100) : 0;
+
+  const selectedRun = filteredRuns.find(r => r.id === selectedRunId) || null;
+
+  if (isLoading || !testCase) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-10 w-60" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-[calc(100vh-200px)] w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* ── Top Summary Bar ────────────────────────────────────────── */}
+      <div className="px-4 py-3 border-b bg-card shrink-0">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => navigate(-1)}>
+              <ArrowLeft size={16} />
+            </Button>
+            <h2 className="text-xl font-bold truncate">{testCase.name}</h2>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button variant="outline" size="sm" className="h-7 text-xs" onClick={() => setShowEditor(true)}>
+              <Pencil size={12} className="mr-1" /> Edit
+            </Button>
+            <Button size="sm" className="h-7 text-xs bg-opensearch-blue hover:bg-blue-600" onClick={() => setRunningTestCase(testCase)}>
+              <Play size={12} className="mr-1" /> Run Test
+            </Button>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap ml-10">
+          <Badge className="text-[10px] px-2 py-0.5 bg-muted text-muted-foreground border-border font-medium uppercase tracking-widest rounded shrink-0">
+            Test Case
+          </Badge>
+          {testCase.labels?.length > 0 && testCase.labels.slice(0, 3).map(l => (
+            <Badge key={l} variant="outline" className={`text-[9px] px-1.5 py-0 ${getLabelColor(l)}`}>{l}</Badge>
+          ))}
+          <span className="flex items-center gap-1"><Calendar size={11} /> {formatDate(testCase.createdAt)}</span>
+          <span className="text-muted-foreground/30">·</span>
+          <span>{totalRuns} run{totalRuns !== 1 ? 's' : ''}</span>
+          <span className="text-muted-foreground/30">·</span>
+          <span className="flex items-center gap-1.5">
+            <span className="text-green-500 font-medium">{passCount}✓</span>
+            <span className="text-red-500 font-medium">{failCount}✗</span>
+          </span>
+          <span className="text-muted-foreground/30">·</span>
+          <span className={`font-medium ${passRate >= 80 ? 'text-green-500' : passRate >= 50 ? 'text-amber-500' : 'text-red-500'}`}>
+            {passRate}% pass rate
+          </span>
+        </div>
+      </div>
+
+      {/* ── Main Content: Left Panel + Right Panel ─────────────────── */}
+      {selectedRunId ? (
+      <ResizablePanelGroup direction="horizontal" className="flex-1">
+        {/* ── Left Panel ──────────────────────────────────────────── */}
+        <ResizablePanel defaultSize={30} minSize={20} maxSize={45} className="border-r">
+          <ScrollArea className="h-full">
+            {/* ── Collapsible Definition ──────────────────────────── */}
+            <div className="border-b">
+              <button
+                onClick={() => setDefinitionOpen(!definitionOpen)}
+                className="w-full flex items-center justify-between px-3 py-2 hover:bg-muted/30 transition-colors"
+              >
+                <div className="flex items-center gap-2">
+                  {definitionOpen ? <ChevronDown size={12} className="text-muted-foreground" /> : <ChevronRight size={12} className="text-muted-foreground" />}
+                  <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Definition</span>
+                </div>
+                <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                  {testCase.expectedOutcomes?.length > 0 && (
+                    <span className="flex items-center gap-0.5"><Target size={9} /> {testCase.expectedOutcomes.length} expected</span>
+                  )}
+                  {testCase.context?.length > 0 && (
+                    <span>{testCase.context.length} context</span>
+                  )}
+                </div>
+              </button>
+              {definitionOpen && (
+                <div className="px-3 pb-3 space-y-2.5">
+                  {/* Input prompt */}
+                  <div>
+                    <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Input</div>
+                    <div className="text-[10px] bg-muted/40 rounded px-2 py-1.5 border border-border max-h-20 overflow-y-auto break-words leading-relaxed">
+                      {testCase.initialPrompt || '—'}
+                    </div>
+                  </div>
+                  {/* Expected outcomes */}
+                  {testCase.expectedOutcomes?.length > 0 && (
+                    <div>
+                      <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Expected</div>
+                      <ul className="space-y-0.5">
+                        {testCase.expectedOutcomes.map((o, i) => (
+                          <li key={i} className="text-[10px] text-muted-foreground flex items-start gap-1 leading-snug">
+                            <CheckCircle2 size={9} className="text-green-500 mt-0.5 shrink-0" />
+                            <span className="break-words min-w-0">{o}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {/* Context */}
+                  {testCase.context?.length > 0 && (
+                    <div>
+                      <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Context ({testCase.context.length})</div>
+                      <div className="space-y-1">
+                        {testCase.context.map((ctx, i) => (
+                          <div key={i} className="bg-muted/30 rounded px-2 py-1 border border-border overflow-hidden">
+                            <p className="text-[9px] font-medium text-muted-foreground truncate">{ctx.description}</p>
+                            <pre className="text-[9px] overflow-x-auto max-h-10 overflow-y-auto whitespace-pre-wrap break-all">{ctx.value.slice(0, 100)}{ctx.value.length > 100 ? '…' : ''}</pre>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* ── Runs List ───────────────────────────────────────── */}
+            <div className="px-3 pt-2 pb-1 border-b flex items-center justify-between">
+              <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Test Case Runs ({filteredRuns.length})</span>
+              <select
+                value={timeRange}
+                onChange={e => setTimeRange(e.target.value as TimeRange)}
+                className="text-[10px] px-1.5 py-0.5 bg-background border border-border rounded"
+              >
+                {TIME_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div className="p-2 space-y-0.5">
+              {filteredRuns.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+                  <FileText size={24} className="mb-2 opacity-20" />
+                  <p className="text-[10px]">No runs yet</p>
+                </div>
+              ) : (
+                filteredRuns.map((run, index) => {
+                  const isPassed = run.passFailStatus === 'passed';
+                  const isSelected = run.id === selectedRunId;
+                  const isLatest = index === 0;
+                  return (
+                    <div
+                      key={run.id}
+                      className={`flex items-start gap-2 px-2 py-1.5 rounded-md cursor-pointer transition-colors ${
+                        isSelected ? 'bg-primary/10 border border-primary/30' : 'hover:bg-muted/50 border border-transparent'
+                      }`}
+                      onClick={() => setSelectedRunId(run.id)}
+                    >
+                      <div className="shrink-0 mt-0.5">
+                        {isPassed
+                          ? <CheckCircle2 size={12} className="text-green-500" />
+                          : <XCircle size={12} className="text-red-500" />}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <span className={`text-[11px] font-semibold ${isPassed ? 'text-green-500' : 'text-red-500'}`}>
+                            {isPassed ? 'PASSED' : 'FAILED'}
+                          </span>
+                          {isLatest && (
+                            <Badge variant="outline" className="text-[7px] px-1 py-0 bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-500/10 dark:text-blue-400 dark:border-blue-500/30">
+                              Latest
+                            </Badge>
+                          )}
+                          <span className="text-[10px] font-semibold text-blue-600 dark:text-blue-400 ml-auto shrink-0">
+                            {run.metrics?.accuracy ?? '—'}%
+                          </span>
+                        </div>
+                        <div className="text-[9px] text-muted-foreground mt-0.5 break-words">
+                          <span className="font-mono">{run.id.slice(0, 10)}</span> · {formatRelativeTime(run.timestamp)} · {getModelName(run.modelName)}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </ScrollArea>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        {/* ── Right Panel: Test Case Inspector ────────────────────── */}
+        <ResizablePanel defaultSize={70} minSize={50}>
+          {selectedRun ? (
+            <TestCaseInspectorPanel
+              report={selectedRun}
+              testCase={testCase}
+              status={getStatus(selectedRun)}
+              onClose={() => setSelectedRunId(null)}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <div className="text-center">
+                <FileText size={32} className="mx-auto mb-3 opacity-20" />
+                <p className="text-sm">{filteredRuns.length === 0 ? 'No test case runs yet' : 'Select a run to inspect'}</p>
+                {filteredRuns.length === 0 && testCase && (
+                  <Button size="sm" className="mt-3 bg-opensearch-blue hover:bg-blue-600" onClick={() => setRunningTestCase(testCase)}>
+                    <Play size={12} className="mr-1" /> Run Test
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </ResizablePanel>
+      </ResizablePanelGroup>
+      ) : (
+        /* Full-width left panel when no run selected */
+        <div className="flex-1 overflow-hidden">
+          <ScrollArea className="h-full">
+            {/* Definition section — always open when no run selected */}
+            <div className="border-b px-4 py-3 space-y-2.5">
+              <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Definition</div>
+              <div>
+                <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Input</div>
+                <div className="text-xs bg-muted/40 rounded px-3 py-2 border border-border break-words leading-relaxed">
+                  {testCase.initialPrompt || '—'}
+                </div>
+              </div>
+              {testCase.expectedOutcomes?.length > 0 && (
+                <div>
+                  <div className="text-[9px] font-semibold text-muted-foreground uppercase tracking-wider mb-0.5">Expected</div>
+                  <ul className="space-y-1">
+                    {testCase.expectedOutcomes.map((o, i) => (
+                      <li key={i} className="text-xs text-muted-foreground flex items-start gap-1.5">
+                        <CheckCircle2 size={11} className="text-green-500 mt-0.5 shrink-0" />
+                        <span>{o}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+            {/* Runs list */}
+            <div className="px-4 pt-3 pb-1 flex items-center justify-between">
+              <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Test Case Runs ({filteredRuns.length})</span>
+            </div>
+            <div className="px-4 py-2 space-y-1">
+              {filteredRuns.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                  <FileText size={32} className="mb-3 opacity-20" />
+                  <p className="text-sm">No test case runs yet</p>
+                  <Button size="sm" className="mt-3 bg-opensearch-blue hover:bg-blue-600" onClick={() => setRunningTestCase(testCase)}>
+                    <Play size={12} className="mr-1" /> Run Test
+                  </Button>
+                </div>
+              ) : (
+                filteredRuns.map((run, index) => {
+                  const isPassed = run.passFailStatus === 'passed';
+                  return (
+                    <div
+                      key={run.id}
+                      className="flex items-center gap-3 px-3 py-2 rounded-md cursor-pointer transition-colors hover:bg-muted/50 border border-transparent"
+                      onClick={() => setSelectedRunId(run.id)}
+                    >
+                      {isPassed ? <CheckCircle2 size={14} className="text-green-500 shrink-0" /> : <XCircle size={14} className="text-red-500 shrink-0" />}
+                      <span className={`text-xs font-semibold ${isPassed ? 'text-green-500' : 'text-red-500'}`}>{isPassed ? 'PASSED' : 'FAILED'}</span>
+                      {index === 0 && <Badge variant="outline" className="text-[7px] px-1 py-0 bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-500/10 dark:text-blue-400 dark:border-blue-500/30">Latest</Badge>}
+                      <span className="text-[10px] text-muted-foreground flex-1">{formatRelativeTime(run.timestamp)} · {getModelName(run.modelName)}</span>
+                      <span className="text-xs font-semibold text-blue-600 dark:text-blue-400 shrink-0">{run.metrics?.accuracy ?? '—'}%</span>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+
+      {/* ── Modals ─────────────────────────────────────────────────── */}
+      {runningTestCase && (
+        <QuickRunModal testCase={runningTestCase} onClose={() => { setRunningTestCase(null); loadData(); }} onSaveAsTestCase={() => {}} />
+      )}
+      {showEditor && (
+        <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm">
+          <div className="fixed inset-4 z-50 overflow-auto bg-background border rounded-lg shadow-lg">
+            <TestCaseEditor testCase={testCase} onSave={async () => { setShowEditor(false); loadData(); }} onCancel={() => setShowEditor(false)} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/evals3/TestCaseInspectorPanel.tsx
+++ b/components/evals3/TestCaseInspectorPanel.tsx
@@ -1,0 +1,100 @@
+/*
+ * TestCaseInspectorPanel — Evals 3: Right panel for test case inspection
+ *
+ * Shows everything needed to answer "Did my agent behave as expected?"
+ * Layout:
+ *   1. Compact summary header (status, accuracy, steps, timestamp, agent, model)
+ *   2. LLM Judge evaluation (collapsible, always visible by default)
+ *   3. Tabs: Conversation | Traces | LLM Judge | Annotations
+ */
+
+import React from 'react';
+import {
+  CheckCircle2, XCircle, Clock, MessageSquare, Target,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { EvaluationReport, TestCase } from '@/types';
+import { formatDate, getModelName } from '@/lib/utils';
+import { RunDetailsContent } from '../RunDetailsContent';
+
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+type ResultStatus = 'passed' | 'failed' | 'running' | 'pending';
+
+interface TestCaseInspectorPanelProps {
+  report: EvaluationReport;
+  testCase: TestCase | null;
+  status: ResultStatus;
+  onClose?: () => void;
+}
+
+
+export const TestCaseInspectorPanel: React.FC<TestCaseInspectorPanelProps> = ({
+  report,
+  testCase,
+  status,
+  onClose,
+}) => {
+  const isPassed = report.passFailStatus === 'passed';
+  const accuracy = report.metrics?.accuracy;
+  const faithfulness = report.metrics?.faithfulness;
+  const modelName = getModelName(report.modelName);
+  const conversationSteps = report.trajectory?.length || 0;
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* ── Compact Summary Bar ────────────────────────────────────── */}
+      <div className="px-4 py-2.5 border-b bg-card shrink-0">
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="flex items-center gap-2 min-w-0">
+            {isPassed
+              ? <CheckCircle2 size={16} className="text-green-500 shrink-0" />
+              : <XCircle size={16} className="text-red-500 shrink-0" />}
+            <span className="text-base font-semibold truncate">{testCase?.name || report.testCaseId}</span>
+            <Badge className={`text-[9px] px-1.5 py-0 shrink-0 ${
+              isPassed ? 'bg-green-100 text-green-700 border-green-300 dark:bg-green-500/15 dark:text-green-500 dark:border-green-500/30' : 'bg-red-100 text-red-700 border-red-300 dark:bg-red-500/15 dark:text-red-500 dark:border-red-500/30'
+            }`}>
+              {isPassed ? 'PASSED' : 'FAILED'}
+            </Badge>
+          </div>
+          {onClose && (
+            <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground" onClick={onClose} title="Close">
+              <X size={14} />
+            </Button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 text-[11px] text-muted-foreground flex-wrap">
+          <Badge className="text-[10px] px-2 py-0.5 bg-muted text-muted-foreground border-border font-medium uppercase tracking-widest rounded shrink-0">
+            Test Case Run
+          </Badge>
+          {accuracy != null && (
+            <span className="flex items-center gap-1">
+              <Target size={10} />
+              Accuracy: <span className={`font-medium ${accuracy >= 50 ? 'text-green-500' : 'text-red-500'}`}>{accuracy}%</span>
+            </span>
+          )}
+          {faithfulness != null && (
+            <span className="flex items-center gap-1">
+              Faithfulness: <span className="font-medium text-blue-600 dark:text-blue-400">{faithfulness}%</span>
+            </span>
+          )}
+          <span className="flex items-center gap-1">
+            <MessageSquare size={10} /> {conversationSteps} steps
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock size={10} /> {formatDate(report.timestamp)}
+          </span>
+          <span>Agent: {report.agentName}</span>
+          <span>Model: {modelName}</span>
+        </div>
+      </div>
+
+      {/* ── Tabs: Conversation, Traces, Judge, Annotations ─────────── */}
+      <div className="flex-1 overflow-hidden">
+        <RunDetailsContent report={report} />
+      </div>
+    </div>
+  );
+};

--- a/components/evals3/TestCasesPage.tsx
+++ b/components/evals3/TestCasesPage.tsx
@@ -1,0 +1,503 @@
+/*
+ * TestCasesPage4 — Evals 3: Test Cases
+ *
+ * Agent Traces-style filter bar + sticky table headers + sortable columns.
+ * Grouped by benchmark with expand/collapse toggle.
+ * Time filter + search + agent filter in header (global, scopes both tabs).
+ * Benchmark count as "In N benchmarks" with click-to-expand dropdown.
+ * Benchmark name count moved left next to group header.
+ */
+
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ChevronRight, ChevronDown, CheckCircle2, XCircle,
+  Loader2, Clock, Search, RefreshCw, Activity, BarChart3,
+  SlidersHorizontal, Layers, List, ChevronsDownUp, ChevronsUpDown, Upload, Plus,
+  Pencil, Play, Calendar,
+} from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { asyncTestCaseStorage, asyncRunStorage, asyncBenchmarkStorage } from '@/services/storage';
+import { TestCase, TestCaseRun, Benchmark } from '@/types';
+import { formatRelativeTime } from '@/lib/utils';
+import { TestCaseEditor } from '../TestCaseEditor';
+import { QuickRunModal } from '../QuickRunModal';
+import { validateTestCasesArrayJson } from '@/lib/testCaseValidation';
+
+// ─── Time Filter ─────────────────────────────────────────────────────────────
+
+type TimeRange = '1h' | '6h' | '1d' | '7d' | '30d' | 'all';
+const TIME_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: '1h', label: 'Last 1h' }, { value: '6h', label: 'Last 6h' },
+  { value: '1d', label: 'Last 1d' }, { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' }, { value: 'all', label: 'All time' },
+];
+function getTimeThreshold(range: TimeRange): Date | null {
+  if (range === 'all') return null;
+  const ms: Record<string, number> = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 };
+  return new Date(Date.now() - ms[range]);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function truncate(s: string | undefined, max: number): string {
+  if (!s) return '—';
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+function getPassFail(run: TestCaseRun): 'pass' | 'fail' | 'running' | 'unknown' {
+  if (run.status === 'running') return 'running';
+  if (run.passFailStatus === 'passed') return 'pass';
+  if (run.passFailStatus === 'failed') return 'fail';
+  if (run.status === 'completed') return run.metrics?.accuracy >= 50 ? 'pass' : 'fail';
+  return 'unknown';
+}
+
+
+function PassFailBadge({ result }: { result: 'pass' | 'fail' | 'running' | 'unknown' }) {
+  const c = {
+    pass: { icon: <CheckCircle2 size={12} />, label: 'Pass', cls: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-500/10 border-green-300 dark:border-green-500/20' },
+    fail: { icon: <XCircle size={12} />, label: 'Fail', cls: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-500/10 border-red-300 dark:border-red-500/20' },
+    running: { icon: <Loader2 size={12} className="animate-spin" />, label: 'Running', cls: 'text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-500/10 border-blue-300 dark:border-blue-500/20' },
+    unknown: { icon: <Clock size={12} />, label: '—', cls: 'text-muted-foreground bg-muted/50 border-border' },
+  }[result];
+  return <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium border ${c.cls}`}>{c.icon} {c.label}</span>;
+}
+
+type SortField = 'name' | 'created' | 'lastRun' | 'runs' | 'passRate';
+type SortDir = 'asc' | 'desc';
+
+function SortHeader({ label, active, dir, onClick, className }: {
+  label: string; active: boolean; dir: SortDir; onClick: () => void; className?: string;
+}) {
+  return (
+    <th className={`h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b cursor-pointer select-none hover:text-foreground transition-colors whitespace-nowrap ${className || ''}`}
+      onClick={onClick}>
+      <span className="inline-flex items-center gap-1">{label}{active && <ChevronDown size={10} className={dir === 'asc' ? 'rotate-180' : ''} />}</span>
+    </th>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export const TestCasesPage4: React.FC = () => {
+  const navigate = useNavigate();
+  const [testCases, setTestCases] = useState<TestCase[]>([]);
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([]);
+  const [runCounts, setRunCounts] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [viewMode, setViewMode] = useState<'flat' | 'grouped'>('flat');
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d');
+  const [openPopoverId, setOpenPopoverId] = useState<string | null>(null);
+  const [selectedBenchmark, setSelectedBenchmark] = useState<string>('all');
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Import/Editor state
+  const [isImporting, setIsImporting] = useState(false);
+  const [showEditor, setShowEditor] = useState(false);
+  const [editingTestCase, setEditingTestCase] = useState<TestCase | null>(null);
+  const [runningTestCase, setRunningTestCase] = useState<TestCase | null>(null);
+
+  // Sort
+  const [sort, setSort] = useState<{ field: SortField; dir: SortDir }>({ field: 'created', dir: 'desc' });
+
+  // Runs tab — deferred
+  const [allRuns, setAllRuns] = useState<TestCaseRun[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const runsLoadedRef = useRef(false);
+
+  const loadDefinitions = useCallback(async () => {
+    try {
+      const [tcs, counts, bms] = await Promise.all([
+        asyncTestCaseStorage.getAll(), asyncRunStorage.getRunCountsByTestCase(), asyncBenchmarkStorage.getAll(),
+      ]);
+      setTestCases(tcs as TestCase[]); setRunCounts(counts); setBenchmarks(bms);
+    } catch (err) { console.error('Failed:', err); }
+    finally { setLoading(false); }
+  }, []);
+
+  const loadRuns = useCallback(async () => {
+    setRunsLoading(true);
+    try { const runs = await asyncRunStorage.getAllReports({ limit: 500 }); setAllRuns(runs as unknown as TestCaseRun[]); runsLoadedRef.current = true; }
+    catch (err) { console.error('Failed:', err); }
+    finally { setRunsLoading(false); }
+  }, []);
+
+  useEffect(() => { loadDefinitions(); }, [loadDefinitions]);
+
+  // Scroll shadow
+  useEffect(() => {
+    const el = scrollRef.current; if (!el) return;
+    const h = () => setIsScrolled(el.scrollTop > 10);
+    el.addEventListener('scroll', h); return () => el.removeEventListener('scroll', h);
+  }, []);
+
+  const tcMap = useMemo(() => new Map(testCases.map(tc => [tc.id, tc])), [testCases]);
+
+  // Reverse map: tcId → benchmarks
+  const tcBenchmarkMap = useMemo(() => {
+    const map = new Map<string, { id: string; name: string }[]>();
+    for (const bm of benchmarks) for (const tcId of bm.testCaseIds) {
+      if (!map.has(tcId)) map.set(tcId, []);
+      map.get(tcId)!.push({ id: bm.id, name: bm.name });
+    }
+    return map;
+  }, [benchmarks]);
+
+  // Latest run by TC (from all runs) — includes status and ID for the Last Run column
+  const latestRunByTc = useMemo(() => {
+    const map: Record<string, { timestamp: string; passed: boolean | null; id: string }> = {};
+    for (const run of allRuns) {
+      const tcId = (run as any).testCaseId;
+      if (tcId && (!map[tcId] || new Date(run.timestamp) > new Date(map[tcId].timestamp))) {
+        const passed = run.passFailStatus === 'passed' ? true : run.passFailStatus === 'failed' ? false : null;
+        map[tcId] = { timestamp: run.timestamp, passed, id: run.id };
+      }
+    }
+    return map;
+  }, [allRuns]);
+
+  // Pass rate per test case
+  const passRateByTc = useMemo(() => {
+    const counts: Record<string, { passed: number; total: number }> = {};
+    for (const run of allRuns) {
+      const tcId = (run as any).testCaseId;
+      if (!tcId) continue;
+      if (!counts[tcId]) counts[tcId] = { passed: 0, total: 0 };
+      counts[tcId].total++;
+      if (run.passFailStatus === 'passed') counts[tcId].passed++;
+    }
+    return counts;
+  }, [allRuns]);
+
+  // Filtered test cases
+  const filteredTcs = useMemo(() => {
+    let list = testCases;
+    if (search) { const q = search.toLowerCase(); list = list.filter(tc => tc.name.toLowerCase().includes(q) || tc.initialPrompt?.toLowerCase().includes(q) || tc.description?.toLowerCase().includes(q)); }
+    if (selectedBenchmark !== 'all') {
+      const bm = benchmarks.find(b => b.id === selectedBenchmark);
+      if (bm) {
+        const bmTcIds = new Set(bm.testCaseIds);
+        list = list.filter(tc => bmTcIds.has(tc.id));
+      }
+    }
+    return list;
+  }, [testCases, search, selectedBenchmark, benchmarks]);
+
+  // Sort test cases within groups (lastRun, runs)
+  const sortTcsWithinGroup = useCallback((tcs: TestCase[]): TestCase[] => {
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    if (sort.field === 'name') {
+      return [...tcs].sort((a, b) => dir * (a.name || '').localeCompare(b.name || ''));
+    }
+    return [...tcs].sort((a, b) => {
+      switch (sort.field) {
+        case 'lastRun': {
+          const aRun = latestRunByTc[a.id]?.timestamp || '';
+          const bRun = latestRunByTc[b.id]?.timestamp || '';
+          return dir * aRun.localeCompare(bRun);
+        }
+        case 'runs': return dir * ((runCounts[a.id] || 0) - (runCounts[b.id] || 0));
+        case 'passRate': {
+          const aRate = passRateByTc[a.id]?.total ? passRateByTc[a.id].passed / passRateByTc[a.id].total : -1;
+          const bRate = passRateByTc[b.id]?.total ? passRateByTc[b.id].passed / passRateByTc[b.id].total : -1;
+          return dir * (aRate - bRate);
+        }
+        default: return 0;
+      }
+    });
+  }, [sort, latestRunByTc, runCounts, passRateByTc]);
+
+  // For flat view: sort all test cases by the active sort field
+  const sortedTcs = useMemo(() => {
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...filteredTcs].sort((a, b) => {
+      switch (sort.field) {
+        case 'name': return dir * (a.name || '').localeCompare(b.name || '');
+        case 'created': return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+        case 'lastRun': {
+          const aRun = latestRunByTc[a.id]?.timestamp || '';
+          const bRun = latestRunByTc[b.id]?.timestamp || '';
+          return dir * aRun.localeCompare(bRun);
+        }
+        case 'runs': return dir * ((runCounts[a.id] || 0) - (runCounts[b.id] || 0));
+        case 'passRate': {
+          const aRate = passRateByTc[a.id]?.total ? passRateByTc[a.id].passed / passRateByTc[a.id].total : -1;
+          const bRate = passRateByTc[b.id]?.total ? passRateByTc[b.id].passed / passRateByTc[b.id].total : -1;
+          return dir * (aRate - bRate);
+        }
+        default: return 0;
+      }
+    });
+  }, [filteredTcs, sort, latestRunByTc, runCounts, passRateByTc]);
+
+  const handleSort = (field: SortField) => {
+    setSort(prev => prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'asc' });
+  };
+
+  // Grouped data — Name sort applies to group order, other sorts apply within groups
+  const groupedData = useMemo(() => {
+    const assignedTcIds = new Set<string>();
+    const groups: { id: string; name: string; testCases: TestCase[] }[] = [];
+    for (const bm of benchmarks) {
+      const tcs = bm.testCaseIds.map(id => filteredTcs.find(tc => tc.id === id)).filter((tc): tc is TestCase => !!tc);
+      if (tcs.length > 0) {
+        groups.push({ id: bm.id, name: bm.name, testCases: sortTcsWithinGroup(tcs) });
+        tcs.forEach(tc => assignedTcIds.add(tc.id));
+      }
+    }
+    const unassigned = filteredTcs.filter(tc => !assignedTcIds.has(tc.id));
+    if (unassigned.length > 0) groups.push({ id: '__unassigned__', name: 'Unassigned', testCases: sortTcsWithinGroup(unassigned) });
+
+    // Sort groups by benchmark name when Name column is sorted
+    if (sort.field === 'name') {
+      const dir = sort.dir === 'asc' ? 1 : -1;
+      groups.sort((a, b) => {
+        if (a.id === '__unassigned__') return 1;
+        if (b.id === '__unassigned__') return -1;
+        return dir * a.name.localeCompare(b.name);
+      });
+    }
+
+    return groups;
+  }, [benchmarks, filteredTcs, sort, sortTcsWithinGroup]);
+
+  const toggleGroup = (id: string) => setCollapsedGroups(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  // Runs tab
+  const timeFilteredRuns = useMemo(() => { const t = getTimeThreshold(timeRange); return t ? allRuns.filter(r => new Date(r.timestamp) >= t) : allRuns; }, [allRuns, timeRange]);
+  const totalRuns = timeFilteredRuns.length;
+  const passCount = timeFilteredRuns.filter(r => getPassFail(r) === 'pass').length;
+  const passRate = totalRuns > 0 ? Math.round((passCount / totalRuns) * 100) : 0;
+  const filteredRuns = useMemo(() => {
+    if (!search) return timeFilteredRuns;
+    const q = search.toLowerCase(); const nm = new Map(testCases.map(tc => [tc.id, tc.name]));
+    return timeFilteredRuns.filter(r => { const n = nm.get((r as any).testCaseId) || ''; return n.toLowerCase().includes(q) || r.agentName?.toLowerCase().includes(q); });
+  }, [timeFilteredRuns, search, testCases]);
+
+  // Import handler
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setIsImporting(true);
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      const validation = validateTestCasesArrayJson(json);
+      if (!validation.valid || !validation.data) return;
+      const result = await asyncTestCaseStorage.bulkCreate(validation.data);
+      if (result.created > 0) {
+        const allTcs = await asyncTestCaseStorage.getAll();
+        const createdIds = (allTcs as TestCase[]).filter(tc => validation.data!.some(d => d.name === tc.name)).map(tc => tc.id);
+        const bm = await asyncBenchmarkStorage.create({
+          name: file.name.replace(/\.json$/i, '') || 'Imported Benchmark',
+          description: `Auto-created from import of ${result.created} test case(s)`,
+          currentVersion: 1,
+          versions: [{ version: 1, createdAt: new Date().toISOString(), testCaseIds: createdIds }],
+          testCaseIds: createdIds, runs: [],
+        });
+        navigate(`/evaluations/benchmarks/${bm.id}/runs`);
+      }
+    } catch (err) { console.error('Import failed:', err); }
+    finally { setIsImporting(false); event.target.value = ''; }
+  };
+
+  const handleEditorSave = async () => { setShowEditor(false); setEditingTestCase(null); loadDefinitions(); };
+
+  if (loading) return <div className="flex items-center justify-center h-full"><Loader2 size={24} className="animate-spin text-muted-foreground" /></div>;
+
+
+  // Render a test case row (shared between grouped and flat)
+  const renderTcRow = (tc: TestCase, indent: boolean = false) => {
+    const bmList = tcBenchmarkMap.get(tc.id) || [];
+    return (
+      <tr key={tc.id} className="border-b hover:bg-muted/50 cursor-pointer transition-colors"
+        onClick={() => navigate(`/evaluations/test-cases/${tc.id}`)}>
+        <td className={`px-2 py-1.5 align-middle ${indent ? 'pl-7' : ''}`}>
+          <div className="text-xs font-medium truncate max-w-[220px]">{tc.name}</div>
+          {tc.labels && tc.labels.length > 0 && (
+            <div className="flex items-center gap-0.5 mt-0.5">
+              {tc.labels.slice(0, 2).map(l => <Badge key={l} variant="outline" className="text-[8px] px-1 py-0">{l}</Badge>)}
+              {tc.labels.length > 2 && <span className="text-[8px] text-muted-foreground">+{tc.labels.length - 2}</span>}
+            </div>
+          )}
+        </td>
+        <td className="px-2 py-1.5 align-middle text-[10px] text-muted-foreground truncate max-w-[180px]">
+          {tc.description || '—'}
+        </td>
+        <td className="px-2 py-1.5 align-middle relative">
+          {bmList.length > 0 ? (
+            <button className="text-[10px] text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 transition-colors"
+              onClick={e => { e.stopPropagation(); setOpenPopoverId(openPopoverId === tc.id ? null : tc.id); }}>
+              In {bmList.length} benchmark{bmList.length !== 1 ? 's' : ''}
+            </button>
+          ) : <span className="text-[9px] text-muted-foreground italic">none</span>}
+          {openPopoverId === tc.id && bmList.length > 0 && (
+            <div className="absolute top-7 left-2 z-20 bg-popover border border-border rounded-md shadow-lg p-1.5 min-w-[140px]">
+              {bmList.map(bm => (
+                <div key={bm.id} className="text-[10px] px-1.5 py-1 rounded hover:bg-muted cursor-pointer flex items-center gap-1"
+                  onClick={e => { e.stopPropagation(); navigate(`/evaluations/benchmarks/${bm.id}/runs`); }}>
+                  <Badge className="text-[7px] px-0.5 py-0 bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-500/15 dark:text-purple-400 dark:border-purple-500/30 shrink-0">BM</Badge>{bm.name}
+                </div>
+              ))}
+            </div>
+          )}
+        </td>
+        <td className="px-2 py-1.5 align-middle text-[10px] text-muted-foreground whitespace-nowrap">
+          {formatRelativeTime(tc.createdAt)}
+        </td>
+        <td className="px-2 py-1.5 align-middle text-right">
+          <div className="inline-flex items-center gap-0.5">
+            <Button variant="ghost" size="icon" className="h-6 w-6" title="Run"
+              onClick={e => { e.stopPropagation(); setRunningTestCase(tc); }}>
+              <Play size={11} />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-6 w-6" title="Edit"
+              onClick={e => { e.stopPropagation(); setEditingTestCase(tc); setShowEditor(true); }}>
+              <Pencil size={11} />
+            </Button>
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* ── Header with filters ────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-xl font-bold">Test Cases</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">{testCases.length} test cases · Define prompts and expected outcomes</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-[200px] relative">
+            <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <Input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} className="pl-7 h-7 text-xs md:text-xs" />
+          </div>
+          {/* Benchmark filter */}
+          <Select value={selectedBenchmark} onValueChange={setSelectedBenchmark}>
+            <SelectTrigger className="w-[160px] h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Benchmarks</SelectItem>
+              {benchmarks.map(bm => <SelectItem key={bm.id} value={bm.id}>{bm.name}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <input ref={fileInputRef} type="file" accept=".json" className="hidden" onChange={handleImportFile} />
+          <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isImporting} className="h-7 gap-1.5 text-xs font-normal">
+            <Upload size={12} /> {isImporting ? 'Importing...' : 'Import JSON'}
+          </Button>
+          <Button size="sm" onClick={() => { setEditingTestCase(null); setShowEditor(true); }} className="h-7 gap-1.5 text-xs">
+            <Plus size={12} /> New Test Case
+          </Button>
+        </div>
+      </div>
+
+      {/* ── View Toggle ──────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          {/* View mode toggle */}
+          <div className="flex items-center border border-border rounded-md overflow-hidden">
+            <button onClick={() => setViewMode('flat')} className={`px-2 py-1 text-xs flex items-center gap-1 transition-colors ${viewMode === 'flat' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+              <List size={12} /> Flat
+            </button>
+            <button onClick={() => setViewMode('grouped')} className={`px-2 py-1 text-xs flex items-center gap-1 transition-colors ${viewMode === 'grouped' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+              <Layers size={12} /> Grouped
+            </button>
+          </div>
+          {/* Expand/Collapse All — separate group, only in grouped mode */}
+          {viewMode === 'grouped' && (
+            <div className="flex items-center border border-border rounded-md overflow-hidden">
+              <button
+                onClick={() => setCollapsedGroups(new Set())}
+                className="px-2 py-1 text-xs flex items-center gap-1 transition-colors text-muted-foreground hover:text-foreground"
+                title="Expand all"
+              >
+                <ChevronsUpDown size={12} />
+              </button>
+              <button
+                onClick={() => setCollapsedGroups(new Set(groupedData.map(g => g.id)))}
+                className="px-2 py-1 text-xs flex items-center gap-1 transition-colors text-muted-foreground hover:text-foreground"
+                title="Collapse all"
+              >
+                <ChevronsDownUp size={12} />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Table ──────────────────────────────────────────────────── */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto rounded-lg border border-border">
+        <table className="w-full caption-bottom text-sm">
+          <thead className={`sticky top-0 z-10 bg-background transition-shadow duration-200 ${isScrolled ? 'shadow-sm' : ''}`}>
+            <tr className="border-b">
+              <th className="h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap cursor-pointer select-none hover:text-foreground transition-colors"
+                onClick={() => handleSort('name')}>
+                <span className="inline-flex items-center gap-1">
+                  Name
+                  {sort.field === 'name' && <ChevronDown size={10} className={sort.dir === 'asc' ? 'rotate-180' : ''} />}
+                </span>
+              </th>
+              <th className="h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Description</th>
+              <th className="h-7 px-2 text-left align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap"></th>
+              <SortHeader label="Created" active={sort.field === 'created'} dir={sort.dir} onClick={() => handleSort('created')} />
+              <th className="h-7 px-2 text-right align-middle font-medium text-xs text-muted-foreground bg-background border-b whitespace-nowrap">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="[&_tr:last-child]:border-0">
+            {viewMode === 'grouped' ? (
+              groupedData.length === 0 ? (
+                <tr><td colSpan={5} className="py-16 text-center text-sm text-muted-foreground">No test cases found</td></tr>
+              ) : (
+                groupedData.map(group => {
+                  const isCollapsed = collapsedGroups.has(group.id);
+                  const isUnassigned = group.id === '__unassigned__';
+                  return (
+                    <React.Fragment key={group.id}>
+                      <tr className={`border-b cursor-pointer hover:bg-muted/30 transition-colors ${isUnassigned ? 'bg-muted/10' : 'bg-purple-50 dark:bg-purple-500/5'}`}
+                        onClick={() => toggleGroup(group.id)}>
+                        <td colSpan={5} className="px-2 py-1.5 align-middle">
+                          <div className="flex items-center gap-2">
+                            <span className="text-muted-foreground">{isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}</span>
+                            {!isUnassigned && <Badge className="text-[9px] px-1 py-0 bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-500/15 dark:text-purple-400 dark:border-purple-500/30 font-semibold uppercase tracking-wider">Benchmark</Badge>}
+                            <span className="text-xs font-semibold">{group.name}</span>
+                            <span className="text-[10px] text-muted-foreground">({group.testCases.length} test case{group.testCases.length !== 1 ? 's' : ''})</span>
+                          </div>
+                        </td>
+                      </tr>
+                      {!isCollapsed && group.testCases.map(tc => renderTcRow(tc, true))}
+                    </React.Fragment>
+                  );
+                })
+              )
+            ) : (
+              sortedTcs.length === 0 ? (
+                <tr><td colSpan={5} className="py-16 text-center text-sm text-muted-foreground">No test cases found</td></tr>
+              ) : sortedTcs.map(tc => renderTcRow(tc, false))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {/* Editor Modal */}
+      {showEditor && (
+        <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm">
+          <div className="fixed inset-4 z-50 overflow-auto bg-background border rounded-lg shadow-lg">
+            <TestCaseEditor testCase={editingTestCase} onSave={handleEditorSave} onCancel={() => { setShowEditor(false); setEditingTestCase(null); }} />
+          </div>
+        </div>
+      )}
+      {/* Quick Run Modal */}
+      {runningTestCase && (
+        <QuickRunModal testCase={runningTestCase} onClose={() => { setRunningTestCase(null); loadDefinitions(); }} onSaveAsTestCase={() => {}} />
+      )}
+    </div>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.41",
-        "@aws-sdk/client-bedrock": "^3.1000.0",
+        "@aws-sdk/client-bedrock": "^3.1026.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
         "@aws-sdk/credential-providers": "^3.1000.0",
         "@opensearch-project/opensearch": "^3.5.1",
@@ -292,49 +292,49 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock": {
-      "version": "3.1004.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1004.0.tgz",
-      "integrity": "sha512-JbfZSV85IL+43S7rPBmeMbvoOYXs1wmrfbEpHkDBjkvbukRQWtoetiPAXNSKDfFq1qVsoq8sWPdoerDQwlUO8w==",
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1026.0.tgz",
+      "integrity": "sha512-vdir7Xr1d1rnHnpBcZjlm0NbWzTuCygU/JZIbvlL3u4nLiycMPcQHBhkq9xLRHWxE84SeHt7S+/nm+Fis0Vbeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-node": "^3.972.18",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/token-providers": "3.1004.0",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-retry": "^4.4.39",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.38",
-        "@smithy/util-defaults-mode-node": "^4.2.41",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -401,17 +401,17 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1004.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
-      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -469,22 +469,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
-      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/xml-builder": "^3.972.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -509,15 +509,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
-      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -525,20 +525,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
-      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -546,24 +546,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.17.tgz",
-      "integrity": "sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-login": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -571,18 +571,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.17.tgz",
-      "integrity": "sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -590,22 +590,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.18.tgz",
-      "integrity": "sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-ini": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -613,16 +613,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
-      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -630,18 +630,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.17.tgz",
-      "integrity": "sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/token-providers": "3.1004.0",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -649,17 +649,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1004.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
-      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -667,17 +667,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.17.tgz",
-      "integrity": "sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -746,14 +746,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
-      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -761,13 +761,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
-      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -775,15 +775,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
-      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/types": "^3.973.7",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -791,18 +791,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.19.tgz",
-      "integrity": "sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@smithy/core": "^3.23.8",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-retry": "^4.2.11",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -833,47 +833,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.7.tgz",
-      "integrity": "sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==",
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-retry": "^4.4.39",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.38",
-        "@smithy/util-defaults-mode-node": "^4.2.41",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -882,15 +882,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
-      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -916,12 +916,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
-      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -929,15 +929,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
-      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-endpoints": "^3.3.2",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -971,27 +971,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
-      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.4.tgz",
-      "integrity": "sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1007,12 +1008,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.0",
         "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
@@ -5268,30 +5269,17 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
+      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5299,18 +5287,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.9",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
-      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "version": "3.23.14",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -5320,15 +5308,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5406,14 +5394,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -5422,12 +5410,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
-      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -5437,12 +5425,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
-      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5462,13 +5450,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
-      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5476,18 +5464,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
-      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "version": "4.4.29",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5495,18 +5483,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.40",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
-      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.0.tgz",
+      "integrity": "sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -5515,13 +5504,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5529,12 +5519,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5542,14 +5532,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5557,15 +5547,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5573,12 +5562,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5586,12 +5575,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5599,12 +5588,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -5613,12 +5602,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5626,24 +5615,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0"
+        "@smithy/types": "^4.14.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5651,16 +5640,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -5670,17 +5659,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
-      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5688,9 +5677,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5700,13 +5689,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/querystring-parser": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5777,14 +5766,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.39",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
-      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "version": "4.3.45",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5792,17 +5781,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.42",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
-      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "version": "4.2.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
+      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5810,13 +5799,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
+      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5836,12 +5825,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5849,13 +5838,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.0.tgz",
+      "integrity": "sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5863,14 +5852,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "version": "4.5.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/types": "^4.13.0",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -13298,9 +13287,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
       "funding": [
         {
           "type": "github",
@@ -15176,9 +15165,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@ag-ui/core": "^0.0.41",
-    "@aws-sdk/client-bedrock": "^3.1000.0",
+    "@aws-sdk/client-bedrock": "^3.1026.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
     "@aws-sdk/credential-providers": "^3.1000.0",
     "@opensearch-project/opensearch": "^3.5.1",


### PR DESCRIPTION
## Description

Adds a complete Evaluations feature set to Agent Health with new pages for benchmarks, test cases, evaluation runs, and run comparison — all with dense, information-rich UI matching the Agent Traces page density.

## New Pages

### Benchmarks (`/evaluations/benchmarks`)
- Leaderboard table with inline metrics bar (benchmarks count, total runs, avg pass rate)
- "Latest Result" column showing pass/fail/total with green/red icons
- SVG sparkline trend column showing pass rate history (last 10 runs) + Improving/Stable/Regressing badge
- Dense rows, sortable columns, search, agent/time filters

### Test Cases (`/evaluations/test-cases`)
- Flat and grouped (by benchmark) views with expand/collapse
- Labels, benchmark membership, search, import JSON
- Dense rows matching benchmarks page density

### Evaluation Runs (`/evaluations/runs`)
- Run-centric view with inline metrics (runs, pass rate, avg accuracy, regressions)
- Regressions count is clickable to filter
- Real annotation counts loaded from reports — shows "N in M TCs" as amber link
- Compare selection with checkboxes (max 10, benchmark group select-all)
- Multi-benchmark warning banner

### Run Inspector (`/evaluations/benchmarks/:id/runs/:runId/inspect`)
- Split-panel layout: left panel with test case list, right panel with TestCaseInspectorPanel

### Test Case Detail (`/evaluations/test-cases/:id`)
- Split-panel with collapsible definition section + test case runs list

## Compare Page Improvements

- Sticky toolbar with benchmark selector and dropdown multi-select for runs
- Evaluator visibility selector (accuracy, faithfulness, trajectory, latency, annotations) with select all/deselect all
- Test case names as links with ID subtitle
- Collapsible Run Summary & Metrics
- Inline summary badges for regression/improvement/mixed/neutral
- "Use Case" renamed to "Test Case" throughout

## 3 Compare Prototypes (accessible via URL, not in sidebar)

| Prototype | URL | Approach |
|-----------|-----|----------|
| Diff-First | `/evaluations/compare` | Change summary strip, delta indicators, changes-only toggle |
| Scorecard | `/evaluations/compare2` | Vertical scorecard columns, delta gutters, mini pass rate chart |
| Heatmap | `/evaluations/compare3` | Matrix heatmap, group-by toggle (flat/category/status), hover tooltips |

## UI Density

- All pages use inline metrics bar instead of summary cards
- Dense table rows matching Agent Traces page density
- Smaller fonts, icons, and action buttons throughout

## Routing

- All URLs use `/evaluations/` prefix
- Evaluations sidebar nav with Benchmarks, Test Cases, Evaluation Runs
- Compare pages accessible via URL but not in sidebar nav

## Files Changed

| File | Change |
|------|--------|
| `App.tsx` | Added routes for all evaluations pages |
| `components/Layout.tsx` | Added Evaluations sidebar nav section |
| `components/evals3/*.tsx` | 12 new page components |
| `components/comparison/ComparisonPage.tsx` | Sticky toolbar, evaluator selector, test case links |
| `components/comparison/MetricCell.tsx` | Multi-metric display with visibility control |
| `components/comparison/UseCaseComparisonTable.tsx` | Test case links, evaluator visibility |

## Testing

- [x] `npm run build` passes (TypeScript + Vite production build)
- [x] All pages verified working with live OpenSearch data
- [x] Dark mode and light mode tested
