### PR TITLE
Restore pr reviewer blocking if analyzer failed in #139

### DIFF
--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -20,7 +20,7 @@ jobs:
   Code-Diff-Reviewer:
     uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@main
     needs: Code-Diff-Analyzer
-    if: ${{ always() && github.repository == 'opensearch-project/agent-health' }}
+    if: github.repository == 'opensearch-project/agent-health'
     permissions:
       id-token: write  # github oidc to assume aws roles
       pull-requests: write  # to create or update comment (peter-evans/create-or-update-comment)


### PR DESCRIPTION
### Description
Restore pr reviewer blocking if analyzer failed in #139

### Issues Resolved
In #139 the reviewer is being altered to still run even if analyzer failed.
This is the wrong behavior we should change it back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
