### PR TITLE
feat: Add Strands and LangGraph connectors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,22 @@
 # OPENAI_COMPATIBLE_ENDPOINT=https://api.openai.com/v1/chat/completions # Direct OpenAI
 
 # =============================================================================
+# AMAZON STRANDS (optional - for Strands agent connector)
+# =============================================================================
+# Required when using the Strands connector to invoke Bedrock agents.
+# AWS credentials above are used for authentication.
+
+# STRANDS_AGENT_ID=your-agent-id
+# STRANDS_ALIAS_ID=TSTALIASID
+
+# =============================================================================
+# LANGGRAPH REST (optional - for non-AG-UI LangGraph agents)
+# =============================================================================
+# For LangGraph agents exposed via direct REST API (not AG-UI streaming).
+
+# LANGGRAPH_API_ENDPOINT=http://localhost:8000
+
+# =============================================================================
 # ADVANCED: Server Configuration (rarely needed)
 # =============================================================================
 # VITE_BACKEND_PORT=4001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Pre-existing test failures: add missing `fast-check` dev dependency and fix incomplete mocks in `app.test.ts` ([#153](https://github.com/opensearch-project/agent-health/pull/153))
 
 ### Added
+- Amazon Strands connector for Bedrock Agent Runtime integration (`services/connectors/strands/`)
+- LangGraph REST connector for non-AG-UI LangGraph instances (`services/connectors/langgraph/`)
 - Dashboard homepage gradient background, stats summary bar, and chart area gradient fills ([#153](https://github.com/opensearch-project/agent-health/pull/153))
 - Auto-increment server port on EADDRINUSE — if port 4001 is in use, tries 4002, 4003, etc. up to 10 attempts
 - GitHub Actions workflow for AI-powered PR code diff analysis and review via AWS Bedrock

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ A unified dashboard for monitoring AI coding agent usage across **Claude Code**,
 |-----------|----------|-------------|
 | `agui-streaming` | AG-UI SSE | ML-Commons agents (default) |
 | `rest` | HTTP POST | Non-streaming REST APIs |
+| `openai-compatible` | OpenAI Chat | LiteLLM, Ollama, vLLM |
+| `strands` | Bedrock Agent Runtime | Amazon Strands agents (server-only) |
+| `langgraph` | LangGraph REST | Non-AG-UI LangGraph instances |
 | `subprocess` | CLI | Command-line tools |
 | `claude-code` | Claude CLI | Claude Code agent comparison |
 | `mock` | In-memory | Demo and testing |
@@ -200,7 +203,7 @@ export default {
       key: "my-agent",
       name: "My Agent",
       endpoint: "http://localhost:8000/agent",
-      connectorType: "rest",  // or "agui-streaming", "subprocess"
+      connectorType: "rest",  // or "agui-streaming", "langgraph", "strands", "subprocess"
       models: ["claude-sonnet-4"],
       useTraces: true,        // Enable OpenTelemetry trace collection
     }

--- a/agent-health.config.example.ts
+++ b/agent-health.config.example.ts
@@ -50,7 +50,33 @@ export default {
     //   useTraces: false,
     // },
 
-    // Example 4: Agent with authentication hook
+    // Example 4: LangGraph REST connector (non-streaming invoke)
+    // {
+    //   key: "my-langgraph-agent",
+    //   name: "My LangGraph Agent",
+    //   endpoint: "http://localhost:8123",
+    //   connectorType: "langgraph",
+    //   connectorConfig: {
+    //     graphId: "agent",        // Assistant/graph ID (defaults to "agent")
+    //     // threadId: "...",      // Optional thread ID for multi-turn
+    //   },
+    //   useTraces: true,
+    // },
+
+    // Example 5: Amazon Strands connector (Bedrock Agent Runtime)
+    // {
+    //   key: "my-strands-agent",
+    //   name: "My Strands Agent",
+    //   endpoint: "ABCDEF1234",     // Bedrock Agent ID
+    //   connectorType: "strands",
+    //   connectorConfig: {
+    //     agentAliasId: "TSTALIASID",  // Agent alias ID
+    //     region: "us-west-2",          // AWS region (defaults to AWS_REGION)
+    //   },
+    //   useTraces: false,
+    // },
+
+    // Example 6: Agent with authentication hook
     // {
     //   key: "authenticated-agent",
     //   name: "Authenticated Agent",
@@ -71,7 +97,7 @@ export default {
     //   },
     // },
 
-    // Example 5: Claude Code with MCP servers (competitive evaluation)
+    // Example 7: Claude Code with MCP servers (competitive evaluation)
     // Uses a standard MCP config JSON file (same format as ~/.claude.json mcpServers)
     // {
     //   key: "claude-code-eval",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -185,7 +185,7 @@ export default defineConfig({
     {
       key: 'my-agent',
       name: 'My Custom Agent',
-      connectorType: 'rest', // or 'agui', 'subprocess'
+      connectorType: 'rest', // or 'agui-streaming', 'langgraph', 'strands', 'subprocess'
       endpoint: 'http://localhost:8080/chat',
       models: ['claude-sonnet-4'],
     },
@@ -224,7 +224,7 @@ interface UserAgentConfig {
   key: string;              // Unique identifier
   name: string;             // Display name
   endpoint: string;         // URL or command name
-  connectorType?: string;   // 'agui', 'rest', 'subprocess', 'claude-code', 'mock'
+  connectorType?: string;   // 'agui-streaming', 'rest', 'langgraph', 'strands', 'subprocess', 'claude-code', 'mock'
   models: string[];         // Supported model keys
   headers?: Record<string, string>;  // HTTP headers
   useTraces?: boolean;      // Enable trace collection
@@ -242,15 +242,18 @@ These agents work out of the box:
 |-------|-----|-----------|-------|
 | Demo Agent | `demo` | `mock` | Simulated responses for testing |
 | Claude Code | `claude-code` | `claude-code` | Requires `claude` CLI installed |
-| Langgraph | `langgraph` | `agui-streaming` | AG-UI protocol |
-| HolmesGPT | `holmesgpt` | `agui-streaming` | AI investigation agent |
+| Amazon Strands | `strands` | `strands` | Bedrock Agent Runtime (disabled by default) |
+| LangGraph (REST) | `langgraph-rest` | `langgraph` | Direct REST API (disabled by default) |
 
 ## Built-in Connectors
 
 | Type | Protocol | Use Case |
 |------|----------|----------|
-| `agui-streaming` | AG-UI SSE | ML-Commons, Langgraph, HolmesGPT |
+| `agui-streaming` | AG-UI SSE | ML-Commons and AG-UI compatible agents |
 | `rest` | HTTP POST | Simple REST APIs |
+| `openai-compatible` | OpenAI Chat Completions | LiteLLM, Ollama, vLLM |
+| `langgraph` | LangGraph REST `/invoke` | Non-AG-UI LangGraph instances |
+| `strands` | Bedrock Agent Runtime | Amazon Strands agents (server-only) |
 | `subprocess` | CLI | Generic CLI tools |
 | `claude-code` | CLI | Claude Code CLI specifically |
 | `mock` | In-memory | Testing and demos |

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -13,13 +13,16 @@ Connectors are protocol adapters that handle communication with different types 
 
 ## Built-in Connectors
 
-| Type | Protocol | Use Case |
-|------|----------|----------|
-| `agui-streaming` | AG-UI SSE | ML-Commons agents (default) |
-| `rest` | HTTP POST | Non-streaming REST APIs |
-| `subprocess` | CLI stdin/stdout | Command-line tools |
-| `claude-code` | Claude Code CLI | Claude Code agent comparison |
-| `mock` | In-memory | Demo and testing |
+| Type | Protocol | Use Case | Browser-safe |
+|------|----------|----------|:---:|
+| `agui-streaming` | AG-UI SSE | ML-Commons agents (default) | Yes |
+| `rest` | HTTP POST | Non-streaming REST APIs | Yes |
+| `openai-compatible` | OpenAI Chat Completions | LiteLLM, Ollama, vLLM | Yes |
+| `langgraph` | LangGraph REST `/invoke` | Non-AG-UI LangGraph instances | Yes |
+| `strands` | Bedrock Agent Runtime | Amazon Strands agents (requires AWS SDK) | No |
+| `subprocess` | CLI stdin/stdout | Command-line tools | No |
+| `claude-code` | Claude Code CLI | Claude Code agent comparison | No |
+| `mock` | In-memory | Demo and testing | Yes |
 
 ## Creating a Custom Connector
 
@@ -281,11 +284,14 @@ Some connectors require Node.js APIs (like `child_process`) and cannot run in th
 **Browser-safe connectors** (in `services/connectors/index.ts`):
 - `agui-streaming`
 - `rest`
+- `openai-compatible`
+- `langgraph`
 - `mock`
 
 **Server-only connectors** (in `services/connectors/server.ts`):
 - `subprocess`
 - `claude-code`
+- `strands` (requires `@aws-sdk/client-bedrock-agent-runtime`)
 
 If your connector needs Node.js APIs, export it from `server.ts` only.
 

--- a/docs/PLAN-non-agui-agent-support.md
+++ b/docs/PLAN-non-agui-agent-support.md
@@ -1,0 +1,525 @@
+<!--
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+-->
+
+# Plan: Non-AG-UI Agent Support in AgentEval
+
+> **Status: Implemented** via the connector system (not the separate adapter pattern originally proposed here).
+> See `services/connectors/strands/` and `services/connectors/langgraph/` for the Strands and LangGraph implementations.
+
+## Problem Statement
+
+Currently, AgentEval only supports agents that emit AG-UI protocol SSE events. This excludes:
+- **Claude Code** - CLI tool with its own execution model
+- **LangGraph non-AG-UI instances** - LangGraph without AG-UI endpoints
+- **Amazon Strands Agents** - AWS agent framework
+
+## Key Insight
+
+OTEL traces alone are insufficient for evaluation - they typically capture metadata (timing, spans) but not the **actual content** (full responses, tool outputs) needed for LLM judge evaluation.
+
+Reference implementations:
+- **Strands Evals**: Direct execution captures output, OTEL supplements with trajectory
+- **LangSmith**: Rich tracing with full content at every step
+
+## Solution Approach
+
+**Unified Agent Adapter Pattern** - One interface that works for API, CLI, and streaming agents:
+
+```typescript
+interface AgentAdapter {
+  execute(prompt: string, context?: any): Promise<AgentResult>;
+}
+
+interface AgentResult {
+  output: string;                    // The actual response (required)
+  trajectory?: TrajectoryStep[];     // Execution steps (optional)
+  metadata?: Record<string, any>;    // Agent-specific data
+}
+```
+
+Each agent type has an adapter that:
+1. **Executes the agent** (CLI, API, or SSE)
+2. **Captures the actual output** directly
+3. **Optionally captures trajectory** from output parsing or OTEL
+4. **Returns unified result** for evaluation
+
+---
+
+## Architecture Overview
+
+```
+                         ┌──────────────────────┐
+                         │      AgentEval       │
+                         │   (Experiment Runner)│
+                         └──────────┬───────────┘
+                                    │ calls adapter.execute()
+                         ┌──────────▼───────────┐
+                         │   Agent Adapter      │
+                         │   Registry           │
+                         └──────────┬───────────┘
+            ┌───────────────────────┼───────────────────────┐
+            │                       │                       │
+     ┌──────▼──────┐        ┌──────▼──────┐        ┌──────▼──────┐
+     │ Claude Code │        │   Strands   │        │  LangGraph  │
+     │   Adapter   │        │   Adapter   │        │   Adapter   │
+     │    (CLI)    │        │   (API)     │        │  (AG-UI)    │
+     └──────┬──────┘        └──────┬──────┘        └──────┬──────┘
+            │                      │                      │
+            │ exec CLI             │ AWS SDK              │ SSE stream
+            ▼                      ▼                      ▼
+     ┌─────────────┐        ┌─────────────┐        ┌─────────────┐
+     │ claude CLI  │        │ Strands API │        │ LangGraph   │
+     └─────────────┘        └─────────────┘        └─────────────┘
+            │                      │                      │
+            └──────────────────────┼──────────────────────┘
+                                   │
+                         ┌─────────▼─────────┐
+                         │   AgentResult     │
+                         │ {output, trajectory}│
+                         └─────────┬─────────┘
+                                   │
+                         ┌─────────▼─────────┐
+                         │    LLM Judge      │
+                         │   (unchanged)     │
+                         └───────────────────┘
+```
+
+---
+
+## Phase 1: Agent Adapter Framework (Foundation)
+
+### 1.1 Core Types
+
+**File: `types/index.ts`** - Add:
+```typescript
+// Adapter types
+export type AdapterType = 'ag-ui' | 'cli' | 'api' | 'custom';
+
+export interface AgentResult {
+  output: string;                    // Required: the actual response
+  trajectory?: TrajectoryStep[];     // Optional: execution steps
+  metadata?: {
+    executionTime?: number;
+    tokenCount?: number;
+    traceId?: string;
+    [key: string]: any;
+  };
+}
+
+export interface AgentAdapter {
+  type: AdapterType;
+  execute(
+    prompt: string,
+    context?: { tools?: any[]; history?: any[] }
+  ): Promise<AgentResult>;
+
+  // Optional streaming support
+  executeStream?(
+    prompt: string,
+    context?: any,
+    onChunk?: (chunk: string) => void
+  ): Promise<AgentResult>;
+}
+
+// Extended AgentConfig
+export interface AgentConfig {
+  // ... existing fields ...
+  adapterType: AdapterType;          // Required: which adapter to use
+  adapterConfig?: {
+    command?: string;                // For CLI adapters
+    apiEndpoint?: string;            // For API adapters
+    timeout?: number;
+    [key: string]: any;
+  };
+}
+```
+
+### 1.2 Adapter Registry
+
+**New file: `services/adapters/index.ts`**
+```typescript
+import { AgentAdapter, AgentConfig } from '@/types';
+
+// Registry of available adapters
+const adapters: Record<string, new (config: AgentConfig) => AgentAdapter> = {};
+
+export function registerAdapter(
+  type: string,
+  adapterClass: new (config: AgentConfig) => AgentAdapter
+): void;
+
+export function getAdapter(config: AgentConfig): AgentAdapter;
+
+export function listAdapters(): string[];
+```
+
+### 1.3 Base Adapter Class
+
+**New file: `services/adapters/baseAdapter.ts`**
+```typescript
+export abstract class BaseAdapter implements AgentAdapter {
+  protected config: AgentConfig;
+
+  constructor(config: AgentConfig) {
+    this.config = config;
+  }
+
+  abstract execute(prompt: string, context?: any): Promise<AgentResult>;
+
+  // Helper to build trajectory from raw output
+  protected parseTrajectory(output: string): TrajectoryStep[] {
+    // Default implementation - can be overridden
+  }
+}
+```
+
+---
+
+## Phase 2: Built-in Adapters
+
+### 2.1 AG-UI Adapter (Existing Flow)
+
+**New file: `services/adapters/aguiAdapter.ts`**
+```typescript
+/**
+ * Wraps existing AG-UI flow as an adapter
+ * Uses SSEClient + AGUIToTrajectoryConverter internally
+ */
+export class AGUIAdapter extends BaseAdapter {
+  type = 'ag-ui' as const;
+
+  async execute(prompt: string, context?: any): Promise<AgentResult> {
+    // Use existing AG-UI streaming flow
+    const trajectory = await streamAgentExecution(
+      this.config.endpoint,
+      buildPayload(prompt, context),
+      this.config.headers
+    );
+
+    return {
+      output: extractFinalResponse(trajectory),
+      trajectory,
+    };
+  }
+
+  async executeStream(prompt, context, onChunk): Promise<AgentResult> {
+    // Real-time streaming with callbacks
+  }
+}
+```
+
+### 2.2 Claude Code Adapter (CLI)
+
+**New file: `services/adapters/claudeCodeAdapter.ts`**
+```typescript
+import { spawn } from 'child_process';
+
+export class ClaudeCodeAdapter extends BaseAdapter {
+  type = 'cli' as const;
+
+  async execute(prompt: string, context?: any): Promise<AgentResult> {
+    const { command = 'claude', timeout = 300000 } = this.config.adapterConfig || {};
+
+    // Execute: claude --print "prompt" --output-format json
+    const result = await this.runCLI(command, [
+      '--print', prompt,
+      '--output-format', 'stream-json',  // Get structured output
+    ], timeout);
+
+    return {
+      output: result.finalResponse,
+      trajectory: this.parseClaudeCodeOutput(result.events),
+      metadata: { executionTime: result.duration },
+    };
+  }
+
+  private parseClaudeCodeOutput(events: any[]): TrajectoryStep[] {
+    // Parse Claude Code's JSON output format
+    // Maps: assistant → response, tool_use → action, tool_result → tool_result
+  }
+}
+```
+
+### 2.3 Strands Adapter (AWS API)
+
+**New file: `services/adapters/strandsAdapter.ts`**
+```typescript
+import { BedrockAgentRuntimeClient, InvokeAgentCommand } from '@aws-sdk/client-bedrock-agent-runtime';
+
+export class StrandsAdapter extends BaseAdapter {
+  type = 'api' as const;
+  private client: BedrockAgentRuntimeClient;
+
+  async execute(prompt: string, context?: any): Promise<AgentResult> {
+    const { agentId, agentAliasId, region } = this.config.adapterConfig || {};
+
+    const response = await this.client.send(new InvokeAgentCommand({
+      agentId,
+      agentAliasId,
+      sessionId: context?.sessionId || generateSessionId(),
+      inputText: prompt,
+    }));
+
+    return {
+      output: await this.extractCompletion(response),
+      trajectory: this.parseStrandsTrace(response.trace),
+      metadata: { sessionId: response.sessionId },
+    };
+  }
+
+  private parseStrandsTrace(trace: any): TrajectoryStep[] {
+    // Parse Strands trace format to TrajectoryStep[]
+  }
+}
+```
+
+### 2.4 LangGraph Adapter (Non-AG-UI)
+
+**New file: `services/adapters/langgraphAdapter.ts`**
+```typescript
+export class LangGraphAdapter extends BaseAdapter {
+  type = 'api' as const;
+
+  async execute(prompt: string, context?: any): Promise<AgentResult> {
+    const { apiEndpoint } = this.config.adapterConfig || {};
+
+    // Call LangGraph API directly (not AG-UI SSE)
+    const response = await fetch(apiEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: prompt, ...context }),
+    });
+
+    const data = await response.json();
+
+    return {
+      output: data.output,
+      trajectory: this.parseLangGraphOutput(data),
+    };
+  }
+}
+```
+
+### 2.5 Custom Adapter (User-Provided)
+
+**New file: `services/adapters/customAdapter.ts`**
+```typescript
+/**
+ * Allows users to provide a task function (like Strands Evals pattern)
+ */
+export class CustomAdapter extends BaseAdapter {
+  type = 'custom' as const;
+  private taskFunction: (prompt: string, context?: any) => Promise<AgentResult>;
+
+  setTaskFunction(fn: typeof this.taskFunction): void {
+    this.taskFunction = fn;
+  }
+
+  async execute(prompt: string, context?: any): Promise<AgentResult> {
+    if (!this.taskFunction) {
+      throw new Error('Custom adapter requires a task function');
+    }
+    return this.taskFunction(prompt, context);
+  }
+}
+```
+
+---
+
+## Phase 3: Integration & UI
+
+### 3.1 Update Experiment Runner
+
+**File: `services/experimentRunner.ts`** - Refactor:
+```typescript
+import { getAdapter } from './adapters';
+
+async function executeTestCase(run, testCase) {
+  const agent = getAgentConfig(run.agentKey);
+  const adapter = getAdapter(agent);
+
+  // Unified execution through adapter
+  const result = await adapter.execute(
+    testCase.initialPrompt,
+    { tools: testCase.tools, history: [] }
+  );
+
+  // Evaluate with judge (same for all adapters)
+  return await evaluateResult(result, testCase);
+}
+```
+
+### 3.2 Update Agent Configuration UI
+
+**File: `components/ConfigEditor.tsx`** - Add:
+- Adapter type selector dropdown
+- Adapter-specific configuration fields
+- Test connection button
+
+### 3.3 Update QuickRunModal
+
+**File: `components/QuickRunModal.tsx`**
+- Show adapter type indicator
+- Streaming output for adapters that support it
+- Progress indication for non-streaming adapters
+
+### 3.4 Add Agent Configuration
+
+**File: `lib/constants.ts`** - Add new agents:
+```typescript
+{
+  key: "claude-code",
+  name: "Claude Code",
+  adapterType: "cli",
+  adapterConfig: {
+    command: "claude",
+    timeout: 300000,
+  },
+  models: ["claude-sonnet-4", "claude-opus-4"],
+  description: "Anthropic's Claude Code CLI agent",
+},
+{
+  key: "strands",
+  name: "Amazon Strands",
+  adapterType: "api",
+  adapterConfig: {
+    agentId: "${STRANDS_AGENT_ID}",
+    agentAliasId: "${STRANDS_ALIAS_ID}",
+    region: "us-east-1",
+  },
+  models: ["claude-sonnet-4", "amazon-nova"],
+  description: "Amazon Strands agent framework",
+},
+{
+  key: "langgraph-api",
+  name: "LangGraph (API)",
+  adapterType: "api",
+  adapterConfig: {
+    apiEndpoint: "${LANGGRAPH_API_ENDPOINT}",
+  },
+  models: ["claude-sonnet-4.5"],
+  description: "LangGraph agent via direct API",
+}
+```
+
+---
+
+## Phase 4: OTEL Trace Enrichment (Optional)
+
+For agents that emit OTEL traces, add optional trace fetching to enrich trajectory:
+
+### 4.1 Trace Enrichment Service
+
+**New file: `services/adapters/traceEnrichment.ts`**
+```typescript
+/**
+ * Optionally fetch OTEL traces to enrich trajectory with timing/metadata
+ */
+export async function enrichWithTraces(
+  result: AgentResult,
+  traceConfig: { serviceName: string; traceId?: string }
+): Promise<AgentResult> {
+  if (!result.metadata?.traceId) return result;
+
+  const spans = await fetchTraces(traceConfig);
+
+  return {
+    ...result,
+    trajectory: mergeTrajectoryWithSpans(result.trajectory, spans),
+  };
+}
+```
+
+---
+
+## Files Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `services/adapters/index.ts` | Adapter registry and factory |
+| `services/adapters/baseAdapter.ts` | Base adapter class |
+| `services/adapters/aguiAdapter.ts` | AG-UI adapter (wraps existing) |
+| `services/adapters/claudeCodeAdapter.ts` | Claude Code CLI adapter |
+| `services/adapters/strandsAdapter.ts` | Amazon Strands API adapter |
+| `services/adapters/langgraphAdapter.ts` | LangGraph API adapter |
+| `services/adapters/customAdapter.ts` | User-provided task function |
+| `services/adapters/traceEnrichment.ts` | Optional OTEL trace enrichment |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `types/index.ts` | Add `AdapterType`, `AgentResult`, `AgentAdapter` |
+| `lib/constants.ts` | Add Claude Code, Strands, LangGraph configs |
+| `services/experimentRunner.ts` | Use adapter pattern for execution |
+| `components/QuickRunModal.tsx` | Adapter-aware UI |
+| `components/ConfigEditor.tsx` | Adapter configuration UI |
+
+---
+
+## Implementation Order
+
+1. **Phase 1** - Adapter Framework
+   - Core types (`AgentResult`, `AgentAdapter`)
+   - Adapter registry
+   - Base adapter class
+
+2. **Phase 2** - Built-in Adapters
+   - AG-UI adapter (wrap existing)
+   - Claude Code adapter (CLI)
+   - Strands adapter (AWS API)
+   - LangGraph adapter (API)
+
+3. **Phase 3** - Integration & UI
+   - Update experiment runner
+   - Configuration UI
+   - Quick run modal updates
+
+4. **Phase 4** - OTEL Enrichment (Optional)
+   - Trace enrichment service
+   - Merge spans with trajectory
+
+---
+
+## Environment Variables
+
+```bash
+# Claude Code
+CLAUDE_CODE_COMMAND=claude
+CLAUDE_CODE_TIMEOUT=300000
+
+# Amazon Strands
+STRANDS_AGENT_ID=your-agent-id
+STRANDS_ALIAS_ID=your-alias-id
+AWS_REGION=us-east-1
+
+# LangGraph (non-AG-UI)
+LANGGRAPH_API_ENDPOINT=http://localhost:8000/invoke
+
+# Optional: OTEL for trace enrichment
+OTEL_TRACE_ENDPOINT=http://localhost:16686
+```
+
+---
+
+## Verification Plan
+
+1. **Unit tests**:
+   - Each adapter's output parsing
+   - Adapter registry functionality
+   - AgentResult validation
+
+2. **Integration tests**:
+   - Claude Code adapter with mock CLI
+   - Strands adapter with mock AWS SDK
+   - AG-UI adapter (existing flow)
+
+3. **E2E tests**:
+   - Mixed-adapter experiment (AG-UI + CLI)
+   - Comparison view with different adapters
+
+4. **Manual testing**:
+   - Run Claude Code via adapter, evaluate
+   - Compare Claude Code vs AG-UI agent on same test case

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -42,6 +42,16 @@ export const CONNECTOR_TYPE_INFO: Record<ConnectorProtocol, ConnectorTypeInfo> =
     description: 'Invokes the Claude Code CLI. Server-only — use the CLI or benchmark runner.',
     serverOnly: true,
   },
+  'strands': {
+    label: 'Amazon Strands',
+    description: 'Amazon Strands agent framework via Bedrock Agent Runtime API. Server-only — requires AWS SDK.',
+    serverOnly: true,
+  },
+  'langgraph': {
+    label: 'LangGraph (REST)',
+    description: 'LangGraph agent via direct REST API. Use for non-AG-UI LangGraph instances.',
+    serverOnly: false,
+  },
   'mock': {
     label: 'Mock',
     description: 'Built-in demo agent for testing. No real endpoint needed.',
@@ -125,6 +135,30 @@ export const DEFAULT_CONFIG: AppConfig = {
       headers: {},
       useTraces: ENV_CONFIG.claudeCodeTelemetryEnabled && !!ENV_CONFIG.otelExporterEndpoint,
       connectorConfig: { env: getClaudeCodeConnectorEnv() },
+    },
+    {
+      key: "strands",
+      name: "Amazon Strands",
+      endpoint: "${STRANDS_AGENT_ID}",
+      description: "Amazon Strands agent framework (Bedrock Agent Runtime)",
+      connectorType: "strands",
+      headers: {},
+      useTraces: false,
+      connectorConfig: {
+        agentAliasId: "${STRANDS_ALIAS_ID:-TSTALIASID}",
+        region: "${AWS_REGION:-us-east-1}",
+      },
+      enabled: false,
+    },
+    {
+      key: "langgraph-rest",
+      name: "LangGraph (REST)",
+      endpoint: "${LANGGRAPH_API_ENDPOINT:-http://localhost:8000}",
+      description: "LangGraph agent via direct REST API",
+      connectorType: "langgraph",
+      headers: {},
+      useTraces: false,
+      enabled: false,
     },
   ],
   models: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "vite-plugin-istanbul": "^8.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
         "puppeteer": "^24.37.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@ag-ui/core": "^0.0.41",
         "@aws-sdk/client-bedrock": "^3.1000.0",
+        "@aws-sdk/client-bedrock-agent": "^3.1038.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1038.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
         "@aws-sdk/credential-providers": "^3.1000.0",
         "@opensearch-project/opensearch": "^3.5.1",
@@ -350,6 +352,109 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-agent": {
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent/-/client-bedrock-agent-3.1038.0.tgz",
+      "integrity": "sha512-cwOkwVhYs+GeW7SzNS/pmgkHZ/SAyv4wIkz62vew6sM6R+XgqqBbtEqDrf+FSsprFtx75edbduRg8boJt0veSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime": {
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1038.0.tgz",
+      "integrity": "sha512-/hp+fWDdo+miapoh6AxZnqJrMaRg6ZEynaGEmBKt6QorEq7IE++DBCQuIFSJ1mKdUFxLKKgDl52EcRirl/0ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1000.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1000.0.tgz",
@@ -477,22 +582,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
-      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/xml-builder": "^3.972.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.20",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -517,15 +623,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
-      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -533,20 +639,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
-      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -554,24 +660,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.17.tgz",
-      "integrity": "sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-login": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-login": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -579,18 +685,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.17.tgz",
-      "integrity": "sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -598,22 +704,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.18.tgz",
-      "integrity": "sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.16",
-        "@aws-sdk/credential-provider-http": "^3.972.18",
-        "@aws-sdk/credential-provider-ini": "^3.972.17",
-        "@aws-sdk/credential-provider-process": "^3.972.16",
-        "@aws-sdk/credential-provider-sso": "^3.972.17",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-ini": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -621,16 +727,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
-      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -638,18 +744,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.17.tgz",
-      "integrity": "sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/token-providers": "3.1004.0",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -657,17 +763,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1004.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
-      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,17 +781,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.17.tgz",
-      "integrity": "sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/nested-clients": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -754,14 +860,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
-      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -769,13 +875,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
-      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -783,15 +889,40 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
-      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -799,18 +930,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.19.tgz",
-      "integrity": "sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@smithy/core": "^3.23.8",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-retry": "^4.2.11",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -841,47 +972,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.7.tgz",
-      "integrity": "sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==",
+      "version": "3.997.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.8",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-retry": "^4.4.39",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.38",
-        "@smithy/util-defaults-mode-node": "^4.2.41",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -890,15 +1022,32 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
-      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -924,12 +1073,24 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
-      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -937,15 +1098,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
-      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-endpoints": "^3.3.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -979,27 +1140,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
-      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.4.tgz",
-      "integrity": "sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==",
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1015,13 +1177,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5543,30 +5706,17 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5574,18 +5724,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.9",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
-      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -5595,15 +5745,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5611,14 +5761,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.10.tgz",
-      "integrity": "sha512-A4ynrsFFfSXUHicfTcRehytppFBcY3HQxEGYiyGktPIOye3Ot7fxpiy4VR42WmtGI4Wfo6OXt/c1Ky1nUFxYYQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5626,13 +5776,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.10.tgz",
-      "integrity": "sha512-0xupsu9yj9oDVuQ50YCTS9nuSYhGlrwqdaKQel9y2Fz7LU9fNErVlw9N0o4pm4qqvWEGbSTI4HKc6XJfB30MVw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5640,12 +5790,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.10.tgz",
-      "integrity": "sha512-8kn6sinrduk0yaYHMJDsNuiFpXwQwibR7n/4CDUqn4UgaG+SeBHu5jHGFdU9BLFAM7Q4/gvr9RYxBHz9/jKrhA==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5653,13 +5803,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.10.tgz",
-      "integrity": "sha512-uUrxPGgIffnYfvIOUmBM5i+USdEBRTdh7mLPttjphgtooxQ8CtdO1p6K5+Q4BBAZvKlvtJ9jWyrWpBJYzBKsyQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5667,13 +5817,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.10.tgz",
-      "integrity": "sha512-aArqzOEvcs2dK+xQVCgLbpJQGfZihw8SD4ymhkwNTtwKbnrzdhJsFDKuMQnam2kF69WzgJYOU5eJlCx+CA32bw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5681,14 +5831,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -5697,12 +5847,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
-      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -5712,12 +5862,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
-      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5737,13 +5887,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
-      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5751,18 +5901,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
-      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5770,18 +5920,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.40",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
-      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -5790,13 +5941,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5804,12 +5956,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5817,14 +5969,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5832,15 +5984,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5848,12 +5999,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5861,12 +6012,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5874,12 +6025,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -5888,12 +6039,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5901,24 +6052,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5926,16 +6077,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -5945,17 +6096,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
-      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.9",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5963,9 +6114,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5975,13 +6126,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6052,14 +6203,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.39",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
-      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6067,17 +6218,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.42",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
-      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6085,13 +6236,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6111,12 +6262,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6124,13 +6275,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6138,14 +6289,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/types": "^4.13.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   "dependencies": {
     "@ag-ui/core": "^0.0.41",
     "@aws-sdk/client-bedrock": "^3.1000.0",
+    "@aws-sdk/client-bedrock-agent": "^3.1038.0",
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.1038.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
     "@aws-sdk/credential-providers": "^3.1000.0",
     "@opensearch-project/opensearch": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "traces"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "bin": {
     "agent-health": "./bin/cli.js"

--- a/services/connectors/index.ts
+++ b/services/connectors/index.ts
@@ -42,6 +42,7 @@ export { AGUIStreamingConnector, aguiStreamingConnector } from './agui/AGUIStrea
 export { MockConnector, mockConnector } from './mock/MockConnector';
 export { RESTConnector, restConnector } from './rest/RESTConnector';
 export { OpenAICompatibleConnector, openaiCompatibleConnector } from './openai-compatible/OpenAICompatibleConnector';
+export { LangGraphConnector, langgraphConnector } from './langgraph/LangGraphConnector';
 
 // ============ Auto-register Browser-safe Connectors ============
 import { connectorRegistry } from './registry';
@@ -49,12 +50,14 @@ import { aguiStreamingConnector } from './agui/AGUIStreamingConnector';
 import { mockConnector } from './mock/MockConnector';
 import { restConnector } from './rest/RESTConnector';
 import { openaiCompatibleConnector } from './openai-compatible/OpenAICompatibleConnector';
+import { langgraphConnector } from './langgraph/LangGraphConnector';
 
 // Register browser-compatible connectors on module load
-// Server-only connectors (subprocess, claude-code) are registered via server.ts
+// Server-only connectors (subprocess, claude-code, strands) are registered via server.ts
 connectorRegistry.register(aguiStreamingConnector);
 connectorRegistry.register(mockConnector);
 connectorRegistry.register(restConnector);
 connectorRegistry.register(openaiCompatibleConnector);
+connectorRegistry.register(langgraphConnector);
 
 console.log('[Connectors] Browser-safe connectors registered:', connectorRegistry.getRegisteredTypes().join(', '));

--- a/services/connectors/langgraph/LangGraphConnector.ts
+++ b/services/connectors/langgraph/LangGraphConnector.ts
@@ -25,7 +25,8 @@ import type {
  * LangGraph REST Connector
  *
  * Communicates with LangGraph agents via the LangGraph REST API.
- * Supports both /invoke (synchronous) and /stream (streaming) endpoints.
+ * Uses the /invoke endpoint for synchronous execution.
+ * For streaming LangGraph agents, use the agui-streaming connector instead.
  *
  * Configuration:
  * - endpoint: Base URL of the LangGraph server (e.g., "http://localhost:8123")

--- a/services/connectors/langgraph/LangGraphConnector.ts
+++ b/services/connectors/langgraph/LangGraphConnector.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * LangGraph REST Connector
+ * Handles non-streaming REST calls to LangGraph agents
+ *
+ * For AG-UI streaming LangGraph agents, use the existing agui-streaming connector.
+ * This connector is for LangGraph instances exposed via direct REST API.
+ */
+
+import type { TrajectoryStep, ToolCallStatus } from '@/types';
+import { BaseConnector } from '@/services/connectors/base/BaseConnector';
+import type {
+  ConnectorAuth,
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorProgressCallback,
+  ConnectorRawEventCallback,
+} from '@/services/connectors/types';
+
+/**
+ * LangGraph REST Connector
+ *
+ * Communicates with LangGraph agents via the LangGraph REST API.
+ * Supports both /invoke (synchronous) and /stream (streaming) endpoints.
+ *
+ * Configuration:
+ * - endpoint: Base URL of the LangGraph server (e.g., "http://localhost:8123")
+ * - connectorConfig.graphId: Graph/assistant ID (defaults to "agent")
+ * - connectorConfig.threadId: Optional thread ID for multi-turn
+ */
+export class LangGraphConnector extends BaseConnector {
+  readonly type = 'langgraph' as const;
+  readonly name = 'LangGraph (REST)';
+  readonly supportsStreaming = false;
+
+  buildPayload(request: ConnectorRequest): any {
+    const config = request.connectorConfig || {};
+    return {
+      input: {
+        messages: [
+          {
+            role: 'user',
+            content: request.testCase.initialPrompt,
+          },
+        ],
+      },
+      config: {
+        configurable: {
+          ...(request.modelId && { model: request.modelId }),
+          ...config.configurable,
+        },
+      },
+    };
+  }
+
+  async execute(
+    endpoint: string,
+    request: ConnectorRequest,
+    auth: ConnectorAuth,
+    onProgress?: ConnectorProgressCallback,
+    onRawEvent?: ConnectorRawEventCallback
+  ): Promise<ConnectorResponse> {
+    const payload = request.payload || this.buildPayload(request);
+    const headers = this.buildAuthHeaders(auth);
+    const config = request.connectorConfig || {};
+    const graphId = config.graphId || 'agent';
+
+    // Build the invoke URL
+    const baseUrl = endpoint.replace(/\/+$/, '');
+    const threadId = config.threadId || request.threadId;
+    const invokeUrl = threadId
+      ? `${baseUrl}/threads/${threadId}/runs/wait`
+      : `${baseUrl}/assistants/${graphId}/invoke`;
+
+    this.debug('Executing LangGraph request');
+    this.debug('URL:', invokeUrl);
+
+    const response = await fetch(invokeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`LangGraph request failed: ${response.status} - ${errorText}`);
+    }
+
+    const data = await response.json();
+    onRawEvent?.(data);
+
+    const trajectory = this.parseResponse(data);
+    trajectory.forEach(step => onProgress?.(step));
+
+    return {
+      trajectory,
+      runId: data.run_id || data.thread_id || threadId || null,
+      rawEvents: [data],
+      metadata: {
+        graphId,
+        threadId: data.thread_id || threadId,
+      },
+    };
+  }
+
+  parseResponse(data: any): TrajectoryStep[] {
+    const steps: TrajectoryStep[] = [];
+
+    // LangGraph invoke response format: { output: { messages: [...] } }
+    // Or thread-based: { values: { messages: [...] } }
+    const messages = data.output?.messages || data.values?.messages || data.messages || [];
+
+    for (const msg of messages) {
+      const role = msg.type || msg.role;
+      const content = typeof msg.content === 'string'
+        ? msg.content
+        : Array.isArray(msg.content)
+          ? msg.content.map((c: any) => c.text || JSON.stringify(c)).join('\n')
+          : JSON.stringify(msg.content);
+
+      if (role === 'ai' || role === 'assistant') {
+        // Check for tool calls in the AI message
+        if (msg.tool_calls && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+          for (const toolCall of msg.tool_calls) {
+            steps.push(this.createStep('action', `Calling ${toolCall.name}...`, {
+              toolName: toolCall.name,
+              toolArgs: toolCall.args,
+            }));
+          }
+        }
+
+        // AI reasoning or intermediate response
+        if (content && !msg.tool_calls?.length) {
+          steps.push(this.createStep('assistant', content));
+        }
+      } else if (role === 'tool') {
+        steps.push(this.createStep('tool_result', content, {
+          toolName: msg.name,
+          status: 'SUCCESS' as ToolCallStatus,
+        }));
+      }
+    }
+
+    // The last AI message without tool calls is the final response
+    const lastAssistant = [...steps].reverse().find(s => s.type === 'assistant');
+    if (lastAssistant) {
+      lastAssistant.type = 'response';
+    }
+
+    // Handle intermediate_steps format (older LangGraph versions)
+    if (data.intermediate_steps && Array.isArray(data.intermediate_steps)) {
+      for (const [action, observation] of data.intermediate_steps) {
+        if (action?.tool) {
+          steps.push(this.createStep('action', `Calling ${action.tool}...`, {
+            toolName: action.tool,
+            toolArgs: action.tool_input,
+          }));
+        }
+        if (observation !== undefined) {
+          const obsContent = typeof observation === 'string' ? observation : JSON.stringify(observation);
+          steps.push(this.createStep('tool_result', obsContent, {
+            status: 'SUCCESS' as ToolCallStatus,
+          }));
+        }
+      }
+    }
+
+    // Handle direct output field
+    if (data.output && typeof data.output === 'string' && steps.length === 0) {
+      steps.push(this.createStep('response', data.output));
+    }
+
+    // Fallback
+    if (steps.length === 0 && data) {
+      steps.push(this.createStep('response', JSON.stringify(data, null, 2)));
+    }
+
+    return steps;
+  }
+
+  async healthCheck(endpoint: string, auth: ConnectorAuth): Promise<boolean> {
+    try {
+      const headers = this.buildAuthHeaders(auth);
+      const baseUrl = endpoint.replace(/\/+$/, '');
+      const response = await fetch(`${baseUrl}/ok`, {
+        method: 'GET',
+        headers,
+      });
+      return response.ok;
+    } catch {
+      // Try root endpoint as fallback
+      try {
+        const headers = this.buildAuthHeaders(auth);
+        const response = await fetch(endpoint, { method: 'GET', headers });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    }
+  }
+}
+
+export const langgraphConnector = new LangGraphConnector();

--- a/services/connectors/server.ts
+++ b/services/connectors/server.ts
@@ -20,14 +20,17 @@ export {
   claudeCodeConnector,
   createBedrockClaudeCodeConnector,
 } from './claude-code/ClaudeCodeConnector';
+export { StrandsConnector, strandsConnector } from './strands/StrandsConnector';
 
 // Register server-only connectors
 import { connectorRegistry } from './registry';
 import { subprocessConnector } from './subprocess/SubprocessConnector';
 import { claudeCodeConnector } from './claude-code/ClaudeCodeConnector';
+import { strandsConnector } from './strands/StrandsConnector';
 
 // Register server-only connectors on module load
 connectorRegistry.register(subprocessConnector);
 connectorRegistry.register(claudeCodeConnector);
+connectorRegistry.register(strandsConnector);
 
 console.log('[Connectors] Server connectors registered:', connectorRegistry.getRegisteredTypes().join(', '));

--- a/services/connectors/strands/StrandsConnector.ts
+++ b/services/connectors/strands/StrandsConnector.ts
@@ -125,8 +125,9 @@ export class StrandsConnector extends BaseConnector {
       }
     }
 
-    // Add final response step
-    if (finalOutput) {
+    // Add final response step only if no response was already emitted from traces
+    const hasResponseFromTrace = trajectory.some(s => s.type === 'response');
+    if (finalOutput && !hasResponseFromTrace) {
       const responseStep = this.createStep('response', finalOutput);
       trajectory.push(responseStep);
       onProgress?.(responseStep);

--- a/services/connectors/strands/StrandsConnector.ts
+++ b/services/connectors/strands/StrandsConnector.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Strands Connector
+ * Integrates with Amazon Strands agents via Bedrock Agent Runtime API
+ * Server-only: requires AWS SDK
+ */
+
+import type { TrajectoryStep, ToolCallStatus } from '@/types';
+import { BaseConnector } from '@/services/connectors/base/BaseConnector';
+import type {
+  ConnectorAuth,
+  ConnectorRequest,
+  ConnectorResponse,
+  ConnectorProgressCallback,
+  ConnectorRawEventCallback,
+} from '@/services/connectors/types';
+
+/**
+ * Configuration for Strands connector
+ */
+export interface StrandsConfig {
+  agentAliasId: string;
+  region?: string;
+  sessionId?: string;
+  enableTrace?: boolean;
+}
+
+/**
+ * Strands Connector for Amazon Bedrock Agent Runtime
+ *
+ * Uses InvokeAgent API to execute Strands agents and parses
+ * trace events into TrajectorySteps for evaluation.
+ *
+ * Configuration:
+ * - endpoint: The Bedrock Agent ID (e.g., "ABCDEF1234")
+ * - connectorConfig.agentAliasId: Agent alias ID (e.g., "TSTALIASID")
+ * - connectorConfig.region: AWS region (defaults to AWS_REGION env var)
+ * - auth: AWS SigV4 credentials (or uses default provider chain)
+ */
+export class StrandsConnector extends BaseConnector {
+  readonly type = 'strands' as const;
+  readonly name = 'Amazon Strands';
+  readonly supportsStreaming = true;
+
+  buildPayload(request: ConnectorRequest): any {
+    const config = (request.connectorConfig || {}) as Partial<StrandsConfig>;
+    return {
+      agentId: '', // Set from endpoint in execute()
+      agentAliasId: config.agentAliasId || 'TSTALIASID',
+      sessionId: config.sessionId || `eval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      inputText: request.testCase.initialPrompt,
+      enableTrace: config.enableTrace !== false,
+    };
+  }
+
+  async execute(
+    endpoint: string,
+    request: ConnectorRequest,
+    auth: ConnectorAuth,
+    onProgress?: ConnectorProgressCallback,
+    onRawEvent?: ConnectorRawEventCallback
+  ): Promise<ConnectorResponse> {
+    const payload = request.payload || this.buildPayload(request);
+    payload.agentId = endpoint; // Agent ID is the endpoint
+
+    const config = (request.connectorConfig || {}) as Partial<StrandsConfig>;
+    const region = config.region || auth.awsRegion || process.env.AWS_REGION || 'us-east-1';
+
+    this.debug('Executing Strands agent');
+    this.debug('Agent ID:', endpoint);
+    this.debug('Alias:', payload.agentAliasId);
+    this.debug('Region:', region);
+
+    // Dynamically import AWS SDK to keep module tree-shakeable
+    const { BedrockAgentRuntimeClient, InvokeAgentCommand } = await import(
+      '@aws-sdk/client-bedrock-agent-runtime'
+    );
+
+    const clientConfig: Record<string, any> = { region };
+
+    // Use explicit credentials if provided via auth
+    if (auth.type === 'aws-sigv4' && auth.awsAccessKeyId && auth.awsSecretAccessKey) {
+      clientConfig.credentials = {
+        accessKeyId: auth.awsAccessKeyId,
+        secretAccessKey: auth.awsSecretAccessKey,
+        ...(auth.awsSessionToken && { sessionToken: auth.awsSessionToken }),
+      };
+    }
+
+    const client = new BedrockAgentRuntimeClient(clientConfig);
+
+    const command = new InvokeAgentCommand({
+      agentId: payload.agentId,
+      agentAliasId: payload.agentAliasId,
+      sessionId: payload.sessionId,
+      inputText: payload.inputText,
+      enableTrace: payload.enableTrace,
+    });
+
+    const response = await client.send(command);
+    const trajectory: TrajectoryStep[] = [];
+    let finalOutput = '';
+
+    // Process streaming response
+    if (response.completion) {
+      for await (const event of response.completion) {
+        onRawEvent?.(event);
+
+        if (event.chunk?.bytes) {
+          const text = new TextDecoder().decode(event.chunk.bytes);
+          finalOutput += text;
+        }
+
+        if (event.trace?.trace) {
+          const traceSteps = this.parseTraceEvent(event.trace.trace);
+          for (const step of traceSteps) {
+            trajectory.push(step);
+            onProgress?.(step);
+          }
+        }
+      }
+    }
+
+    // Add final response step
+    if (finalOutput) {
+      const responseStep = this.createStep('response', finalOutput);
+      trajectory.push(responseStep);
+      onProgress?.(responseStep);
+    }
+
+    return {
+      trajectory,
+      runId: payload.sessionId,
+      metadata: {
+        agentId: endpoint,
+        agentAliasId: payload.agentAliasId,
+        sessionId: payload.sessionId,
+        region,
+      },
+    };
+  }
+
+  parseResponse(rawResponse: any): TrajectoryStep[] {
+    if (rawResponse?.trace?.trace) {
+      return this.parseTraceEvent(rawResponse.trace.trace);
+    }
+    if (typeof rawResponse === 'string') {
+      return [this.createStep('response', rawResponse)];
+    }
+    return [];
+  }
+
+  /**
+   * Parse a Bedrock Agent trace event into TrajectorySteps
+   */
+  private parseTraceEvent(trace: any): TrajectoryStep[] {
+    const steps: TrajectoryStep[] = [];
+
+    // Pre-processing trace
+    if (trace.preProcessingTrace) {
+      const pre = trace.preProcessingTrace;
+      if (pre.modelInvocationOutput?.parsedResponse?.isValid !== undefined) {
+        steps.push(this.createStep('thinking',
+          `Pre-processing: Input ${pre.modelInvocationOutput.parsedResponse.isValid ? 'valid' : 'invalid'}` +
+          (pre.modelInvocationOutput.parsedResponse.rationale
+            ? ` — ${pre.modelInvocationOutput.parsedResponse.rationale}`
+            : '')
+        ));
+      }
+    }
+
+    // Orchestration trace (main reasoning + tool use)
+    if (trace.orchestrationTrace) {
+      const orch = trace.orchestrationTrace;
+
+      // Rationale (thinking)
+      if (orch.rationale?.text) {
+        steps.push(this.createStep('thinking', orch.rationale.text));
+      }
+
+      // Model invocation input
+      if (orch.modelInvocationInput?.text) {
+        steps.push(this.createStep('thinking', `Model input: ${this.truncate(orch.modelInvocationInput.text, 500)}`));
+      }
+
+      // Tool invocation
+      if (orch.invocationInput) {
+        const inv = orch.invocationInput;
+
+        if (inv.actionGroupInvocationInput) {
+          const action = inv.actionGroupInvocationInput;
+          steps.push(this.createStep('action', `Calling ${action.actionGroupName || 'action'}::${action.apiPath || action.function || 'invoke'}`, {
+            toolName: `${action.actionGroupName || 'action'}::${action.apiPath || action.function || 'invoke'}`,
+            toolArgs: action.parameters ? Object.fromEntries(
+              action.parameters.map((p: any) => [p.name, p.value])
+            ) : undefined,
+          }));
+        }
+
+        if (inv.knowledgeBaseLookupInput) {
+          steps.push(this.createStep('action', `Knowledge base lookup: ${inv.knowledgeBaseLookupInput.text}`, {
+            toolName: 'knowledge_base_lookup',
+            toolArgs: { query: inv.knowledgeBaseLookupInput.text },
+          }));
+        }
+      }
+
+      // Tool observation (result)
+      if (orch.observation) {
+        const obs = orch.observation;
+
+        if (obs.actionGroupInvocationOutput?.text) {
+          steps.push(this.createStep('tool_result', obs.actionGroupInvocationOutput.text, {
+            status: 'SUCCESS' as ToolCallStatus,
+          }));
+        }
+
+        if (obs.knowledgeBaseLookupOutput?.retrievedReferences) {
+          const refs = obs.knowledgeBaseLookupOutput.retrievedReferences;
+          steps.push(this.createStep('tool_result',
+            `Retrieved ${refs.length} reference(s) from knowledge base`, {
+            status: 'SUCCESS' as ToolCallStatus,
+            toolOutput: refs.map((r: any) => ({
+              content: this.truncate(r.content?.text, 200),
+              location: r.location,
+            })),
+          }));
+        }
+
+        if (obs.finalResponse?.text) {
+          steps.push(this.createStep('response', obs.finalResponse.text));
+        }
+      }
+    }
+
+    // Post-processing trace
+    if (trace.postProcessingTrace) {
+      const post = trace.postProcessingTrace;
+      if (post.modelInvocationOutput?.parsedResponse?.text) {
+        steps.push(this.createStep('thinking',
+          `Post-processing: ${this.truncate(post.modelInvocationOutput.parsedResponse.text, 300)}`
+        ));
+      }
+    }
+
+    // Failure trace
+    if (trace.failureTrace) {
+      steps.push(this.createStep('response',
+        `Agent error: ${trace.failureTrace.failureReason || 'Unknown failure'}`
+      ));
+    }
+
+    return steps;
+  }
+
+  /**
+   * Health check: verify the agent exists via GetAgent
+   */
+  async healthCheck(endpoint: string, auth: ConnectorAuth): Promise<boolean> {
+    try {
+      const config = auth as any;
+      const region = config.awsRegion || process.env.AWS_REGION || 'us-east-1';
+
+      const { BedrockAgentClient, GetAgentCommand } = await import(
+        '@aws-sdk/client-bedrock-agent'
+      );
+
+      const clientConfig: Record<string, any> = { region };
+      if (auth.type === 'aws-sigv4' && auth.awsAccessKeyId && auth.awsSecretAccessKey) {
+        clientConfig.credentials = {
+          accessKeyId: auth.awsAccessKeyId,
+          secretAccessKey: auth.awsSecretAccessKey,
+          ...(auth.awsSessionToken && { sessionToken: auth.awsSessionToken }),
+        };
+      }
+
+      const client = new BedrockAgentClient(clientConfig);
+      const result = await client.send(new GetAgentCommand({ agentId: endpoint }));
+      return result.agent?.agentStatus === 'PREPARED';
+    } catch (error) {
+      this.error('Health check failed:', error);
+      return false;
+    }
+  }
+
+  private truncate(text: string | undefined, maxLen: number): string {
+    if (!text) return '';
+    return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
+  }
+}
+
+export const strandsConnector = new StrandsConnector();

--- a/services/connectors/types.ts
+++ b/services/connectors/types.ts
@@ -15,7 +15,7 @@ import type { TestCase, TrajectoryStep, AgentHooks } from '@/types';
  * - claude-code: Claude Code CLI (specialized subprocess)
  * - mock: Demo/testing connector
  */
-export type ConnectorProtocol = 'agui-streaming' | 'rest' | 'openai-compatible' | 'subprocess' | 'claude-code' | 'mock';
+export type ConnectorProtocol = 'agui-streaming' | 'rest' | 'openai-compatible' | 'subprocess' | 'claude-code' | 'strands' | 'langgraph' | 'mock';
 
 // ============ Authentication Types ============
 

--- a/services/connectors/types.ts
+++ b/services/connectors/types.ts
@@ -11,8 +11,11 @@ import type { TestCase, TrajectoryStep, AgentHooks } from '@/types';
  * Protocol type for agent communication
  * - agui-streaming: AG-UI protocol over SSE (current default)
  * - rest: Non-streaming REST API
+ * - openai-compatible: OpenAI chat completions format (LiteLLM, Ollama, vLLM)
  * - subprocess: CLI tools invoked as child processes
  * - claude-code: Claude Code CLI (specialized subprocess)
+ * - strands: Amazon Strands via Bedrock Agent Runtime API
+ * - langgraph: LangGraph agent via direct REST API
  * - mock: Demo/testing connector
  */
 export type ConnectorProtocol = 'agui-streaming' | 'rest' | 'openai-compatible' | 'subprocess' | 'claude-code' | 'strands' | 'langgraph' | 'mock';

--- a/tests/integration/server/routes/config.integration.test.ts
+++ b/tests/integration/server/routes/config.integration.test.ts
@@ -25,7 +25,7 @@ const TEST_TIMEOUT = 30000;
  * Number of agents in DEFAULT_CONFIG (lib/constants.ts).
  * If the defaults change, update this constant.
  */
-const DEFAULT_AGENT_COUNT = 2;
+const DEFAULT_AGENT_COUNT = 4;
 
 /**
  * Minimum number of models in DEFAULT_CONFIG.

--- a/tests/unit/server/app.test.ts
+++ b/tests/unit/server/app.test.ts
@@ -106,6 +106,12 @@ jest.mock('@/server/middleware/dataSourceConfig', () => ({
   },
 }));
 
+jest.mock('@/lib/telemetry', () => ({
+  initEvalTracerProvider: jest.fn(),
+  resolveEvalTelemetryConfig: jest.fn().mockReturnValue({}),
+  shutdownEvalTracer: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('@/server/services/storageInitializer', () => ({
   initializeStorageFromConfig: jest.fn().mockResolvedValue({
     backend: 'file',

--- a/tests/unit/services/connectors/langgraph/LangGraphConnector.test.ts
+++ b/tests/unit/services/connectors/langgraph/LangGraphConnector.test.ts
@@ -1,0 +1,448 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LangGraphConnector, langgraphConnector } from '@/services/connectors/langgraph/LangGraphConnector';
+import type { ConnectorRequest, ConnectorAuth } from '@/services/connectors/types';
+import type { TestCase, TrajectoryStep } from '@/types';
+
+describe('LangGraphConnector', () => {
+  let connector: LangGraphConnector;
+  let mockTestCase: TestCase;
+  let mockAuth: ConnectorAuth;
+
+  beforeEach(() => {
+    connector = new LangGraphConnector();
+    mockTestCase = {
+      id: 'tc-123',
+      name: 'Test Case',
+      initialPrompt: 'What is the cluster health?',
+      context: [{ description: 'Cluster Name', value: 'test-cluster' }],
+      expectedOutcomes: ['Check cluster health'],
+      labels: [],
+      tools: ['tool1'],
+      version: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    mockAuth = { type: 'none' };
+    jest.spyOn(global, 'fetch').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('properties', () => {
+    it('should have correct type', () => {
+      expect(connector.type).toBe('langgraph');
+    });
+
+    it('should have correct name', () => {
+      expect(connector.name).toBe('LangGraph (REST)');
+    });
+
+    it('should not support streaming', () => {
+      expect(connector.supportsStreaming).toBe(false);
+    });
+  });
+
+  describe('buildPayload', () => {
+    it('should build payload with messages format', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        modelId: 'test-model',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.input.messages).toEqual([
+        { role: 'user', content: 'What is the cluster health?' },
+      ]);
+      expect(payload.config.configurable.model).toBe('test-model');
+    });
+
+    it('should include custom configurable from connectorConfig', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: {
+          configurable: { thread_id: 'abc' },
+        },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.config.configurable.thread_id).toBe('abc');
+    });
+
+    it('should omit model when modelId is not provided', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.config.configurable.model).toBeUndefined();
+    });
+  });
+
+  describe('execute', () => {
+    it('should POST to invoke URL with default graphId', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          output: { messages: [{ type: 'ai', content: 'Hello' }] },
+        }),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+
+      await connector.execute('http://localhost:8123', request, mockAuth);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/agent/invoke',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        })
+      );
+    });
+
+    it('should use custom graphId from connectorConfig', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { graphId: 'my-graph' },
+      };
+
+      await connector.execute('http://localhost:8123', request, mockAuth);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/my-graph/invoke',
+        expect.any(Object)
+      );
+    });
+
+    it('should use thread-based URL when threadId is provided', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ values: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { threadId: 'thread-123' },
+      };
+
+      await connector.execute('http://localhost:8123', request, mockAuth);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8123/threads/thread-123/runs/wait',
+        expect.any(Object)
+      );
+    });
+
+    it('should include auth headers', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+
+      await connector.execute(
+        'http://localhost:8123',
+        request,
+        { type: 'bearer', token: 'my-token' }
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer my-token',
+          }),
+        })
+      );
+    });
+
+    it('should throw on non-ok response', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+
+      await expect(
+        connector.execute('http://localhost:8123', request, mockAuth)
+      ).rejects.toThrow('LangGraph request failed: 500');
+    });
+
+    it('should return trajectory from response', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          output: {
+            messages: [
+              { type: 'ai', content: 'The cluster is healthy' },
+            ],
+          },
+          run_id: 'run-abc',
+        }),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const result = await connector.execute('http://localhost:8123', request, mockAuth);
+
+      expect(result.trajectory.length).toBeGreaterThan(0);
+      expect(result.runId).toBe('run-abc');
+      expect(result.rawEvents).toHaveLength(1);
+    });
+
+    it('should call onProgress for each step', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          output: {
+            messages: [{ type: 'ai', content: 'Response' }],
+          },
+        }),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const progressSteps: TrajectoryStep[] = [];
+
+      await connector.execute(
+        'http://localhost:8123',
+        request,
+        mockAuth,
+        (step) => progressSteps.push(step)
+      );
+
+      expect(progressSteps.length).toBeGreaterThan(0);
+    });
+
+    it('should call onRawEvent with response data', async () => {
+      const responseData = {
+        output: { messages: [{ type: 'ai', content: 'Hello' }] },
+      };
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseData),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const rawEvents: any[] = [];
+
+      await connector.execute(
+        'http://localhost:8123',
+        request,
+        mockAuth,
+        undefined,
+        (event) => rawEvents.push(event)
+      );
+
+      expect(rawEvents).toContainEqual(responseData);
+    });
+
+    it('should strip trailing slashes from endpoint', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+
+      await connector.execute('http://localhost:8123///', request, mockAuth);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/agent/invoke',
+        expect.any(Object)
+      );
+    });
+
+    it('should use custom payload when provided', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ output: { messages: [] } }),
+      });
+
+      const customPayload = { custom: 'payload' };
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        payload: customPayload,
+      };
+
+      await connector.execute('http://localhost:8123', request, mockAuth);
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      expect(JSON.parse(fetchCall[1].body)).toEqual(customPayload);
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should parse AI messages as response', () => {
+      const steps = connector.parseResponse({
+        output: {
+          messages: [
+            { type: 'ai', content: 'The answer is 42' },
+          ],
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('The answer is 42');
+    });
+
+    it('should parse tool calls in AI messages', () => {
+      const steps = connector.parseResponse({
+        output: {
+          messages: [
+            {
+              type: 'ai',
+              content: '',
+              tool_calls: [
+                { name: 'search', args: { query: 'test' } },
+              ],
+            },
+            { type: 'tool', name: 'search', content: 'found results' },
+            { type: 'ai', content: 'Based on search results...' },
+          ],
+        },
+      });
+
+      expect(steps.length).toBeGreaterThanOrEqual(3);
+      expect(steps[0].type).toBe('action');
+      expect(steps[0].toolName).toBe('search');
+      expect(steps[1].type).toBe('tool_result');
+      expect(steps[1].content).toBe('found results');
+      // Last AI message becomes 'response'
+      const responseStep = steps.find(s => s.type === 'response');
+      expect(responseStep).toBeDefined();
+      expect(responseStep!.content).toBe('Based on search results...');
+    });
+
+    it('should parse values.messages format (thread-based)', () => {
+      const steps = connector.parseResponse({
+        values: {
+          messages: [
+            { type: 'ai', content: 'Thread response' },
+          ],
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Thread response');
+    });
+
+    it('should parse intermediate_steps format (older LangGraph)', () => {
+      const steps = connector.parseResponse({
+        intermediate_steps: [
+          [{ tool: 'search', tool_input: { q: 'test' } }, 'result data'],
+        ],
+      });
+
+      expect(steps).toHaveLength(2);
+      expect(steps[0].type).toBe('action');
+      expect(steps[0].toolName).toBe('search');
+      expect(steps[1].type).toBe('tool_result');
+      expect(steps[1].content).toBe('result data');
+    });
+
+    it('should parse direct string output', () => {
+      const steps = connector.parseResponse({
+        output: 'Simple string output',
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Simple string output');
+    });
+
+    it('should handle array content in messages', () => {
+      const steps = connector.parseResponse({
+        output: {
+          messages: [
+            {
+              type: 'ai',
+              content: [
+                { text: 'Part 1' },
+                { text: 'Part 2' },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].content).toBe('Part 1\nPart 2');
+    });
+
+    it('should fallback to JSON stringified data when no recognized format', () => {
+      const data = { unknown_field: 'value' };
+      const steps = connector.parseResponse(data);
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe(JSON.stringify(data, null, 2));
+    });
+
+    it('should handle empty messages array', () => {
+      const steps = connector.parseResponse({
+        output: { messages: [] },
+      });
+
+      // Should fallback since no steps were generated from empty messages
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should check /ok endpoint', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
+      const result = await connector.healthCheck('http://localhost:8123', mockAuth);
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8123/ok',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should fallback to root endpoint', async () => {
+      (global.fetch as jest.Mock)
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ ok: true });
+
+      const result = await connector.healthCheck('http://localhost:8123', mockAuth);
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return false when both endpoints fail', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('connection refused'));
+
+      const result = await connector.healthCheck('http://localhost:8123', mockAuth);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('default instance', () => {
+    it('should export a default instance', () => {
+      expect(langgraphConnector).toBeInstanceOf(LangGraphConnector);
+    });
+  });
+});

--- a/tests/unit/services/connectors/strands/StrandsConnector.test.ts
+++ b/tests/unit/services/connectors/strands/StrandsConnector.test.ts
@@ -1,0 +1,486 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StrandsConnector, strandsConnector } from '@/services/connectors/strands/StrandsConnector';
+import type { ConnectorRequest, ConnectorAuth } from '@/services/connectors/types';
+import type { TestCase, TrajectoryStep } from '@/types';
+
+// Mock AWS SDK modules
+const mockSend = jest.fn();
+jest.mock('@aws-sdk/client-bedrock-agent-runtime', () => ({
+  BedrockAgentRuntimeClient: jest.fn().mockImplementation(() => ({
+    send: mockSend,
+  })),
+  InvokeAgentCommand: jest.fn().mockImplementation((params: any) => params),
+}));
+
+const mockAgentSend = jest.fn();
+jest.mock('@aws-sdk/client-bedrock-agent', () => ({
+  BedrockAgentClient: jest.fn().mockImplementation(() => ({
+    send: mockAgentSend,
+  })),
+  GetAgentCommand: jest.fn().mockImplementation((params: any) => params),
+}));
+
+describe('StrandsConnector', () => {
+  let connector: StrandsConnector;
+  let mockTestCase: TestCase;
+  let mockAuth: ConnectorAuth;
+
+  beforeEach(() => {
+    connector = new StrandsConnector();
+    mockTestCase = {
+      id: 'tc-123',
+      name: 'Test Case',
+      initialPrompt: 'Diagnose the issue',
+      context: [{ description: 'Service', value: 'my-service' }],
+      expectedOutcomes: ['Identify root cause'],
+      labels: [],
+      tools: ['search_logs'],
+      version: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    mockAuth = { type: 'aws-sigv4', awsRegion: 'us-west-2' };
+    mockSend.mockReset();
+    mockAgentSend.mockReset();
+  });
+
+  describe('properties', () => {
+    it('should have correct type', () => {
+      expect(connector.type).toBe('strands');
+    });
+
+    it('should have correct name', () => {
+      expect(connector.name).toBe('Amazon Strands');
+    });
+
+    it('should support streaming', () => {
+      expect(connector.supportsStreaming).toBe(true);
+    });
+  });
+
+  describe('buildPayload', () => {
+    it('should build payload with agent input text', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.inputText).toBe('Diagnose the issue');
+      expect(payload.agentAliasId).toBe('TSTALIASID');
+      expect(payload.enableTrace).toBe(true);
+      expect(payload.sessionId).toMatch(/^eval-/);
+    });
+
+    it('should use custom agentAliasId from connectorConfig', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { agentAliasId: 'CUSTOM123' },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.agentAliasId).toBe('CUSTOM123');
+    });
+
+    it('should use custom sessionId from connectorConfig', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { sessionId: 'my-session' },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.sessionId).toBe('my-session');
+    });
+
+    it('should allow disabling trace', () => {
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { enableTrace: false },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.enableTrace).toBe(false);
+    });
+  });
+
+  describe('execute', () => {
+    function createStreamingResponse(events: any[]) {
+      return {
+        completion: (async function* () {
+          for (const event of events) {
+            yield event;
+          }
+        })(),
+      };
+    }
+
+    it('should invoke Bedrock agent with correct parameters', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([
+        { chunk: { bytes: new TextEncoder().encode('Hello') } },
+      ]));
+
+      const request: ConnectorRequest = {
+        testCase: mockTestCase,
+        connectorConfig: { agentAliasId: 'ALIAS1' },
+      };
+
+      await connector.execute('AGENT123', request, mockAuth);
+
+      const { InvokeAgentCommand } = require('@aws-sdk/client-bedrock-agent-runtime');
+      expect(InvokeAgentCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'AGENT123',
+          agentAliasId: 'ALIAS1',
+          inputText: 'Diagnose the issue',
+          enableTrace: true,
+        })
+      );
+    });
+
+    it('should accumulate chunk bytes into final response', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([
+        { chunk: { bytes: new TextEncoder().encode('Hello ') } },
+        { chunk: { bytes: new TextEncoder().encode('World') } },
+      ]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const result = await connector.execute('AGENT123', request, mockAuth);
+
+      const responseStep = result.trajectory.find(s => s.type === 'response');
+      expect(responseStep).toBeDefined();
+      expect(responseStep!.content).toBe('Hello World');
+    });
+
+    it('should parse trace events into trajectory steps', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                rationale: { text: 'I should search the logs' },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                invocationInput: {
+                  actionGroupInvocationInput: {
+                    actionGroupName: 'tools',
+                    function: 'search_logs',
+                    parameters: [{ name: 'query', value: 'error' }],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                observation: {
+                  actionGroupInvocationOutput: { text: 'Found 5 errors' },
+                },
+              },
+            },
+          },
+        },
+        { chunk: { bytes: new TextEncoder().encode('The issue is...') } },
+      ]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const progressSteps: TrajectoryStep[] = [];
+
+      const result = await connector.execute(
+        'AGENT123',
+        request,
+        mockAuth,
+        (step) => progressSteps.push(step)
+      );
+
+      expect(result.trajectory.length).toBeGreaterThanOrEqual(4);
+      expect(progressSteps.length).toBe(result.trajectory.length);
+
+      // Verify step types
+      const thinking = result.trajectory.find(s => s.type === 'thinking');
+      expect(thinking).toBeDefined();
+      expect(thinking!.content).toContain('search the logs');
+
+      const action = result.trajectory.find(s => s.type === 'action');
+      expect(action).toBeDefined();
+      expect(action!.toolName).toContain('search_logs');
+
+      const toolResult = result.trajectory.find(s => s.type === 'tool_result');
+      expect(toolResult).toBeDefined();
+      expect(toolResult!.content).toBe('Found 5 errors');
+
+      const response = result.trajectory.find(s => s.type === 'response');
+      expect(response).toBeDefined();
+      expect(response!.content).toBe('The issue is...');
+    });
+
+    it('should call onRawEvent for each event', async () => {
+      const events = [
+        { chunk: { bytes: new TextEncoder().encode('Hi') } },
+      ];
+      mockSend.mockResolvedValue(createStreamingResponse(events));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const rawEvents: any[] = [];
+
+      await connector.execute(
+        'AGENT123',
+        request,
+        mockAuth,
+        undefined,
+        (event) => rawEvents.push(event)
+      );
+
+      expect(rawEvents.length).toBeGreaterThan(0);
+    });
+
+    it('should use explicit AWS credentials when provided', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const authWithCreds: ConnectorAuth = {
+        type: 'aws-sigv4',
+        awsRegion: 'eu-west-1',
+        awsAccessKeyId: 'AKID',
+        awsSecretAccessKey: 'SECRET',
+        awsSessionToken: 'TOKEN',
+      };
+
+      await connector.execute('AGENT123', request, authWithCreds);
+
+      const { BedrockAgentRuntimeClient } = require('@aws-sdk/client-bedrock-agent-runtime');
+      expect(BedrockAgentRuntimeClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'eu-west-1',
+          credentials: expect.objectContaining({
+            accessKeyId: 'AKID',
+            secretAccessKey: 'SECRET',
+            sessionToken: 'TOKEN',
+          }),
+        })
+      );
+    });
+
+    it('should return metadata with agent and session info', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const result = await connector.execute('AGENT123', request, mockAuth);
+
+      expect(result.metadata).toEqual(expect.objectContaining({
+        agentId: 'AGENT123',
+        region: 'us-west-2',
+      }));
+      expect(result.runId).toBeDefined();
+    });
+
+    it('should default region to us-east-1 when not specified', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const noRegionAuth: ConnectorAuth = { type: 'none' };
+
+      // Remove env var to test default
+      const originalRegion = process.env.AWS_REGION;
+      delete process.env.AWS_REGION;
+
+      await connector.execute('AGENT123', request, noRegionAuth);
+
+      const { BedrockAgentRuntimeClient } = require('@aws-sdk/client-bedrock-agent-runtime');
+      const callArgs = BedrockAgentRuntimeClient.mock.calls[BedrockAgentRuntimeClient.mock.calls.length - 1][0];
+      expect(callArgs.region).toBe('us-east-1');
+
+      // Restore
+      if (originalRegion) process.env.AWS_REGION = originalRegion;
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should parse trace event with trace.trace', () => {
+      const steps = connector.parseResponse({
+        trace: {
+          trace: {
+            orchestrationTrace: {
+              rationale: { text: 'Thinking...' },
+            },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('thinking');
+      expect(steps[0].content).toContain('Thinking...');
+    });
+
+    it('should parse string response', () => {
+      const steps = connector.parseResponse('Simple answer');
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Simple answer');
+    });
+
+    it('should return empty array for unrecognized input', () => {
+      const steps = connector.parseResponse({ unknown: true });
+
+      expect(steps).toHaveLength(0);
+    });
+  });
+
+  describe('parseTraceEvent (via parseResponse)', () => {
+    function parseTrace(trace: any) {
+      return connector.parseResponse({ trace: { trace } });
+    }
+
+    it('should parse pre-processing trace', () => {
+      const steps = parseTrace({
+        preProcessingTrace: {
+          modelInvocationOutput: {
+            parsedResponse: { isValid: true, rationale: 'Input looks good' },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('thinking');
+      expect(steps[0].content).toContain('valid');
+      expect(steps[0].content).toContain('Input looks good');
+    });
+
+    it('should parse orchestration rationale', () => {
+      const steps = parseTrace({
+        orchestrationTrace: {
+          rationale: { text: 'Let me check the logs' },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('thinking');
+      expect(steps[0].content).toBe('Let me check the logs');
+    });
+
+    it('should parse knowledge base lookup', () => {
+      const steps = parseTrace({
+        orchestrationTrace: {
+          invocationInput: {
+            knowledgeBaseLookupInput: { text: 'How to fix OOM' },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('action');
+      expect(steps[0].toolName).toBe('knowledge_base_lookup');
+    });
+
+    it('should parse knowledge base results', () => {
+      const steps = parseTrace({
+        orchestrationTrace: {
+          observation: {
+            knowledgeBaseLookupOutput: {
+              retrievedReferences: [
+                { content: { text: 'Reference 1' }, location: { uri: 's3://bucket/doc.pdf' } },
+                { content: { text: 'Reference 2' }, location: { uri: 's3://bucket/doc2.pdf' } },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('tool_result');
+      expect(steps[0].content).toContain('2 reference(s)');
+    });
+
+    it('should parse final response in observation', () => {
+      const steps = parseTrace({
+        orchestrationTrace: {
+          observation: {
+            finalResponse: { text: 'The root cause is...' },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('The root cause is...');
+    });
+
+    it('should parse post-processing trace', () => {
+      const steps = parseTrace({
+        postProcessingTrace: {
+          modelInvocationOutput: {
+            parsedResponse: { text: 'Summarizing findings' },
+          },
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('thinking');
+      expect(steps[0].content).toContain('Summarizing findings');
+    });
+
+    it('should parse failure trace', () => {
+      const steps = parseTrace({
+        failureTrace: {
+          failureReason: 'Agent throttled',
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toContain('Agent throttled');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should return true when agent is PREPARED', async () => {
+      mockAgentSend.mockResolvedValue({
+        agent: { agentStatus: 'PREPARED' },
+      });
+
+      const result = await connector.healthCheck('AGENT123', mockAuth);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when agent is not PREPARED', async () => {
+      mockAgentSend.mockResolvedValue({
+        agent: { agentStatus: 'CREATING' },
+      });
+
+      const result = await connector.healthCheck('AGENT123', mockAuth);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false on error', async () => {
+      mockAgentSend.mockRejectedValue(new Error('Access denied'));
+
+      const result = await connector.healthCheck('AGENT123', mockAuth);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('default instance', () => {
+    it('should export a default instance', () => {
+      expect(strandsConnector).toBeInstanceOf(StrandsConnector);
+    });
+  });
+});

--- a/tests/unit/services/connectors/strands/StrandsConnector.test.ts
+++ b/tests/unit/services/connectors/strands/StrandsConnector.test.ts
@@ -289,6 +289,30 @@ describe('StrandsConnector', () => {
       expect(result.runId).toBeDefined();
     });
 
+    it('should not produce duplicate response steps when trace emits finalResponse and chunks are present', async () => {
+      mockSend.mockResolvedValue(createStreamingResponse([
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                observation: {
+                  finalResponse: { text: 'Final from trace' },
+                },
+              },
+            },
+          },
+        },
+        { chunk: { bytes: new TextEncoder().encode('Final from chunks') } },
+      ]));
+
+      const request: ConnectorRequest = { testCase: mockTestCase };
+      const result = await connector.execute('AGENT123', request, mockAuth);
+
+      const responseSteps = result.trajectory.filter(s => s.type === 'response');
+      expect(responseSteps).toHaveLength(1);
+      expect(responseSteps[0].content).toBe('Final from trace');
+    });
+
     it('should default region to us-east-1 when not specified', async () => {
       mockSend.mockResolvedValue(createStreamingResponse([]));
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,7 +15,7 @@ export type DateFormatVariant = 'date' | 'datetime' | 'detailed';
 export type JudgeProvider = 'demo' | 'bedrock' | 'openai-compatible';
 
 // Connector protocol for agent communication
-export type ConnectorProtocol = 'agui-streaming' | 'rest' | 'openai-compatible' | 'subprocess' | 'claude-code' | 'mock';
+export type ConnectorProtocol = 'agui-streaming' | 'rest' | 'openai-compatible' | 'subprocess' | 'claude-code' | 'strands' | 'langgraph' | 'mock';
 
 export interface ModelConfig {
   model_id: string;


### PR DESCRIPTION
## Summary
- Add **Amazon Strands** connector (server-only) using Bedrock Agent Runtime API with streaming trace parsing for pre-processing, orchestration, and post-processing events
- Add **LangGraph REST** connector (browser-safe) for non-AG-UI LangGraph agents via direct REST API with support for thread-based and assistant-based invocation patterns
- Fix pre-existing `app.test.ts` worker crash (missing mocks for telemetry and observability config imports)

## Details
Both connectors extend `BaseConnector`, are registered in the connector registry, and include:
- Type system updates (`ConnectorProtocol` union in both `types/index.ts` and `services/connectors/types.ts`)
- `CONNECTOR_TYPE_INFO` entries and default agent configs in `lib/constants.ts`
- AWS SDK dependencies (`@aws-sdk/client-bedrock-agent-runtime`, `@aws-sdk/client-bedrock-agent`)
- `.env.example` documentation
- 63 new unit tests (56 connector + 7 app.test.ts now passing)

## Test plan
- [x] `npm run build:all` passes
- [x] All 144 unit test suites pass (3147 tests)
- [x] All 19 integration test suites pass (176 tests)
- [x] `app.test.ts` worker crash fixed
- [ ] Manual: Configure a Strands agent, run `npx agent-health doctor` to verify health check
- [ ] Manual: Configure a LangGraph REST endpoint, test via Quick Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)