### PR TITLE
ci: Onboard code diff analyzer and reviewer

### DIFF
--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -1,0 +1,30 @@
+---
+name: PR Review
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  Code-Diff-Analyzer:
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@main
+    if: github.repository == 'opensearch-project/agent-health'
+    permissions:
+      id-token: write  # github oidc to assume aws roles
+      pull-requests: write  # to create or update comment (peter-evans/create-or-update-comment)
+    secrets:
+      BEDROCK_ACCESS_ROLE: ${{ secrets.BEDROCK_ACCESS_ROLE }}
+    with:
+      skip_diff_analyzer_with_label_name: 'skip-diff-analyzer'
+      update_pr_comment_with_analyzer_report: true
+
+  Code-Diff-Reviewer:
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@main
+    needs: Code-Diff-Analyzer
+    if: github.repository == 'opensearch-project/agent-health'
+    permissions:
+      id-token: write  # github oidc to assume aws roles
+      pull-requests: write  # to create or update comment (peter-evans/create-or-update-comment)
+    secrets:
+      BEDROCK_ACCESS_ROLE: ${{ secrets.BEDROCK_ACCESS_ROLE }}
+    with:
+      skip_diff_reviewer_with_label_name: 'skip-diff-reviewer'


### PR DESCRIPTION
## Summary
- Adds a `pr_review.yml` GitHub Actions workflow that triggers on `pull_request_target` events (opened, synchronize, reopened)
- Uses reusable workflows from `opensearch-project/opensearch-build` for AI-powered code diff analysis and review via AWS Bedrock
- Mirrors the same workflow onboarded in [OpenSearch-Dashboards#11388](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11388)

## Jobs
1. *Code-Diff-Analyzer* — Analyzes code diffs for potential issues (severity levels) and optionally posts a report as a PR comment
2. *Code-Diff-Reviewer* — Runs after the analyzer; performs an AI-powered PR review using pr-agent with Bedrock

## Required Setup
- [ ] *BEDROCK_ACCESS_ROLE* GitHub secret must be configured with an IAM role ARN that:
  - Has a trust policy allowing GitHub OIDC federation from `opensearch-project/agent-health`
  - Has permissions to invoke AWS Bedrock models (Claude Sonnet/Haiku)
- [ ] The IAM role's trust policy must include the `agent-health` repo (see AWS console steps below)

## AWS Console Steps
1. Create (or reuse) an IAM role with Bedrock invoke permissions
2. Update the trust policy to allow GitHub OIDC from `repo:opensearch-project/agent-health:*`
3. Copy the role ARN and set it as a GitHub secret: `gh secret set BEDROCK_ACCESS_ROLE --repo opensearch-project/agent-health --body "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"`

## Test plan
- [ ] Merge PR and open a test PR to verify the workflow triggers
- [ ] Confirm Code-Diff-Analyzer posts a comment on the test PR
- [ ] Confirm Code-Diff-Reviewer posts a review on the test PR
- [ ] Test `skip-diff-analyzer` and `skip-diff-reviewer` labels work as expected

Signed-off-by: Megha Goyal <goyamegh@amazon.com>