### PR TITLE
feat: add CLI import command for HolmesGPT test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Pre-existing test failures: add missing `fast-check` dev dependency and fix incomplete mocks in `app.test.ts` ([#153](https://github.com/opensearch-project/agent-health/pull/153))
 
 ### Added
+- CLI `import` command for importing test cases from external evaluation frameworks (HolmesGPT)
+- HolmesGPT YAML-to-Agent Health converter with GitHub and local source support
 - Dashboard homepage gradient background, stats summary bar, and chart area gradient fills ([#153](https://github.com/opensearch-project/agent-health/pull/153))
 - Auto-increment server port on EADDRINUSE — if port 4001 is in use, tries 4002, 4003, etc. up to 10 attempts
 - GitHub Actions workflow for AI-powered PR code diff analysis and review via AWS Bedrock

--- a/cli/commands/import.ts
+++ b/cli/commands/import.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Import Command
+ * Imports test cases from external evaluation frameworks (e.g., HolmesGPT).
+ *
+ * Architecture: Fetches from GitHub or local path, converts to Agent Health format,
+ * outputs JSON compatible with `benchmark -f`.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { writeFileSync } from 'fs';
+import { convertAllFromLocal, convertAllFromGitHub } from '@/cli/converters/index.js';
+
+const SUPPORTED_FORMATS = ['holmesgpt'] as const;
+type SupportedFormat = (typeof SUPPORTED_FORMATS)[number];
+
+/**
+ * Create the import command
+ */
+export function createImportCommand(): Command {
+  const command = new Command('import')
+    .description('Import test cases from external evaluation frameworks')
+    .requiredOption('--from <format>', `Source format (${SUPPORTED_FORMATS.join(', ')})`)
+    .option('--source <path>', 'Local path to fixtures directory (fetches from GitHub if omitted)')
+    .option('-o, --output <file>', 'Output JSON file path', 'holmesgpt-test-cases.json')
+    .option('--dry-run', 'Show conversion summary without writing files')
+    .option('--repo <owner/name>', 'GitHub repository (default: robusta-dev/holmesgpt)')
+    .option('--branch <name>', 'GitHub branch (default: master)')
+    .action(async (options: {
+      from: string;
+      source?: string;
+      output: string;
+      dryRun?: boolean;
+      repo?: string;
+      branch?: string;
+    }) => {
+      const format = options.from.toLowerCase();
+
+      if (!SUPPORTED_FORMATS.includes(format as SupportedFormat)) {
+        console.error(chalk.red(`\n  Error: Unsupported format '${format}'`));
+        console.log(chalk.gray(`  Supported formats: ${SUPPORTED_FORMATS.join(', ')}\n`));
+        process.exit(1);
+      }
+
+      console.log(chalk.cyan.bold('\n  Agent Health - Import Test Cases\n'));
+
+      if (format === 'holmesgpt') {
+        await importHolmesGPT(options);
+      }
+    });
+
+  return command;
+}
+
+async function importHolmesGPT(options: {
+  source?: string;
+  output: string;
+  dryRun?: boolean;
+  repo?: string;
+  branch?: string;
+}): Promise<void> {
+  const spinner = ora();
+
+  try {
+    if (options.source) {
+      // Local import
+      spinner.start(`Reading test cases from ${options.source}...`);
+      const result = convertAllFromLocal(options.source);
+      spinner.succeed(`Found ${result.testCases.length} test case(s)`);
+      outputResults(result.testCases, result.skipped, result.errors, options);
+    } else {
+      // GitHub import
+      const repo = options.repo || 'robusta-dev/holmesgpt';
+      const branch = options.branch || 'master';
+      spinner.start(`Fetching test cases from GitHub (${repo}@${branch})...`);
+
+      const result = await convertAllFromGitHub(repo, branch, (current, total) => {
+        spinner.text = `Fetching test cases from GitHub (${current}/${total})...`;
+      });
+      spinner.succeed(`Fetched and converted ${result.testCases.length} test case(s)`);
+      outputResults(result.testCases, result.skipped, result.errors, options);
+    }
+  } catch (error: any) {
+    spinner.fail('Import failed');
+    console.error(chalk.red(`\n  Error: ${error.message}\n`));
+    process.exit(1);
+  }
+}
+
+function outputResults(
+  testCases: import('@/lib/testCaseValidation').ValidatedTestCaseInput[],
+  skipped: Array<{ path: string; reason: string }>,
+  errors: Array<{ path: string; error: string }>,
+  options: { output: string; dryRun?: boolean }
+): void {
+  // Print summary
+  console.log(chalk.gray(`  Converted: ${testCases.length}`));
+  if (skipped.length > 0) {
+    console.log(chalk.gray(`  Skipped:   ${skipped.length}`));
+  }
+  if (errors.length > 0) {
+    console.log(chalk.red(`  Errors:    ${errors.length}`));
+    for (const err of errors) {
+      console.log(chalk.red(`    - ${err.path}: ${err.error}`));
+    }
+  }
+
+  if (options.dryRun) {
+    console.log(chalk.gray('\n  Dry run — no files written.\n'));
+
+    // Show a sample test case
+    if (testCases.length > 0) {
+      console.log(chalk.cyan('  Sample test case:'));
+      console.log(chalk.gray(`  ${JSON.stringify(testCases[0], null, 2).split('\n').join('\n  ')}\n`));
+    }
+    return;
+  }
+
+  // Write output file
+  writeFileSync(options.output, JSON.stringify(testCases, null, 2) + '\n', 'utf-8');
+  console.log(chalk.green(`\n  Output: ${chalk.bold(options.output)}`));
+  console.log(
+    chalk.gray(
+      `\n  Next step: run a benchmark with these test cases:\n` +
+        `    ${chalk.cyan(`agent-health benchmark -f ${options.output} -a holmesgpt -n "HolmesGPT Evaluations"`)}\n`
+    )
+  );
+}

--- a/cli/commands/index.ts
+++ b/cli/commands/index.ts
@@ -18,3 +18,4 @@ export { createInitCommand } from './init.js';
 export { createMigrateCommand } from './migrate.js';
 export { createCompareServicesCommand } from './compare-services.js';
 export { createRemoteCommand } from './remote.js';
+export { createImportCommand } from './import.js';

--- a/cli/converters/holmesgpt.ts
+++ b/cli/converters/holmesgpt.ts
@@ -1,0 +1,375 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * HolmesGPT YAML → Agent Health JSON converter.
+ * Fetches test cases from GitHub and converts them to Agent Health format.
+ */
+
+import { parse as parseYaml } from 'yaml';
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { join, relative, basename, dirname } from 'path';
+import { testCaseSchema, type ValidatedTestCaseInput } from '@/lib/testCaseValidation.js';
+import type { HolmesGPTTestCase, ConversionResult } from './types.js';
+import type { AgentContextItem } from '@/types/index.js';
+
+const DEFAULT_REPO = 'robusta-dev/holmesgpt';
+const DEFAULT_BRANCH = 'master';
+const FIXTURES_PATH = 'tests/llm/fixtures';
+
+/**
+ * Fetch the full file tree from a GitHub repo and filter for test_case.yaml files.
+ */
+export async function fetchTestCasePathsFromGitHub(
+  repo: string = DEFAULT_REPO,
+  branch: string = DEFAULT_BRANCH
+): Promise<string[]> {
+  const url = `https://api.github.com/repos/${repo}/git/trees/${branch}?recursive=1`;
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'agent-health-cli' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { tree: Array<{ path: string; type: string }> };
+  return data.tree
+    .filter(
+      (item) =>
+        item.type === 'blob' &&
+        item.path.startsWith(`${FIXTURES_PATH}/`) &&
+        item.path.endsWith('/test_case.yaml')
+    )
+    .map((item) => item.path);
+}
+
+/**
+ * Fetch a single file's content from GitHub raw.
+ */
+export async function fetchFileFromGitHub(
+  filePath: string,
+  repo: string = DEFAULT_REPO,
+  branch: string = DEFAULT_BRANCH
+): Promise<string> {
+  const url = `https://raw.githubusercontent.com/${repo}/${branch}/${filePath}`;
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'agent-health-cli' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${filePath}: ${response.status}`);
+  }
+
+  return response.text();
+}
+
+/**
+ * Discover test_case.yaml files in a local directory.
+ */
+export function discoverLocalTestCases(basePath: string): string[] {
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (entry === 'test_case.yaml') {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  // Walk test_ask_holmes and test_holmes_checks directories
+  const testDirs = ['test_ask_holmes', 'test_holmes_checks', 'compaction'];
+  for (const testDir of testDirs) {
+    const fullDir = join(basePath, testDir);
+    if (existsSync(fullDir)) {
+      walk(fullDir);
+    }
+  }
+
+  // If no subdirectories found, walk the basePath itself
+  if (results.length === 0) {
+    walk(basePath);
+  }
+
+  return results;
+}
+
+/**
+ * Parse a test_case.yaml file content.
+ */
+export function parseTestCaseYaml(content: string): HolmesGPTTestCase {
+  return parseYaml(content) as HolmesGPTTestCase;
+}
+
+/**
+ * Infer category from tags.
+ */
+export function inferCategory(tags: string[] = []): string {
+  const lower = tags.map((t) => t.toLowerCase());
+
+  if (lower.some((t) => t === 'kubernetes' || t === 'k8s')) return 'Kubernetes';
+  if (lower.some((t) => t === 'logs' || t === 'logging')) return 'Log Analysis';
+  if (lower.some((t) => t === 'prometheus' || t === 'grafana' || t === 'metrics')) return 'Metrics';
+  if (lower.some((t) => t === 'elasticsearch' || t === 'opensearch')) return 'Search';
+  if (lower.some((t) => t === 'postgres' || t === 'mysql' || t === 'mongodb' || t === 'redis' || t === 'database'))
+    return 'Database';
+  if (lower.some((t) => t === 'bash' || t === 'shell')) return 'Bash';
+  if (lower.some((t) => t === 'confluence' || t === 'wiki')) return 'Confluence';
+  if (lower.some((t) => t === 'jira')) return 'Jira';
+
+  return 'General';
+}
+
+/**
+ * Infer difficulty from tags.
+ */
+export function inferDifficulty(tags: string[] = []): 'Easy' | 'Medium' | 'Hard' {
+  const lower = tags.map((t) => t.toLowerCase());
+
+  if (lower.includes('easy')) return 'Easy';
+  if (lower.includes('hard') || lower.includes('complex')) return 'Hard';
+  return 'Medium';
+}
+
+/**
+ * Convert folder name to human-readable name.
+ * "01_how_many_pods" → "How Many Pods"
+ */
+export function humanizeFolderName(folderName: string): string {
+  // Strip numeric prefix (e.g., "01_")
+  const stripped = folderName.replace(/^\d+_/, '');
+  // Replace underscores with spaces and title case
+  return stripped
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Build a stable name for idempotent matching on re-import.
+ * "holmesgpt/test_ask_holmes/01_how_many_pods"
+ */
+export function buildStableName(parentDir: string, folderName: string): string {
+  return `holmesgpt/${parentDir}/${folderName}`;
+}
+
+/**
+ * Build context items from test case metadata.
+ */
+export function buildContextItems(tc: HolmesGPTTestCase): AgentContextItem[] {
+  const context: AgentContextItem[] = [];
+
+  if (tc.before_test) {
+    context.push({ description: 'Setup Script (before_test)', value: tc.before_test });
+  }
+
+  if (tc.after_test) {
+    context.push({ description: 'Teardown Script (after_test)', value: tc.after_test });
+  }
+
+  if (tc.toolsets && Object.keys(tc.toolsets).length > 0) {
+    context.push({ description: 'Toolsets', value: JSON.stringify(tc.toolsets, null, 2) });
+  }
+
+  if (tc.conversation_history && tc.conversation_history.length > 0) {
+    context.push({
+      description: 'Conversation History',
+      value: JSON.stringify(tc.conversation_history, null, 2),
+    });
+  }
+
+  if (tc.runbooks && tc.runbooks.length > 0) {
+    context.push({ description: 'Runbooks', value: JSON.stringify(tc.runbooks, null, 2) });
+  }
+
+  if (tc.cluster_name) {
+    context.push({ description: 'Cluster Name', value: tc.cluster_name });
+  }
+
+  if (tc.port_forwards && tc.port_forwards.length > 0) {
+    context.push({ description: 'Port Forwards', value: JSON.stringify(tc.port_forwards, null, 2) });
+  }
+
+  if (tc.test_env_vars && Object.keys(tc.test_env_vars).length > 0) {
+    context.push({ description: 'Environment Variables', value: JSON.stringify(tc.test_env_vars, null, 2) });
+  }
+
+  if (tc.mocked_date) {
+    context.push({ description: 'Mocked Date', value: tc.mocked_date });
+  }
+
+  return context;
+}
+
+/**
+ * Resolve user_prompt from a test case.
+ * Handles: string, string[], or missing (falls back to checks/description).
+ */
+export function resolvePrompt(tc: HolmesGPTTestCase): string {
+  // Direct string prompt
+  if (typeof tc.user_prompt === 'string') {
+    return tc.user_prompt;
+  }
+
+  // Array of prompt parts — join into a single string
+  if (Array.isArray(tc.user_prompt)) {
+    return tc.user_prompt.join('\n');
+  }
+
+  // No user_prompt — synthesize from checks (test_holmes_checks format)
+  if (tc.checks && tc.checks.length > 0) {
+    const checkDescriptions = tc.checks.map((c) => c.query || c.description).join('; ');
+    return `Run health checks: ${checkDescriptions}`;
+  }
+
+  // Fall back to description (compaction format)
+  if (tc.description) {
+    return tc.description;
+  }
+
+  return '';
+}
+
+/**
+ * Convert a single HolmesGPT test case to Agent Health format.
+ */
+export function convertTestCase(
+  tc: HolmesGPTTestCase,
+  folderName: string,
+  parentDir: string
+): ValidatedTestCaseInput {
+  const expectedOutcomes = Array.isArray(tc.expected_output)
+    ? [...tc.expected_output]
+    : [tc.expected_output];
+
+  // For test_holmes_checks, add check expectations
+  if (tc.checks && tc.expected_results) {
+    for (const [checkName, expectedResult] of Object.entries(tc.expected_results)) {
+      expectedOutcomes.push(`Check '${checkName}' should result in: ${expectedResult}`);
+    }
+  }
+
+  return {
+    name: buildStableName(parentDir, folderName),
+    description: tc.description || humanizeFolderName(folderName),
+    category: inferCategory(tc.tags),
+    subcategory: tc.tags?.filter((t) => !['easy', 'medium', 'hard'].includes(t.toLowerCase())).join(', '),
+    difficulty: inferDifficulty(tc.tags),
+    initialPrompt: resolvePrompt(tc),
+    context: buildContextItems(tc),
+    expectedOutcomes,
+  };
+}
+
+/**
+ * Extract parentDir and folderName from a file path.
+ * Input: "tests/llm/fixtures/test_ask_holmes/01_how_many_pods/test_case.yaml"
+ * Output: { parentDir: "test_ask_holmes", folderName: "01_how_many_pods" }
+ */
+export function extractPathParts(filePath: string): { parentDir: string; folderName: string } {
+  // The folder containing test_case.yaml
+  const folder = dirname(filePath);
+  const folderName = basename(folder);
+  const parentDir = basename(dirname(folder));
+  return { parentDir, folderName };
+}
+
+/**
+ * Convert all test cases from a local directory.
+ */
+export function convertAllFromLocal(basePath: string): ConversionResult {
+  const testCases: ValidatedTestCaseInput[] = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
+  const errors: Array<{ path: string; error: string }> = [];
+
+  const files = discoverLocalTestCases(basePath);
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(file, 'utf-8');
+      const tc = parseTestCaseYaml(content);
+
+      if (tc.skip) {
+        skipped.push({ path: file, reason: tc.skip_reason || 'Marked as skip' });
+        continue;
+      }
+
+      const relPath = relative(basePath, file);
+      const { parentDir, folderName } = extractPathParts(relPath);
+      const converted = convertTestCase(tc, folderName, parentDir);
+
+      // Validate against schema
+      const result = testCaseSchema.safeParse(converted);
+      if (result.success) {
+        testCases.push(converted);
+      } else {
+        errors.push({
+          path: file,
+          error: result.error.errors.map((e) => e.message).join('; '),
+        });
+      }
+    } catch (err: any) {
+      errors.push({ path: file, error: err.message });
+    }
+  }
+
+  return { testCases, skipped, errors };
+}
+
+/**
+ * Convert all test cases by fetching from GitHub.
+ */
+export async function convertAllFromGitHub(
+  repo: string = DEFAULT_REPO,
+  branch: string = DEFAULT_BRANCH,
+  onProgress?: (current: number, total: number) => void
+): Promise<ConversionResult> {
+  const testCases: ValidatedTestCaseInput[] = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
+  const errors: Array<{ path: string; error: string }> = [];
+
+  const paths = await fetchTestCasePathsFromGitHub(repo, branch);
+
+  for (let i = 0; i < paths.length; i++) {
+    const filePath = paths[i];
+    onProgress?.(i + 1, paths.length);
+
+    try {
+      const content = await fetchFileFromGitHub(filePath, repo, branch);
+      const tc = parseTestCaseYaml(content);
+
+      if (tc.skip) {
+        skipped.push({ path: filePath, reason: tc.skip_reason || 'Marked as skip' });
+        continue;
+      }
+
+      // Extract path relative to fixtures dir
+      const relPath = filePath.replace(`${FIXTURES_PATH}/`, '');
+      const { parentDir, folderName } = extractPathParts(relPath);
+      const converted = convertTestCase(tc, folderName, parentDir);
+
+      // Validate against schema
+      const result = testCaseSchema.safeParse(converted);
+      if (result.success) {
+        testCases.push(converted);
+      } else {
+        errors.push({
+          path: filePath,
+          error: result.error.errors.map((e) => e.message).join('; '),
+        });
+      }
+    } catch (err: any) {
+      errors.push({ path: filePath, error: err.message });
+    }
+  }
+
+  return { testCases, skipped, errors };
+}

--- a/cli/converters/index.ts
+++ b/cli/converters/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  convertAllFromLocal,
+  convertAllFromGitHub,
+  convertTestCase,
+  resolvePrompt,
+  humanizeFolderName,
+  inferCategory,
+  inferDifficulty,
+  buildStableName,
+  buildContextItems,
+  extractPathParts,
+  parseTestCaseYaml,
+  discoverLocalTestCases,
+  fetchTestCasePathsFromGitHub,
+  fetchFileFromGitHub,
+} from './holmesgpt.js';
+
+export type { HolmesGPTTestCase, ConversionResult } from './types.js';

--- a/cli/converters/types.ts
+++ b/cli/converters/types.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * TypeScript interfaces for HolmesGPT test_case.yaml format.
+ * Based on https://github.com/robusta-dev/holmesgpt/tree/master/tests/llm/fixtures
+ */
+
+export interface HolmesGPTPortForward {
+  namespace: string;
+  service: string;
+  local_port: number;
+  remote_port: number;
+}
+
+export interface HolmesGPTRunbook {
+  description: string;
+  link: string;
+}
+
+export interface HolmesGPTConversationMessage {
+  role: string;
+  content: string;
+}
+
+export interface HolmesGPTCheck {
+  name: string;
+  description: string;
+  query: string;
+  tags?: string[];
+}
+
+export interface HolmesGPTTestCase {
+  user_prompt?: string | string[];
+  description?: string;
+  expected_output: string | string[];
+  tags?: string[];
+  before_test?: string;
+  after_test?: string;
+  skip?: boolean;
+  skip_reason?: string;
+  mocked_date?: string;
+  cluster_name?: string;
+  toolsets?: Record<string, unknown>;
+  port_forwards?: HolmesGPTPortForward[];
+  test_env_vars?: Record<string, string>;
+  conversation_history?: HolmesGPTConversationMessage[];
+  include_files?: string[];
+  runbooks?: HolmesGPTRunbook[];
+  checks?: HolmesGPTCheck[];
+  expected_results?: Record<string, string>;
+}
+
+export interface ConversionResult {
+  testCases: import('@/lib/testCaseValidation').ValidatedTestCaseInput[];
+  skipped: Array<{ path: string; reason: string }>;
+  errors: Array<{ path: string; error: string }>;
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -29,6 +29,7 @@ import {
   createMigrateCommand,
   createCompareServicesCommand,
   createRemoteCommand,
+  createImportCommand,
 } from './commands/index.js';
 
 // Get package.json for version
@@ -142,6 +143,10 @@ ${chalk.cyan.bold('Remote Servers:')}
   ${chalk.yellow('agent-health remote list')}             List configured remote servers
   ${chalk.yellow('agent-health remote test')}             Test connectivity to all remotes
 
+${chalk.cyan.bold('Importing:')}
+  ${chalk.yellow('agent-health import')} ${chalk.gray('--from holmesgpt')}     Import HolmesGPT test cases from GitHub
+  ${chalk.yellow('agent-health import')} ${chalk.gray('--from holmesgpt --source <path>')}  Import from local fixtures
+
 ${chalk.cyan.bold('Maintenance:')}
   ${chalk.yellow('agent-health migrate')}                Migrate legacy benchmark data to current format
   ${chalk.yellow('agent-health serve')}                  Start the server (same as default, explicit command)
@@ -230,6 +235,7 @@ program.addCommand(createInitCommand());
 program.addCommand(createMigrateCommand());
 program.addCommand(createCompareServicesCommand());
 program.addCommand(createRemoteCommand());
+program.addCommand(createImportCommand());
 
 // Add serve command as an alias for the default action
 program

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
     // Mock data files to avoid JSON import issues in tests
     '^@/data/testCases$': '<rootDir>/__mocks__/@/data/testCases.ts',
     '^@/data/mockComparisonData$': '<rootDir>/__mocks__/@/data/mockComparisonData.ts',
+    '^@/(.*)\\.js$': '<rootDir>/$1',
     '^@/(.*)$': '<rootDir>/$1',
     // Mock browser-only modules
     '^dagre$': '<rootDir>/__mocks__/dagre.ts',

--- a/tests/unit/cli/commands/import.test.ts
+++ b/tests/unit/cli/commands/import.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the import CLI command.
+ */
+
+jest.mock('chalk', () => ({
+  default: {
+    cyan: Object.assign((s: string) => s, { bold: (s: string) => s }),
+    green: Object.assign((s: string) => s, { bold: (s: string) => s }),
+    red: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+  },
+  cyan: Object.assign((s: string) => s, { bold: (s: string) => s }),
+  green: Object.assign((s: string) => s, { bold: (s: string) => s }),
+  red: (s: string) => s,
+  gray: (s: string) => s,
+  bold: (s: string) => s,
+}));
+
+jest.mock('ora', () => {
+  return jest.fn(() => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+    stop: jest.fn().mockReturnThis(),
+    text: '',
+  }));
+});
+
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+}));
+
+jest.mock('@/cli/converters/index', () => ({
+  convertAllFromLocal: jest.fn(),
+  convertAllFromGitHub: jest.fn(),
+}));
+
+import { createImportCommand } from '@/cli/commands/import';
+import { convertAllFromLocal, convertAllFromGitHub } from '@/cli/converters/index';
+import { writeFileSync } from 'fs';
+
+const mockConvertLocal = convertAllFromLocal as jest.MockedFunction<typeof convertAllFromLocal>;
+const mockConvertGitHub = convertAllFromGitHub as jest.MockedFunction<typeof convertAllFromGitHub>;
+const mockWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
+
+describe('createImportCommand', () => {
+  const originalExit = process.exit;
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.exit = jest.fn() as any;
+    console.log = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  it('creates a command named "import"', () => {
+    const cmd = createImportCommand();
+    expect(cmd.name()).toBe('import');
+  });
+
+  it('has required --from option', () => {
+    const cmd = createImportCommand();
+    const fromOpt = cmd.options.find((o) => o.long === '--from');
+    expect(fromOpt).toBeDefined();
+    expect(fromOpt!.required).toBe(true);
+  });
+
+  it('has optional --source, --output, --dry-run options', () => {
+    const cmd = createImportCommand();
+    const optionNames = cmd.options.map((o) => o.long);
+    expect(optionNames).toContain('--source');
+    expect(optionNames).toContain('--output');
+    expect(optionNames).toContain('--dry-run');
+  });
+
+  it('rejects unsupported format', async () => {
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'unknown']);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Unsupported format'));
+  });
+
+  it('uses local converter when --source is provided', async () => {
+    mockConvertLocal.mockReturnValue({
+      testCases: [
+        {
+          name: 'holmesgpt/test_ask_holmes/01_pods',
+          description: 'Pods',
+          category: 'Kubernetes',
+          difficulty: 'Medium',
+          initialPrompt: 'How many pods?',
+          expectedOutcomes: ['3 pods'],
+          context: [],
+        },
+      ],
+      skipped: [],
+      errors: [],
+    });
+
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'holmesgpt', '--source', '/some/path']);
+
+    expect(mockConvertLocal).toHaveBeenCalledWith('/some/path');
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it('uses GitHub converter when --source is omitted', async () => {
+    mockConvertGitHub.mockResolvedValue({
+      testCases: [
+        {
+          name: 'holmesgpt/test_ask_holmes/01_pods',
+          description: 'Pods',
+          category: 'Kubernetes',
+          difficulty: 'Medium',
+          initialPrompt: 'How many pods?',
+          expectedOutcomes: ['3 pods'],
+          context: [],
+        },
+      ],
+      skipped: [],
+      errors: [],
+    });
+
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'holmesgpt']);
+
+    expect(mockConvertGitHub).toHaveBeenCalledWith('robusta-dev/holmesgpt', 'master', expect.any(Function));
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it('does not write files in dry-run mode', async () => {
+    mockConvertLocal.mockReturnValue({
+      testCases: [
+        {
+          name: 'holmesgpt/test_ask_holmes/01_pods',
+          description: 'Pods',
+          category: 'Kubernetes',
+          difficulty: 'Medium',
+          initialPrompt: 'How many pods?',
+          expectedOutcomes: ['3 pods'],
+          context: [],
+        },
+      ],
+      skipped: [],
+      errors: [],
+    });
+
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'holmesgpt', '--source', '/path', '--dry-run']);
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('defaults output to holmesgpt-test-cases.json', async () => {
+    mockConvertLocal.mockReturnValue({
+      testCases: [
+        {
+          name: 'test',
+          description: 'Test',
+          category: 'General',
+          difficulty: 'Medium',
+          initialPrompt: 'test',
+          expectedOutcomes: ['result'],
+          context: [],
+        },
+      ],
+      skipped: [],
+      errors: [],
+    });
+
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'holmesgpt', '--source', '/path']);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'holmesgpt-test-cases.json',
+      expect.any(String),
+      'utf-8'
+    );
+  });
+
+  it('respects custom --output path', async () => {
+    mockConvertLocal.mockReturnValue({
+      testCases: [
+        {
+          name: 'test',
+          description: 'Test',
+          category: 'General',
+          difficulty: 'Medium',
+          initialPrompt: 'test',
+          expectedOutcomes: ['result'],
+          context: [],
+        },
+      ],
+      skipped: [],
+      errors: [],
+    });
+
+    const cmd = createImportCommand();
+    await cmd.parseAsync(['node', 'test', '--from', 'holmesgpt', '--source', '/path', '-o', 'custom.json']);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      'custom.json',
+      expect.any(String),
+      'utf-8'
+    );
+  });
+});

--- a/tests/unit/cli/converters/holmesgpt.test.ts
+++ b/tests/unit/cli/converters/holmesgpt.test.ts
@@ -1,0 +1,566 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  humanizeFolderName,
+  inferCategory,
+  inferDifficulty,
+  buildStableName,
+  buildContextItems,
+  convertTestCase,
+  resolvePrompt,
+  extractPathParts,
+  parseTestCaseYaml,
+  discoverLocalTestCases,
+  convertAllFromLocal,
+} from '@/cli/converters/holmesgpt';
+import { testCaseSchema } from '@/lib/testCaseValidation';
+import type { HolmesGPTTestCase } from '@/cli/converters/types';
+
+// Mock fs for discoverLocalTestCases and convertAllFromLocal
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    readdirSync: jest.fn(),
+    readFileSync: jest.fn(),
+    statSync: jest.fn(),
+    existsSync: jest.fn(),
+  };
+});
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+
+const mockReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const mockStatSync = statSync as jest.MockedFunction<typeof statSync>;
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+
+describe('holmesgpt converter', () => {
+  describe('humanizeFolderName', () => {
+    it('strips numeric prefix and title-cases', () => {
+      expect(humanizeFolderName('01_how_many_pods')).toBe('How Many Pods');
+    });
+
+    it('handles no numeric prefix', () => {
+      expect(humanizeFolderName('check_pod_status')).toBe('Check Pod Status');
+    });
+
+    it('handles single word', () => {
+      expect(humanizeFolderName('03_restart')).toBe('Restart');
+    });
+
+    it('handles multi-digit prefix', () => {
+      expect(humanizeFolderName('123_long_test_name')).toBe('Long Test Name');
+    });
+  });
+
+  describe('inferCategory', () => {
+    it('returns Kubernetes for k8s tags', () => {
+      expect(inferCategory(['kubernetes', 'pods'])).toBe('Kubernetes');
+      expect(inferCategory(['k8s'])).toBe('Kubernetes');
+    });
+
+    it('returns Log Analysis for logs tag', () => {
+      expect(inferCategory(['logs'])).toBe('Log Analysis');
+    });
+
+    it('returns Metrics for prometheus/grafana', () => {
+      expect(inferCategory(['prometheus'])).toBe('Metrics');
+      expect(inferCategory(['grafana'])).toBe('Metrics');
+      expect(inferCategory(['metrics'])).toBe('Metrics');
+    });
+
+    it('returns Search for elasticsearch/opensearch', () => {
+      expect(inferCategory(['elasticsearch'])).toBe('Search');
+      expect(inferCategory(['opensearch'])).toBe('Search');
+    });
+
+    it('returns Database for DB tags', () => {
+      expect(inferCategory(['postgres'])).toBe('Database');
+      expect(inferCategory(['mysql'])).toBe('Database');
+      expect(inferCategory(['mongodb'])).toBe('Database');
+      expect(inferCategory(['redis'])).toBe('Database');
+    });
+
+    it('returns Bash for bash tag', () => {
+      expect(inferCategory(['bash'])).toBe('Bash');
+    });
+
+    it('returns Confluence for confluence tag', () => {
+      expect(inferCategory(['confluence'])).toBe('Confluence');
+    });
+
+    it('returns Jira for jira tag', () => {
+      expect(inferCategory(['jira'])).toBe('Jira');
+    });
+
+    it('returns General for unknown tags', () => {
+      expect(inferCategory(['custom', 'unknown'])).toBe('General');
+    });
+
+    it('returns General for empty tags', () => {
+      expect(inferCategory([])).toBe('General');
+      expect(inferCategory()).toBe('General');
+    });
+
+    it('is case-insensitive', () => {
+      expect(inferCategory(['KUBERNETES'])).toBe('Kubernetes');
+      expect(inferCategory(['Logs'])).toBe('Log Analysis');
+    });
+  });
+
+  describe('inferDifficulty', () => {
+    it('returns Easy when tagged', () => {
+      expect(inferDifficulty(['kubernetes', 'easy'])).toBe('Easy');
+    });
+
+    it('returns Hard when tagged', () => {
+      expect(inferDifficulty(['hard'])).toBe('Hard');
+      expect(inferDifficulty(['complex'])).toBe('Hard');
+    });
+
+    it('returns Medium by default', () => {
+      expect(inferDifficulty(['kubernetes'])).toBe('Medium');
+      expect(inferDifficulty([])).toBe('Medium');
+      expect(inferDifficulty()).toBe('Medium');
+    });
+
+    it('is case-insensitive', () => {
+      expect(inferDifficulty(['EASY'])).toBe('Easy');
+      expect(inferDifficulty(['Hard'])).toBe('Hard');
+    });
+  });
+
+  describe('buildStableName', () => {
+    it('builds expected format', () => {
+      expect(buildStableName('test_ask_holmes', '01_how_many_pods')).toBe(
+        'holmesgpt/test_ask_holmes/01_how_many_pods'
+      );
+    });
+  });
+
+  describe('extractPathParts', () => {
+    it('extracts parentDir and folderName from nested path', () => {
+      const result = extractPathParts('test_ask_holmes/01_how_many_pods/test_case.yaml');
+      expect(result).toEqual({ parentDir: 'test_ask_holmes', folderName: '01_how_many_pods' });
+    });
+
+    it('extracts from deeper path', () => {
+      const result = extractPathParts('tests/llm/fixtures/test_holmes_checks/02_check/test_case.yaml');
+      expect(result).toEqual({ parentDir: 'test_holmes_checks', folderName: '02_check' });
+    });
+  });
+
+  describe('buildContextItems', () => {
+    it('returns empty array for minimal test case', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+      };
+      expect(buildContextItems(tc)).toEqual([]);
+    });
+
+    it('includes before_test script', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        before_test: 'kubectl apply -f setup.yaml',
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Setup Script (before_test)');
+      expect(items[0].value).toBe('kubectl apply -f setup.yaml');
+    });
+
+    it('includes after_test script', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        after_test: 'kubectl delete -f setup.yaml',
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Teardown Script (after_test)');
+    });
+
+    it('includes toolsets as JSON', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        toolsets: { kubernetes: { enabled: true } },
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Toolsets');
+      expect(JSON.parse(items[0].value)).toEqual({ kubernetes: { enabled: true } });
+    });
+
+    it('includes conversation_history', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        conversation_history: [{ role: 'user', content: 'previous question' }],
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Conversation History');
+    });
+
+    it('includes runbooks', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        runbooks: [{ description: 'Restart guide', link: 'https://example.com' }],
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Runbooks');
+    });
+
+    it('includes cluster_name', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        cluster_name: 'prod-cluster',
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(1);
+      expect(items[0].description).toBe('Cluster Name');
+      expect(items[0].value).toBe('prod-cluster');
+    });
+
+    it('includes all fields in order', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        before_test: 'setup',
+        after_test: 'teardown',
+        toolsets: { k8s: {} },
+        conversation_history: [{ role: 'user', content: 'hi' }],
+        runbooks: [{ description: 'doc', link: 'url' }],
+        cluster_name: 'test-cluster',
+        port_forwards: [{ namespace: 'default', service: 'svc', local_port: 8080, remote_port: 80 }],
+        test_env_vars: { FOO: 'bar' },
+        mocked_date: '2024-01-01',
+      };
+      const items = buildContextItems(tc);
+      expect(items).toHaveLength(9);
+      expect(items.map((i) => i.description)).toEqual([
+        'Setup Script (before_test)',
+        'Teardown Script (after_test)',
+        'Toolsets',
+        'Conversation History',
+        'Runbooks',
+        'Cluster Name',
+        'Port Forwards',
+        'Environment Variables',
+        'Mocked Date',
+      ]);
+    });
+  });
+
+  describe('parseTestCaseYaml', () => {
+    it('parses valid YAML', () => {
+      const yaml = `
+user_prompt: "How many pods are running?"
+expected_output:
+  - "3 pods are running"
+tags:
+  - kubernetes
+  - easy
+`;
+      const result = parseTestCaseYaml(yaml);
+      expect(result.user_prompt).toBe('How many pods are running?');
+      expect(result.expected_output).toEqual(['3 pods are running']);
+      expect(result.tags).toEqual(['kubernetes', 'easy']);
+    });
+
+    it('parses YAML with optional fields', () => {
+      const yaml = `
+user_prompt: "Check status"
+expected_output:
+  - "Status OK"
+skip: true
+skip_reason: "Requires external service"
+before_test: "kubectl apply -f test.yaml"
+after_test: "kubectl delete -f test.yaml"
+`;
+      const result = parseTestCaseYaml(yaml);
+      expect(result.skip).toBe(true);
+      expect(result.skip_reason).toBe('Requires external service');
+      expect(result.before_test).toBe('kubectl apply -f test.yaml');
+      expect(result.after_test).toBe('kubectl delete -f test.yaml');
+    });
+  });
+
+  describe('resolvePrompt', () => {
+    it('returns string prompt directly', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'How many pods?',
+        expected_output: ['3'],
+      };
+      expect(resolvePrompt(tc)).toBe('How many pods?');
+    });
+
+    it('joins array prompt with newlines', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: ['Check the service.', 'Look for latency issues.'],
+        expected_output: ['result'],
+      };
+      expect(resolvePrompt(tc)).toBe('Check the service.\nLook for latency issues.');
+    });
+
+    it('synthesizes prompt from checks when no user_prompt', () => {
+      const tc: HolmesGPTTestCase = {
+        expected_output: ['All checks passed'],
+        checks: [
+          { name: 'PodCheck', description: 'Check pods', query: 'Are pods running?' },
+          { name: 'SvcCheck', description: 'Check services', query: 'Are services up?' },
+        ],
+      };
+      expect(resolvePrompt(tc)).toBe('Run health checks: Are pods running?; Are services up?');
+    });
+
+    it('uses check description when query is missing', () => {
+      const tc: HolmesGPTTestCase = {
+        expected_output: ['result'],
+        checks: [{ name: 'Test', description: 'Check something', query: '' }],
+      };
+      expect(resolvePrompt(tc)).toBe('Run health checks: Check something');
+    });
+
+    it('falls back to description for compaction-style tests', () => {
+      const tc: HolmesGPTTestCase = {
+        expected_output: ['compacted'],
+        description: 'Verify compaction of a multi-turn conversation',
+      };
+      expect(resolvePrompt(tc)).toBe('Verify compaction of a multi-turn conversation');
+    });
+
+    it('returns empty string when nothing available', () => {
+      const tc: HolmesGPTTestCase = {
+        expected_output: ['result'],
+      };
+      expect(resolvePrompt(tc)).toBe('');
+    });
+  });
+
+  describe('convertTestCase', () => {
+    it('converts a basic test case', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'How many pods are running in the default namespace?',
+        expected_output: ['3 pods are running', 'All pods healthy'],
+        tags: ['kubernetes', 'easy'],
+      };
+
+      const result = convertTestCase(tc, '01_how_many_pods', 'test_ask_holmes');
+
+      expect(result.name).toBe('holmesgpt/test_ask_holmes/01_how_many_pods');
+      expect(result.description).toBe('How Many Pods');
+      expect(result.category).toBe('Kubernetes');
+      expect(result.difficulty).toBe('Easy');
+      expect(result.initialPrompt).toBe('How many pods are running in the default namespace?');
+      expect(result.expectedOutcomes).toEqual(['3 pods are running', 'All pods healthy']);
+    });
+
+    it('adds check expectations for test_holmes_checks', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'Run health checks',
+        expected_output: ['All checks passed'],
+        tags: ['kubernetes'],
+        checks: [{ name: 'PodRunning', description: 'Check pods', query: 'pods running?' }],
+        expected_results: { PodRunning: 'pass' },
+      };
+
+      const result = convertTestCase(tc, '01_health_check', 'test_holmes_checks');
+      expect(result.expectedOutcomes).toContain("Check 'PodRunning' should result in: pass");
+      expect(result.expectedOutcomes).toHaveLength(2);
+    });
+
+    it('uses tc.description when present', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        description: 'Verify compaction of conversation',
+      };
+
+      const result = convertTestCase(tc, '01_compaction', 'compaction');
+      expect(result.description).toBe('Verify compaction of conversation');
+    });
+
+    it('handles array user_prompt', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: ['Investigate latency.', 'Check traces.'],
+        expected_output: ['found issue'],
+        tags: ['kubernetes'],
+      };
+
+      const result = convertTestCase(tc, '114_checkout_latency', 'test_ask_holmes');
+      expect(result.initialPrompt).toBe('Investigate latency.\nCheck traces.');
+    });
+
+    it('handles test case with no user_prompt (checks format)', () => {
+      const tc: HolmesGPTTestCase = {
+        expected_output: ['Check passed'],
+        tags: ['kubernetes'],
+        checks: [{ name: 'PodCheck', description: 'Check pods', query: 'Are pods running?' }],
+        expected_results: { PodCheck: 'pass' },
+      };
+
+      const result = convertTestCase(tc, '01_basic_pod_health', 'test_holmes_checks');
+      expect(result.initialPrompt).toBe('Run health checks: Are pods running?');
+      expect(result.expectedOutcomes).toContain("Check 'PodCheck' should result in: pass");
+    });
+
+    it('filters difficulty tags from subcategory', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'test',
+        expected_output: ['result'],
+        tags: ['kubernetes', 'easy', 'pods'],
+      };
+
+      const result = convertTestCase(tc, '01_test', 'test_ask_holmes');
+      expect(result.subcategory).toBe('kubernetes, pods');
+    });
+
+    it('validates against testCaseSchema', () => {
+      const tc: HolmesGPTTestCase = {
+        user_prompt: 'How many pods?',
+        expected_output: ['3 pods'],
+        tags: ['kubernetes'],
+      };
+
+      const result = convertTestCase(tc, '01_pods', 'test_ask_holmes');
+      const validation = testCaseSchema.safeParse(result);
+      expect(validation.success).toBe(true);
+    });
+  });
+
+  describe('discoverLocalTestCases', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('discovers test_case.yaml files in test directories', () => {
+      mockExistsSync.mockImplementation((path: any) => {
+        return path === '/fixtures/test_ask_holmes' || path === '/fixtures/test_holmes_checks';
+      });
+
+      // test_ask_holmes directory structure
+      mockReaddirSync.mockImplementation((dir: any) => {
+        if (dir === '/fixtures/test_ask_holmes') return ['01_pods', '02_logs'] as any;
+        if (dir === '/fixtures/test_ask_holmes/01_pods') return ['test_case.yaml'] as any;
+        if (dir === '/fixtures/test_ask_holmes/02_logs') return ['test_case.yaml'] as any;
+        if (dir === '/fixtures/test_holmes_checks') return ['01_check'] as any;
+        if (dir === '/fixtures/test_holmes_checks/01_check') return ['test_case.yaml'] as any;
+        return [] as any;
+      });
+
+      mockStatSync.mockImplementation((path: any) => {
+        const p = path as string;
+        const isDir =
+          p.endsWith('01_pods') ||
+          p.endsWith('02_logs') ||
+          p.endsWith('01_check');
+        return { isDirectory: () => isDir } as any;
+      });
+
+      const results = discoverLocalTestCases('/fixtures');
+      expect(results).toHaveLength(3);
+      expect(results).toContain('/fixtures/test_ask_holmes/01_pods/test_case.yaml');
+      expect(results).toContain('/fixtures/test_ask_holmes/02_logs/test_case.yaml');
+      expect(results).toContain('/fixtures/test_holmes_checks/01_check/test_case.yaml');
+    });
+  });
+
+  describe('convertAllFromLocal', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('converts test cases and reports skipped/errors', () => {
+      mockExistsSync.mockImplementation((path: any) => {
+        return path === '/fixtures/test_ask_holmes';
+      });
+
+      mockReaddirSync.mockImplementation((dir: any) => {
+        if (dir === '/fixtures/test_ask_holmes') return ['01_pods', '02_skipped'] as any;
+        if (dir === '/fixtures/test_ask_holmes/01_pods') return ['test_case.yaml'] as any;
+        if (dir === '/fixtures/test_ask_holmes/02_skipped') return ['test_case.yaml'] as any;
+        return [] as any;
+      });
+
+      mockStatSync.mockImplementation((path: any) => {
+        const p = path as string;
+        const isDir = p.endsWith('01_pods') || p.endsWith('02_skipped');
+        return { isDirectory: () => isDir } as any;
+      });
+
+      mockReadFileSync.mockImplementation((path: any) => {
+        const p = path as string;
+        if (p.includes('01_pods')) {
+          return `
+user_prompt: "How many pods?"
+expected_output:
+  - "3 pods"
+tags:
+  - kubernetes
+`;
+        }
+        if (p.includes('02_skipped')) {
+          return `
+user_prompt: "Skipped test"
+expected_output:
+  - "result"
+skip: true
+skip_reason: "Not supported"
+`;
+        }
+        return '';
+      });
+
+      const result = convertAllFromLocal('/fixtures');
+      expect(result.testCases).toHaveLength(1);
+      expect(result.testCases[0].name).toBe('holmesgpt/test_ask_holmes/01_pods');
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('Not supported');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('reports errors for invalid YAML', () => {
+      mockExistsSync.mockImplementation((path: any) => {
+        return path === '/fixtures/test_ask_holmes';
+      });
+
+      mockReaddirSync.mockImplementation((dir: any) => {
+        if (dir === '/fixtures/test_ask_holmes') return ['01_bad'] as any;
+        if (dir === '/fixtures/test_ask_holmes/01_bad') return ['test_case.yaml'] as any;
+        return [] as any;
+      });
+
+      mockStatSync.mockImplementation(() => {
+        return { isDirectory: () => false } as any;
+      });
+
+      // Make the first call (for directory) return isDirectory true, rest false
+      mockStatSync.mockImplementation((path: any) => {
+        const p = path as string;
+        return { isDirectory: () => p.endsWith('01_bad') } as any;
+      });
+
+      mockReadFileSync.mockImplementation(() => {
+        return `
+user_prompt: ""
+expected_output: []
+`;
+      });
+
+      const result = convertAllFromLocal('/fixtures');
+      expect(result.testCases).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `agent-health import --from holmesgpt` CLI command that fetches 230+ evaluation test cases from the HolmesGPT GitHub repo and converts them to Agent Health JSON format
- Supports GitHub fetch (default), local path (`--source`), dry-run preview (`--dry-run`), and custom output path (`-o`)
- Handles all HolmesGPT test variants: standard prompts, array prompts, checks-based tests, and compaction tests
- Adds Jest `@/` path alias fix for ESM `.js` extension resolution

## Design
- **Extensible**: `--from <format>` flag allows adding more converters (e.g., SWE-bench, GAIA) — each converter is format-specific
- **Idempotent**: Stable names (`holmesgpt/test_ask_holmes/01_how_many_pods`) enable re-import without duplication via `benchmark -f`
- **Phase 1 only**: Imports + converts test cases. Phase 2 (future) will add `before_test`/`after_test` script execution

## Test plan
- [x] 57 unit tests pass (converter + command)
- [x] End-to-end dry-run: 232 test cases converted, 16 skipped, 0 errors
- [x] Full JSON output verified with category breakdown (84 Kubernetes, 75 General, 32 Log Analysis, etc.)
- [x] `npm run build:all` passes
- [ ] CI unit tests pass

## Usage
```bash
# Preview
agent-health import --from holmesgpt --dry-run

# Import from GitHub
agent-health import --from holmesgpt -o holmesgpt-evals.json

# Import from local fixtures
agent-health import --from holmesgpt --source ./tests/llm/fixtures

# Run benchmark
agent-health benchmark -f holmesgpt-evals.json -a holmesgpt -n "HolmesGPT Evaluations"
```