### PR TITLE
feat: session metadata API, OTel instrumentation skill, and CFN resource tags

### DIFF
--- a/.claude/skills/config-auth/SKILL.md
+++ b/.claude/skills/config-auth/SKILL.md
@@ -51,10 +51,17 @@ Agent Health uses **two separate config systems** for different purposes. Unders
     "authType": "sigv4",
     "awsProfile": "default",
     "awsRegion": "us-west-2",
-    "awsService": "es"
+    "awsService": "es",
+    "tracesIndex": "otel-v1-apm-span-*"
   }
 }
 ```
+
+**Observability config** is where Agent Health reads OTel traces from. This is configured by:
+1. `npx @opensearch-project/agent-health setup-telemetry` (writes to JSON automatically)
+2. Manual edit of `agent-health.config.json` (add `observability` block with endpoint + auth)
+
+The `tracesIndex` field defaults to `otel-v1-apm-span-*` if omitted. See `/instrument-otel` skill for the full instrumentation flow.
 
 **Auth types** (`server/services/opensearchClientFactory.ts`):
 

--- a/.claude/skills/instrument-otel/SKILL.md
+++ b/.claude/skills/instrument-otel/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: instrument-otel
+description: Use when instrumenting an application with OpenTelemetry for Agent Health. Provides span structure, required attributes, and config setup for routing traces.
+---
+
+## Task: Instrument with OpenTelemetry for Agent Health
+
+Add OpenTelemetry instrumentation following GenAI semantic conventions so traces are compatible with Agent Health.
+
+### Steps
+
+1. **Install OTel dependencies** for the project's language (Python: `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`; Node.js: `@opentelemetry/api`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-trace-otlp-http`)
+
+2. **Initialize tracer** with OTLP exporter pointing to `OTEL_EXPORTER_OTLP_ENDPOINT` using `http/protobuf` protocol
+
+3. **Create spans** in this hierarchy:
+   ```
+   Root: invoke_agent (gen_ai.operation.name = "invoke_agent")
+   ├── chat (gen_ai.operation.name = "chat")
+   ├── execute_tool (gen_ai.operation.name = "execute_tool")
+   └── ...
+   ```
+
+4. **Set required attributes:**
+
+   Agent root span:
+   - `gen_ai.operation.name`: `"invoke_agent"`
+   - `gen_ai.agent.name`: agent name
+   - `gen_ai.system`: provider (e.g., `"aws.bedrock"`, `"openai"`, `"anthropic"`)
+   - `gen_ai.request.id`: unique run/session ID
+
+   LLM spans:
+   - `gen_ai.operation.name`: `"chat"`
+   - `gen_ai.request.model`: full model ID (e.g., `"anthropic.claude-sonnet-4-20250514-v1:0"`)
+   - `gen_ai.usage.input_tokens`: integer
+   - `gen_ai.usage.output_tokens`: integer
+
+   Tool spans:
+   - `gen_ai.operation.name`: `"execute_tool"`
+   - `gen_ai.tool.name`: tool name
+
+5. **Set environment variables** to emit traces:
+   ```bash
+   export OTEL_TRACES_EXPORTER=otlp
+   export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+   export OTEL_EXPORTER_OTLP_ENDPOINT=<YOUR_OTLP_ENDPOINT>
+   export OTEL_SERVICE_NAME=my-agent
+   ```
+
+6. **Configure Agent Health** to read traces from the OpenSearch domain:
+
+   **Option 1: CLI (recommended)**
+   ```bash
+   npx @opensearch-project/agent-health setup-telemetry
+   ```
+   This writes the observability config to `agent-health.config.json` automatically.
+
+   **Option 2: Manual JSON config**
+   Add to `agent-health.config.json`:
+   ```json
+   {
+     "observability": {
+       "endpoint": "https://search-my-domain.us-west-2.es.amazonaws.com",
+       "authType": "sigv4",
+       "awsRegion": "us-west-2",
+       "awsService": "es",
+       "tracesIndex": "otel-v1-apm-span-*"
+     }
+   }
+   ```
+
+7. **Verify** with `npx @opensearch-project/agent-health doctor`
+
+### Key Rules
+
+- Token counts MUST be integers, not strings
+- Always call `span.end()` (or use context manager)
+- Use full model IDs (e.g., `anthropic.claude-sonnet-4-20250514-v1:0`), not short names
+- Every span needs `gen_ai.operation.name` or it falls into "OTHER" category
+- Set span status to ERROR on failures
+
+### Reference
+
+Full guide with code examples: [docs/INSTRUMENT_WITH_OTEL.md](../../../docs/INSTRUMENT_WITH_OTEL.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.4.0]
+## [0.4.0] - 2025-05-05
 
 ### Fixed
 - Extra spacing in Timeline view by removing container padding ([#73](https://github.com/opensearch-project/agent-health/issues/73))

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npx @opensearch-project/agent-health
 
 Opens http://localhost:4001 with pre-loaded sample data for exploration. If port 4001 is already in use, the server automatically tries the next available port (4002, 4003, etc., up to 10 attempts).
 
-### Option 2: Docker Compose (with OpenSearch Observability Stack)
+### Option 2: Docker Compose
 
 For the full observability stack with OpenSearch, OpenTelemetry Collector, and Data Prepper for trace ingestion:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Agent Health helps you evaluate, monitor, and optimize AI agents. From autonomou
 
 <div align="center" style="margin-top: 1em; margin-bottom: 1em;">
 <a href="#what-is-agent-health">What is Agent Health?</a> &bull;
+<a href="#ai-skills">AI Skills</a> &bull;
 <a href="#installation">Installation</a> &bull;
 <a href="#features">Features</a> &bull;
 <a href="#quick-configuration">Configuration</a> &bull;
@@ -65,6 +66,24 @@ Agent Health is an evaluation and observability framework for AI agents, built o
 - Developers using AI coding agents who want visibility into usage, costs, and productivity
 
 > **See it in action:** Watch the [demo video on YouTube](https://www.youtube.com/watch?v=MU3tTv4lKtc)
+
+---
+
+<a id="ai-skills"></a>
+## AI Agent Skills
+
+Agent Health ships with built-in skill files for *Claude Code* and *Kiro* that teach your AI coding agent how to work with this project effectively. Copy the relevant directory into your workspace to unlock project-aware assistance:
+
+| Skill | Claude Code | Kiro | What it does |
+|-------|-------------|------|--------------|
+| **Add Connector** | [`.claude/skills/add-connector/SKILL.md`](./.claude/skills/add-connector/SKILL.md) | [`.kiro/steering/add-connector.md`](./.kiro/steering/add-connector.md) | Guides creation of custom agent connectors |
+| **Write Test** | [`.claude/skills/write-test/SKILL.md`](./.claude/skills/write-test/SKILL.md) | [`.kiro/steering/write-test.md`](./.kiro/steering/write-test.md) | Project test conventions, mocking patterns, coverage thresholds |
+| **Create PR** | [`.claude/skills/create-pr/SKILL.md`](./.claude/skills/create-pr/SKILL.md) | [`.kiro/steering/create-pr.md`](./.kiro/steering/create-pr.md) | PR workflow with DCO signoff and CI compliance |
+| **Config & Auth** | [`.claude/skills/config-auth/SKILL.md`](./.claude/skills/config-auth/SKILL.md) | — | Config loading, AWS auth, multi-profile setup |
+
+**To use these skills:**
+- *Claude Code* — Skills in `.claude/skills/` are auto-discovered when the directory exists in your workspace root. No extra setup needed.
+- *Kiro* — Copy `.kiro/steering/` to your workspace root. Kiro loads steering files automatically.
 
 ---
 

--- a/__mocks__/@/server/services/observioAgent.ts
+++ b/__mocks__/@/server/services/observioAgent.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Mock for observioAgent - avoids import.meta.url issues in Jest
+ *
+ * All functions are jest.fn() so tests can configure return values.
+ */
+
+export const OBSERVIO_PORT = 3001;
+
+export const findObservioRoot = jest.fn().mockReturnValue(null);
+
+export const isPortFree = jest.fn().mockResolvedValue(true);
+
+export const spawnObservioAgent = jest.fn().mockReturnValue(null);
+
+export const killObservioAgent = jest.fn().mockResolvedValue(false);

--- a/cli/commands/setup-telemetry.ts
+++ b/cli/commands/setup-telemetry.ts
@@ -369,6 +369,8 @@ export function createSetupTelemetryCommand(): Command {
         }
       }
 
+      validateInput(endpoint, 'endpoint');
+
       // Step: Test OTLP connectivity
       console.log(chalk.gray('\n  Testing OTLP endpoint connectivity...'));
       const connectivity = await testEndpoint(endpoint);

--- a/components/codingAgents/CodingAgentsPage.tsx
+++ b/components/codingAgents/CodingAgentsPage.tsx
@@ -21,6 +21,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import SessionTracesView from './SessionTracesView';
+import SessionAnnotationsTab from './SessionAnnotationsTab';
 import { PerformancePulseSection, EvalTrendPoint } from './PerformancePulse';
 // Task 3A/3B/3C: shared primitives for the AI Dev Tools page.
 import {
@@ -1025,6 +1026,7 @@ function SessionDetailPanel({ session, onClose }: { session: Session; onClose: (
           <TabsList className="mb-3">
             <TabsTrigger value="messages">Messages</TabsTrigger>
             <TabsTrigger value="traces">Traces</TabsTrigger>
+            <TabsTrigger value="annotations">Annotations</TabsTrigger>
           </TabsList>
 
           <TabsContent value="messages">
@@ -1104,6 +1106,10 @@ function SessionDetailPanel({ session, onClose }: { session: Session; onClose: (
 
           <TabsContent value="traces">
             <SessionTracesView sessionId={session.session_id} />
+          </TabsContent>
+
+          <TabsContent value="annotations">
+            <SessionAnnotationsTab agentKind={session.agent} sessionId={session.session_id} />
           </TabsContent>
         </Tabs>
       </div>

--- a/components/codingAgents/PerformancePulse.tsx
+++ b/components/codingAgents/PerformancePulse.tsx
@@ -192,6 +192,8 @@ export function buildRadarData(
   stats: CombinedStats,
   evalTrends: EvalTrendPoint[] | null,
 ): Array<Record<string, number | string>> {
+  if (efficiency.agents.length === 0) return [];
+
   const hasEval = evalTrends && evalTrends.length > 0;
   const dims = hasEval ? RADAR_DIMS_WITH_EVAL : RADAR_DIMS_NO_EVAL;
 

--- a/components/codingAgents/SessionAnnotationsTab.tsx
+++ b/components/codingAgents/SessionAnnotationsTab.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @experimental Session metadata / annotations tab.
+ * Uses the generic session metadata API (GET/PUT) — annotations are stored
+ * as an array inside the metadata doc.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { SessionMetadata } from '@/types';
+import { getSessionMetadata, putSessionMetadata } from '@/services/client/sessionAnnotationsApi';
+
+interface Annotation {
+  id: string;
+  text: string;
+  tags?: string[];
+  severity?: 'info' | 'warning' | 'critical';
+  timestamp: string;
+  linkedMessageIndex?: number;
+}
+
+const PRESET_TAGS = ['bug', 'hallucination', 'performance', 'interesting', 'regression', 'tool-failure'];
+const SEVERITY_COLORS: Record<string, string> = {
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  critical: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+};
+const STATUS_OPTIONS = ['normal', 'interesting', 'problematic', 'resolved'] as const;
+
+interface Props {
+  agentKind: string;
+  sessionId: string;
+  onLinkedMessageClick?: (index: number) => void;
+}
+
+export default function SessionAnnotationsTab({ agentKind, sessionId, onLinkedMessageClick }: Props) {
+  const [meta, setMeta] = useState<SessionMetadata | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [text, setText] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [severity, setSeverity] = useState<'info' | 'warning' | 'critical'>('info');
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    getSessionMetadata(agentKind, sessionId)
+      .then(setMeta)
+      .catch(() => setMeta(null))
+      .finally(() => setLoading(false));
+  }, [agentKind, sessionId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const annotations: Annotation[] = (meta?.annotations as Annotation[]) || [];
+  const status = (meta?.status as string) || 'normal';
+
+  const save = async (updates: Record<string, unknown>) => {
+    setSaving(true);
+    try {
+      const result = await putSessionMetadata(agentKind, sessionId, updates);
+      setMeta(result);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!text.trim()) return;
+    const newAnnotation: Annotation = {
+      id: `a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      text: text.trim(),
+      tags: selectedTags.length > 0 ? selectedTags : undefined,
+      severity,
+      timestamp: new Date().toISOString(),
+    };
+    await save({ annotations: [...annotations, newAnnotation] });
+    setText('');
+    setSelectedTags([]);
+    setSeverity('info');
+  };
+
+  const handleDelete = async (id: string) => {
+    await save({ annotations: annotations.filter(a => a.id !== id) });
+  };
+
+  const handleStatusChange = async (newStatus: string) => {
+    await save({ status: newStatus });
+  };
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags(prev => prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]);
+  };
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground py-4 text-center">Loading...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground border border-dashed rounded px-2 py-1">
+        <span className="font-medium text-amber-600 dark:text-amber-400">EXPERIMENTAL</span>
+        <span>Session metadata &amp; annotations</span>
+      </div>
+
+      {/* Status */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Status:</span>
+        <Select value={status} onValueChange={handleStatusChange}>
+          <SelectTrigger className="w-36 h-7 text-xs"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map(s => (
+              <SelectItem key={s} value={s}>{s}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Add annotation */}
+      <div className="border rounded-md p-3 space-y-2 bg-muted/30">
+        <textarea
+          className="w-full border rounded px-3 py-2 text-sm bg-background resize-y min-h-[60px]"
+          placeholder="Add a note..."
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleAdd(); }}
+        />
+        <div className="flex flex-wrap gap-1.5">
+          {PRESET_TAGS.map(tag => (
+            <button
+              key={tag}
+              onClick={() => toggleTag(tag)}
+              className={`text-xs px-2 py-0.5 rounded-full border transition-colors ${
+                selectedTags.includes(tag)
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background border-border hover:border-primary/50'
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={severity} onValueChange={v => setSeverity(v as any)}>
+            <SelectTrigger className="w-28 h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="info">Info</SelectItem>
+              <SelectItem value="warning">Warning</SelectItem>
+              <SelectItem value="critical">Critical</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button size="sm" onClick={handleAdd} disabled={!text.trim() || saving} className="ml-auto h-7 text-xs">
+            {saving ? 'Saving...' : 'Add Note'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Annotations list */}
+      {annotations.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-4">No annotations yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {annotations.map((ann) => (
+            <div key={ann.id} className="border rounded-md p-3 text-sm space-y-1.5">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {ann.severity && (
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${SEVERITY_COLORS[ann.severity] || ''}`}>
+                      {ann.severity}
+                    </span>
+                  )}
+                  {ann.tags?.map(tag => (
+                    <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">{tag}</Badge>
+                  ))}
+                </div>
+                <button onClick={() => handleDelete(ann.id)} className="text-muted-foreground hover:text-red-500 text-xs shrink-0">&times;</button>
+              </div>
+              <p className="whitespace-pre-wrap text-xs">{ann.text}</p>
+              <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                <span>{new Date(ann.timestamp).toLocaleString()}</span>
+                {ann.linkedMessageIndex !== undefined && onLinkedMessageClick && (
+                  <button onClick={() => onLinkedMessageClick(ann.linkedMessageIndex!)} className="text-blue-500 hover:underline">
+                    Message #{ann.linkedMessageIndex + 1}
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/codingAgents/SessionAnnotationsTab.tsx
+++ b/components/codingAgents/SessionAnnotationsTab.tsx
@@ -178,7 +178,7 @@ export default function SessionAnnotationsTab({ agentKind, sessionId, onLinkedMe
                     <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">{tag}</Badge>
                   ))}
                 </div>
-                <button onClick={() => handleDelete(ann.id)} className="text-muted-foreground hover:text-red-500 text-xs shrink-0">&times;</button>
+                <button onClick={() => handleDelete(ann.id)} aria-label="Delete annotation" title="Delete annotation" className="text-muted-foreground hover:text-red-500 text-xs shrink-0">&times;</button>
               </div>
               <p className="whitespace-pre-wrap text-xs">{ann.text}</p>
               <div className="flex items-center gap-2 text-[10px] text-muted-foreground">

--- a/components/codingAgents/SessionAnnotationsTab.tsx
+++ b/components/codingAgents/SessionAnnotationsTab.tsx
@@ -57,8 +57,8 @@ export default function SessionAnnotationsTab({ agentKind, sessionId, onLinkedMe
 
   useEffect(() => { refresh(); }, [refresh]);
 
-  const annotations: Annotation[] = (meta?.annotations as Annotation[]) || [];
-  const status = (meta?.status as string) || 'normal';
+  const annotations: Annotation[] = Array.isArray(meta?.annotations) ? meta.annotations as Annotation[] : [];
+  const status = (typeof meta?.status === 'string' ? meta.status : 'normal');
 
   const save = async (updates: Record<string, unknown>) => {
     setSaving(true);

--- a/deployment/cloudformation/agent-health-observability.yaml
+++ b/deployment/cloudformation/agent-health-observability.yaml
@@ -656,6 +656,13 @@ Resources:
       - RoleMappingFunction
     Properties:
       ServiceToken: !GetAtt RoleMappingFunction.Arn
+      # Include role ARNs so CFN re-triggers on changes
+      OSISRoleArn: !GetAtt OSISPipelineRole.Arn
+      LambdaRoleArn: !GetAtt OTLPIngestLambdaRole.Arn
+      AdminRoleArn: !If
+        - HasAdminRoleARN
+        - !Ref AdminRoleARN
+        - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
 
   OTLPIngestApi:
     Type: AWS::ApiGatewayV2::Api

--- a/deployment/cloudformation/agent-health-observability.yaml
+++ b/deployment/cloudformation/agent-health-observability.yaml
@@ -19,11 +19,13 @@ Description: >-
 Parameters:
   DomainName:
     Type: String
-    Default: agent-health-traces
-    Description: Name for the OpenSearch Service domain
+    Default: ah-traces
+    Description: >-
+      Name for the OpenSearch Service domain. Keep ≤21 chars because OSIS
+      pipeline names are "${DomainName}-traces" with a 28-char max.
     AllowedPattern: '[a-z][a-z0-9\-]+'
     MinLength: 3
-    MaxLength: 28
+    MaxLength: 21
 
   InstanceType:
     Type: String
@@ -57,18 +59,20 @@ Parameters:
     MinValue: 1
     MaxValue: 96
 
-  MasterUserARN:
+  AdminRoleARN:
     Type: String
     Description: >-
-      IAM ARN for the OpenSearch FGAC master user (used for security plugin admin).
-      Defaults to the account root; override with your IAM role ARN for direct access.
+      Optional IAM role ARN to grant OpenSearch all_access (e.g., your Admin role).
+      The domain master user is always the internal RoleMappingFunctionRole;
+      this parameter adds an additional role with full access via backend role mapping.
     Default: ''
 
 # =============================================================================
 # Conditions
 # =============================================================================
 Conditions:
-  HasMasterUserARN: !Not [!Equals [!Ref MasterUserARN, '']]
+  HasAdminRoleARN: !Not [!Equals [!Ref AdminRoleARN, '']]
+  # Note: Domain MasterUserARN is always RoleMappingFunctionRole (not conditional)
 
 # =============================================================================
 # Resources
@@ -76,10 +80,48 @@ Conditions:
 Resources:
 
   # ---------------------------------------------------------------------------
+  # IAM Role — FGAC Role Mapping Custom Resource (also used as MasterUserARN)
+  # Defined first because the OpenSearch domain references it as master user.
+  # ---------------------------------------------------------------------------
+  RoleMappingFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${DomainName}-${AWS::Region}-role-mapping-cr-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: OpenSearchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'es:ESHttp*'
+                Resource:
+                  - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DomainName}/*'
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*'
+
+  # ---------------------------------------------------------------------------
   # OpenSearch Service Domain
   # ---------------------------------------------------------------------------
   OpenSearchDomain:
     Type: AWS::OpenSearchService::Domain
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       DomainName: !Ref DomainName
       EngineVersion: OpenSearch_3.5
@@ -107,10 +149,7 @@ Resources:
         Enabled: true
         InternalUserDatabaseEnabled: false
         MasterUserOptions:
-          MasterUserARN: !If
-            - HasMasterUserARN
-            - !Ref MasterUserARN
-            - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+          MasterUserARN: !GetAtt RoleMappingFunctionRole.Arn
       # "Only use fine-grained access control" — open domain policy,
       # all authorization is handled by the OpenSearch Security plugin (FGAC).
       AccessPolicies:
@@ -133,7 +172,7 @@ Resources:
   OSISPipelineRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${DomainName}-osis-pipeline-role'
+      RoleName: !Sub '${DomainName}-${AWS::Region}-osis-pipeline-role'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -160,7 +199,7 @@ Resources:
   IngestionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${DomainName}-ingestion-role'
+      RoleName: !Sub '${DomainName}-${AWS::Region}-ingestion-role'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -271,7 +310,7 @@ Resources:
   OTLPIngestLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${DomainName}-otlp-ingest-lambda-role'
+      RoleName: !Sub '${DomainName}-${AWS::Region}-otlp-ingest-lambda-role'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -475,6 +514,120 @@ Resources:
       Tags:
         - Key: agent-health
           Value: observability
+
+  # ---------------------------------------------------------------------------
+  # Custom Resource — Map IAM Roles to OpenSearch FGAC Backend Roles
+  # Maps the OSIS pipeline role and Lambda ingest role to 'all_access' so they
+  # can write to OpenSearch indices. Runs once during stack create/update.
+  # ---------------------------------------------------------------------------
+  RoleMappingFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: OpenSearchDomain
+    Properties:
+      FunctionName: !Sub '${DomainName}-fgac-role-mapping'
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 60
+      MemorySize: 128
+      Role: !GetAtt RoleMappingFunctionRole.Arn
+      Environment:
+        Variables:
+          OPENSEARCH_ENDPOINT: !Sub 'https://${OpenSearchDomain.DomainEndpoint}'
+          OSIS_ROLE_ARN: !GetAtt OSISPipelineRole.Arn
+          LAMBDA_ROLE_ARN: !GetAtt OTLPIngestLambdaRole.Arn
+          ADMIN_ROLE_ARN: !If
+            - HasAdminRoleARN
+            - !Ref AdminRoleARN
+            - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+      Code:
+        ZipFile: |
+          """Custom Resource — maps IAM role ARNs to OpenSearch all_access backend role."""
+          import json
+          import os
+          import urllib.request
+          from botocore.auth import SigV4Auth
+          from botocore.awsrequest import AWSRequest
+          from botocore.session import Session
+
+          OS_ENDPOINT = os.environ['OPENSEARCH_ENDPOINT']
+          REGION = os.environ.get('AWS_REGION', 'us-east-1')
+          OSIS_ROLE_ARN = os.environ['OSIS_ROLE_ARN']
+          LAMBDA_ROLE_ARN = os.environ['LAMBDA_ROLE_ARN']
+          ADMIN_ROLE_ARN = os.environ.get('ADMIN_ROLE_ARN', '')
+          session = Session()
+
+          def _creds():
+              c = session.get_credentials()
+              return c.resolve_credentials() if hasattr(c, 'resolve_credentials') else c
+
+          def _signed_request(method, path, body=None):
+              url = OS_ENDPOINT + path
+              headers = {'Content-Type': 'application/json'}
+              request = AWSRequest(method=method, url=url, data=body or '', headers=headers)
+              SigV4Auth(_creds(), 'es', REGION).add_auth(request)
+              req = urllib.request.Request(url, data=(body or '').encode('utf-8'), method=method,
+                                           headers={k: v for k, v in dict(request.headers).items()})
+              try:
+                  with urllib.request.urlopen(req) as resp:
+                      return resp.status, json.loads(resp.read().decode('utf-8', errors='replace'))
+              except urllib.error.HTTPError as e:
+                  return e.code, json.loads(e.read().decode('utf-8', errors='replace'))
+
+          def _send_cfn_response(event, context, status, reason=''):
+              body = json.dumps({
+                  'Status': status,
+                  'Reason': reason or f'See CloudWatch Log Stream: {context.log_stream_name}',
+                  'PhysicalResourceId': context.log_stream_name,
+                  'StackId': event['StackId'],
+                  'RequestId': event['RequestId'],
+                  'LogicalResourceId': event['LogicalResourceId'],
+              })
+              req = urllib.request.Request(event['ResponseURL'], data=body.encode('utf-8'),
+                                           method='PUT', headers={'Content-Type': ''})
+              urllib.request.urlopen(req)
+
+          def handler(event, context):
+              print(f"Event: {json.dumps(event)}")
+              try:
+                  if event['RequestType'] == 'Delete':
+                      _send_cfn_response(event, context, 'SUCCESS')
+                      return
+                  # Get current mapping for all_access
+                  status, current = _signed_request('GET', '/_plugins/_security/api/rolesmapping/all_access')
+                  print(f"Current mapping (status={status}): {json.dumps(current)}")
+                  if status == 200:
+                      backend_roles = current.get('all_access', {}).get('backend_roles', [])
+                  else:
+                      backend_roles = []
+                  # Add our roles if not already present
+                  roles_to_map = [r for r in [OSIS_ROLE_ARN, LAMBDA_ROLE_ARN, ADMIN_ROLE_ARN] if r]
+                  for role in roles_to_map:
+                      if role not in backend_roles:
+                          backend_roles.append(role)
+                  # PUT the updated mapping
+                  payload = json.dumps({'backend_roles': backend_roles})
+                  status, resp = _signed_request('PUT', '/_plugins/_security/api/rolesmapping/all_access', payload)
+                  print(f"PUT mapping (status={status}): {json.dumps(resp)}")
+                  if status in (200, 201):
+                      _send_cfn_response(event, context, 'SUCCESS')
+                  else:
+                      _send_cfn_response(event, context, 'FAILED', f'OpenSearch returned {status}: {json.dumps(resp)}')
+              except Exception as e:
+                  print(f"Error: {e}")
+                  _send_cfn_response(event, context, 'FAILED', str(e))
+      Tags:
+        - Key: agent-health
+          Value: observability
+
+  RoleMappingCustomResource:
+    Type: Custom::OpenSearchRoleMapping
+    DependsOn:
+      - OpenSearchDomain
+      - OSISPipelineRole
+      - OTLPIngestLambdaRole
+      - RoleMappingFunction
+    Properties:
+      ServiceToken: !GetAtt RoleMappingFunction.Arn
 
   OTLPIngestApi:
     Type: AWS::ApiGatewayV2::Api

--- a/deployment/cloudformation/agent-health-observability.yaml
+++ b/deployment/cloudformation/agent-health-observability.yaml
@@ -114,6 +114,11 @@ Resources:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                 Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*'
+      Tags:
+        - Key: agent-health
+          Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # OpenSearch Service Domain
@@ -192,6 +197,11 @@ Resources:
                 Resource:
                   - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DomainName}'
                   - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DomainName}/*'
+      Tags:
+        - Key: agent-health
+          Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # IAM Role — Ingestion (for agents pushing telemetry via SigV4)
@@ -218,6 +228,11 @@ Resources:
                 Resource:
                   - !Sub 'arn:aws:osis:${AWS::Region}:${AWS::AccountId}:pipeline/${DomainName}-traces'
                   - !Sub 'arn:aws:osis:${AWS::Region}:${AWS::AccountId}:pipeline/${DomainName}-logs'
+      Tags:
+        - Key: agent-health
+          Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # OpenSearch Ingestion (OSIS) Pipeline — OTLP Traces → OpenSearch
@@ -272,6 +287,8 @@ Resources:
       Tags:
         - Key: agent-health
           Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # OpenSearch Ingestion (OSIS) Pipeline — OTLP Logs → OpenSearch
@@ -300,6 +317,8 @@ Resources:
       Tags:
         - Key: agent-health
           Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # OTLP Ingestion — API Gateway + Lambda → OpenSearch (direct)
@@ -348,6 +367,11 @@ Resources:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                 Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*'
+      Tags:
+        - Key: agent-health
+          Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   OTLPIngestFunction:
     Type: AWS::Lambda::Function
@@ -514,6 +538,8 @@ Resources:
       Tags:
         - Key: agent-health
           Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   # ---------------------------------------------------------------------------
   # Custom Resource — Map IAM Roles to OpenSearch FGAC Backend Roles
@@ -618,6 +644,8 @@ Resources:
       Tags:
         - Key: agent-health
           Value: observability
+        - Key: ManagedBy
+          Value: AgentHealthCFN
 
   RoleMappingCustomResource:
     Type: Custom::OpenSearchRoleMapping
@@ -641,6 +669,9 @@ Resources:
           - POST
         AllowHeaders:
           - content-type
+      Tags:
+        agent-health: observability
+        ManagedBy: AgentHealthCFN
 
   OTLPIngestApiIntegration:
     Type: AWS::ApiGatewayV2::Integration

--- a/deployment/test-role-mapping.py
+++ b/deployment/test-role-mapping.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Test the FGAC role mapping logic locally against a live OpenSearch domain.
+
+Usage:
+  python3 deployment/test-role-mapping.py <opensearch-endpoint> <region> [--profile PROFILE]
+
+Example:
+  python3 deployment/test-role-mapping.py https://search-agent-health-traces-xxx.us-east-1.es.amazonaws.com us-east-1 --profile default
+"""
+import json
+import sys
+import urllib.request
+import argparse
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session
+
+def _signed_request(session, method, url, region, body=None):
+    headers = {'Content-Type': 'application/json'}
+    request = AWSRequest(method=method, url=url, data=body or '', headers=headers)
+    creds = session.get_credentials().get_frozen_credentials()
+    SigV4Auth(creds, 'es', region).add_auth(request)
+    req = urllib.request.Request(url, data=(body or '').encode('utf-8'), method=method,
+                                 headers={k: v for k, v in dict(request.headers).items()})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode('utf-8', errors='replace'))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode('utf-8', errors='replace'))
+
+def main():
+    parser = argparse.ArgumentParser(description='Test FGAC role mapping against OpenSearch')
+    parser.add_argument('endpoint', help='OpenSearch domain endpoint (https://...)')
+    parser.add_argument('region', help='AWS region')
+    parser.add_argument('--profile', default=None, help='AWS profile')
+    parser.add_argument('--role-arns', nargs='+', default=['arn:aws:iam::651304888251:role/test-role'],
+                        help='Role ARNs to map')
+    parser.add_argument('--dry-run', action='store_true', help='Only GET current mapping, do not PUT')
+    args = parser.parse_args()
+
+    session = Session()
+    if args.profile:
+        session.set_config_variable('profile', args.profile)
+
+    endpoint = args.endpoint.rstrip('/')
+
+    # Step 1: Check connectivity
+    print(f"[1/4] Testing connectivity to {endpoint}...")
+    status, resp = _signed_request(session, 'GET', f'{endpoint}/_cluster/health', args.region)
+    if status == 200:
+        print(f"  OK — cluster: {resp.get('cluster_name')}, status: {resp.get('status')}")
+    else:
+        print(f"  FAILED ({status}): {json.dumps(resp, indent=2)}")
+        sys.exit(1)
+
+    # Step 2: Check current caller identity in OpenSearch
+    print(f"\n[2/4] Checking FGAC identity...")
+    status, resp = _signed_request(session, 'GET', f'{endpoint}/_plugins/_security/authinfo', args.region)
+    if status == 200:
+        print(f"  User: {resp.get('user_name')}")
+        print(f"  Backend roles: {resp.get('backend_roles', [])}")
+        print(f"  Roles: {resp.get('roles', [])}")
+        is_admin = 'all_access' in resp.get('roles', [])
+        print(f"  Has all_access: {is_admin}")
+    else:
+        print(f"  FAILED ({status}): {json.dumps(resp, indent=2)}")
+        print("  (This likely means the caller is not the master user)")
+        sys.exit(1)
+
+    # Step 3: GET current role mapping
+    print(f"\n[3/4] Getting current all_access role mapping...")
+    status, resp = _signed_request(session, 'GET', f'{endpoint}/_plugins/_security/api/rolesmapping/all_access', args.region)
+    if status == 200:
+        backend_roles = resp.get('all_access', {}).get('backend_roles', [])
+        print(f"  Current backend_roles: {json.dumps(backend_roles, indent=4)}")
+    elif status == 404:
+        backend_roles = []
+        print(f"  No existing mapping (will create)")
+    else:
+        print(f"  FAILED ({status}): {json.dumps(resp, indent=2)}")
+        sys.exit(1)
+
+    # Step 4: PUT updated mapping
+    roles_to_add = args.role_arns
+    added = []
+    for role in roles_to_add:
+        if role not in backend_roles:
+            backend_roles.append(role)
+            added.append(role)
+
+    if not added:
+        print(f"\n[4/4] All roles already mapped. Nothing to do.")
+        return
+
+    if args.dry_run:
+        print(f"\n[4/4] DRY RUN — would add: {json.dumps(added, indent=4)}")
+        return
+
+    print(f"\n[4/4] Adding roles: {json.dumps(added, indent=4)}")
+    payload = json.dumps({'backend_roles': backend_roles})
+    status, resp = _signed_request(session, 'PUT', f'{endpoint}/_plugins/_security/api/rolesmapping/all_access', args.region, payload)
+    if status in (200, 201):
+        print(f"  SUCCESS: {json.dumps(resp)}")
+    else:
+        print(f"  FAILED ({status}): {json.dumps(resp, indent=2)}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/deployment/test-role-mapping.py
+++ b/deployment/test-role-mapping.py
@@ -33,8 +33,8 @@ def main():
     parser.add_argument('endpoint', help='OpenSearch domain endpoint (https://...)')
     parser.add_argument('region', help='AWS region')
     parser.add_argument('--profile', default=None, help='AWS profile')
-    parser.add_argument('--role-arns', nargs='+', default=['arn:aws:iam::651304888251:role/test-role'],
-                        help='Role ARNs to map')
+    parser.add_argument('--role-arns', nargs='+', default=['arn:aws:iam::123456789012:role/test-role'],
+                        help='Role ARNs to map (replace placeholder account ID)')
     parser.add_argument('--dry-run', action='store_true', help='Only GET current mapping, do not PUT')
     args = parser.parse_args()
 

--- a/docs/INSTRUMENT_WITH_OTEL.md
+++ b/docs/INSTRUMENT_WITH_OTEL.md
@@ -1,0 +1,380 @@
+<!--
+  * Copyright OpenSearch Contributors
+  * SPDX-License-Identifier: Apache-2.0
+-->
+
+# Instrument Your Agent with OpenTelemetry
+
+This guide is a prompt you can give to a coding agent (Claude Code, Cursor, Copilot, etc.) to instrument your application with OpenTelemetry and route telemetry to the Agent Health observability stack.
+
+---
+
+## Quick Start: Give This Prompt to Your Coding Agent
+
+Copy the prompt below and paste it into your coding agent. It will instrument your application with the correct OTel attributes that Agent Health expects.
+
+---
+
+## The Prompt
+
+````markdown
+# Task: Instrument this application with OpenTelemetry
+
+Add OpenTelemetry instrumentation to this application following the GenAI semantic conventions so that traces are compatible with the Agent Health observability dashboard.
+
+## Requirements
+
+### 1. Install Dependencies
+
+For Python:
+```bash
+pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-semantic-conventions
+```
+
+For TypeScript/Node.js:
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-node @opentelemetry/exporter-trace-otlp-http @opentelemetry/semantic-conventions
+```
+
+### 2. Initialize the Tracer
+
+Configure an OTLP exporter that sends traces to the endpoint specified by `OTEL_EXPORTER_OTLP_ENDPOINT`. Use `http/protobuf` protocol.
+
+**Python:**
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+import os
+
+resource = Resource.create({
+    "service.name": os.getenv("OTEL_SERVICE_NAME", "my-agent"),
+})
+
+provider = TracerProvider(resource=resource)
+exporter = OTLPSpanExporter(
+    endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318") + "/v1/traces",
+)
+provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("my-agent")
+```
+
+**TypeScript:**
+```typescript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+
+const sdk = new NodeSDK({
+  resource: new Resource({
+    'service.name': process.env.OTEL_SERVICE_NAME || 'my-agent',
+  }),
+  traceExporter: new OTLPTraceExporter({
+    url: (process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318') + '/v1/traces',
+  }),
+});
+sdk.start();
+
+import { trace } from '@opentelemetry/api';
+const tracer = trace.getTracer('my-agent');
+```
+
+### 3. Span Structure (Required)
+
+Create spans in this hierarchy:
+
+```
+Root span: agent invocation (gen_ai.operation.name = "invoke_agent")
+├── LLM call (gen_ai.operation.name = "chat")
+├── Tool execution (gen_ai.operation.name = "execute_tool")
+├── LLM call (gen_ai.operation.name = "chat")
+└── ...
+```
+
+### 4. Required Span Attributes
+
+These attributes MUST be set on spans for Agent Health to correctly categorize and compute metrics.
+
+#### Agent Spans (root span)
+
+| Attribute | Value | Example |
+|-----------|-------|---------|
+| `gen_ai.operation.name` | `"invoke_agent"` or `"create_agent"` | `"invoke_agent"` |
+| `gen_ai.agent.name` | Your agent's name | `"rca-agent"` |
+| `gen_ai.system` | Provider identifier | `"aws.bedrock"`, `"openai"`, `"anthropic"` |
+| `gen_ai.request.id` | Unique run/session ID | `"run-abc123"` |
+
+#### LLM Call Spans
+
+| Attribute | Value | Example |
+|-----------|-------|---------|
+| `gen_ai.operation.name` | `"chat"`, `"text_completion"`, or `"generate_content"` | `"chat"` |
+| `gen_ai.request.model` | Full model identifier | `"anthropic.claude-sonnet-4-20250514-v1:0"` |
+| `gen_ai.system` | Provider identifier | `"aws.bedrock"` |
+| `gen_ai.usage.input_tokens` | Integer token count | `1234` |
+| `gen_ai.usage.output_tokens` | Integer token count | `567` |
+| `gen_ai.request.temperature` | Float (optional) | `0.7` |
+
+#### Tool Execution Spans
+
+| Attribute | Value | Example |
+|-----------|-------|---------|
+| `gen_ai.operation.name` | `"execute_tool"` | `"execute_tool"` |
+| `gen_ai.tool.name` | Name of the tool invoked | `"search_logs"` |
+| `gen_ai.tool.call_id` | Unique tool call ID (optional) | `"call_abc123"` |
+
+### 5. Implementation Pattern
+
+**Python example — wrapping an agent loop:**
+
+```python
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+import uuid
+
+tracer = trace.get_tracer("my-agent")
+
+def run_agent(prompt: str, run_id: str = None):
+    run_id = run_id or str(uuid.uuid4())
+
+    with tracer.start_as_current_span("invoke_agent") as agent_span:
+        agent_span.set_attribute("gen_ai.operation.name", "invoke_agent")
+        agent_span.set_attribute("gen_ai.agent.name", "my-rca-agent")
+        agent_span.set_attribute("gen_ai.system", "aws.bedrock")
+        agent_span.set_attribute("gen_ai.request.id", run_id)
+
+        # LLM call
+        with tracer.start_as_current_span("chat") as llm_span:
+            llm_span.set_attribute("gen_ai.operation.name", "chat")
+            llm_span.set_attribute("gen_ai.request.model", "anthropic.claude-sonnet-4-20250514-v1:0")
+            llm_span.set_attribute("gen_ai.system", "aws.bedrock")
+
+            response = call_llm(prompt)
+
+            llm_span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens)
+            llm_span.set_attribute("gen_ai.usage.output_tokens", response.output_tokens)
+
+        # Tool execution (if the LLM requested a tool call)
+        if response.tool_calls:
+            for tool_call in response.tool_calls:
+                with tracer.start_as_current_span("execute_tool") as tool_span:
+                    tool_span.set_attribute("gen_ai.operation.name", "execute_tool")
+                    tool_span.set_attribute("gen_ai.tool.name", tool_call.name)
+                    tool_span.set_attribute("gen_ai.tool.call_id", tool_call.id)
+
+                    result = execute_tool(tool_call)
+
+                    if result.error:
+                        tool_span.set_status(StatusCode.ERROR, result.error)
+
+    return response
+```
+
+**TypeScript example:**
+
+```typescript
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { v4 as uuid } from 'uuid';
+
+const tracer = trace.getTracer('my-agent');
+
+async function runAgent(prompt: string, runId?: string) {
+  runId = runId || uuid();
+
+  return tracer.startActiveSpan('invoke_agent', async (agentSpan) => {
+    agentSpan.setAttribute('gen_ai.operation.name', 'invoke_agent');
+    agentSpan.setAttribute('gen_ai.agent.name', 'my-rca-agent');
+    agentSpan.setAttribute('gen_ai.system', 'aws.bedrock');
+    agentSpan.setAttribute('gen_ai.request.id', runId);
+
+    try {
+      // LLM call
+      const response = await tracer.startActiveSpan('chat', async (llmSpan) => {
+        llmSpan.setAttribute('gen_ai.operation.name', 'chat');
+        llmSpan.setAttribute('gen_ai.request.model', 'anthropic.claude-sonnet-4-20250514-v1:0');
+        llmSpan.setAttribute('gen_ai.system', 'aws.bedrock');
+
+        const resp = await callLLM(prompt);
+
+        llmSpan.setAttribute('gen_ai.usage.input_tokens', resp.inputTokens);
+        llmSpan.setAttribute('gen_ai.usage.output_tokens', resp.outputTokens);
+        llmSpan.end();
+        return resp;
+      });
+
+      // Tool execution
+      for (const toolCall of response.toolCalls || []) {
+        await tracer.startActiveSpan('execute_tool', async (toolSpan) => {
+          toolSpan.setAttribute('gen_ai.operation.name', 'execute_tool');
+          toolSpan.setAttribute('gen_ai.tool.name', toolCall.name);
+          toolSpan.setAttribute('gen_ai.tool.call_id', toolCall.id);
+
+          const result = await executeTool(toolCall);
+          if (result.error) {
+            toolSpan.setStatus({ code: SpanStatusCode.ERROR, message: result.error });
+          }
+          toolSpan.end();
+        });
+      }
+
+      agentSpan.end();
+      return response;
+    } catch (err) {
+      agentSpan.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+      agentSpan.end();
+      throw err;
+    }
+  });
+}
+```
+
+### 6. Configure Telemetry Export and Agent Health
+
+#### A. Set environment variables to emit traces
+
+Set these in your shell or `.env` file to route telemetry from your agent to the OTLP endpoint:
+
+```bash
+# Required: enable OTLP export
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=<YOUR_OTLP_ENDPOINT>
+
+# Recommended: identify your service
+export OTEL_SERVICE_NAME=my-agent
+
+# Optional: also export logs and metrics
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+```
+
+Replace `<YOUR_OTLP_ENDPOINT>` with one of:
+- **Agent Health API Gateway**: `https://<api-gateway-id>.execute-api.<region>.amazonaws.com/prod` (from CloudFormation stack)
+- **Local ADOT collector**: `http://localhost:4318`
+- **Direct OSIS pipeline**: `https://<osis-endpoint>.osis.<region>.amazonaws.com`
+
+#### B. Configure Agent Health to read traces from OpenSearch
+
+After traces are flowing into your OpenSearch domain, configure Agent Health to access them.
+
+**Option 1: CLI setup (recommended)**
+
+Run the setup command to configure everything interactively:
+
+```bash
+npx @opensearch-project/agent-health setup-telemetry
+```
+
+This deploys the telemetry stack and writes the observability config to `agent-health.config.json` automatically.
+
+**Option 2: JSON config file (manual)**
+
+In your `agent-health.config.json`:
+
+```json
+{
+  "observability": {
+    "endpoint": "https://search-my-domain.us-west-2.es.amazonaws.com",
+    "authType": "sigv4",
+    "awsRegion": "us-west-2",
+    "awsService": "es",
+    "tracesIndex": "otel-v1-apm-span-*"
+  }
+}
+```
+
+For basic auth:
+
+```json
+{
+  "observability": {
+    "endpoint": "https://search-my-domain.us-west-2.es.amazonaws.com",
+    "authType": "basic",
+    "username": "admin",
+    "password": "your-password",
+    "tracesIndex": "otel-v1-apm-span-*"
+  }
+}
+```
+
+#### C. Verify the connection
+
+```bash
+npx @opensearch-project/agent-health doctor
+```
+
+Confirm that the "Observability" check shows a connected OpenSearch domain with the correct traces index.
+
+### 7. Validation Checklist
+
+After instrumenting, verify your spans include:
+
+- [ ] Root span has `gen_ai.operation.name` = `"invoke_agent"` and `gen_ai.agent.name`
+- [ ] LLM spans have `gen_ai.operation.name` = `"chat"` and `gen_ai.request.model`
+- [ ] LLM spans report `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`
+- [ ] Tool spans have `gen_ai.operation.name` = `"execute_tool"` and `gen_ai.tool.name`
+- [ ] All spans share the same trace ID (automatic if using `start_as_current_span`)
+- [ ] `gen_ai.request.id` on the root span matches the run ID used in Agent Health
+- [ ] Failed operations set span status to ERROR
+
+### 8. What Agent Health Does With Your Traces
+
+Agent Health uses these attributes to:
+- **Categorize spans**: `gen_ai.operation.name` determines if a span is AGENT, LLM, TOOL, or OTHER
+- **Calculate cost**: `gen_ai.usage.input_tokens` + `gen_ai.usage.output_tokens` + `gen_ai.request.model` → USD cost
+- **Track tool usage**: `gen_ai.tool.name` populates tool call counts and tool lists
+- **Correlate runs**: `gen_ai.request.id` links traces to benchmark runs
+- **Measure duration**: Span start/end times compute total and per-step latency
+- **Detect errors**: Span status ERROR is surfaced in the trace viewer
+
+### 9. Common Mistakes
+
+- **Missing `gen_ai.operation.name`**: Spans without this attribute fall into "OTHER" category and won't be counted as LLM/Tool calls
+- **Token counts as strings**: Must be integers, not strings like `"1234"`
+- **Not ending spans**: Always call `span.end()` (or use context manager in Python) — unended spans are never exported
+- **Wrong model ID format**: Use the full model identifier (e.g., `anthropic.claude-sonnet-4-20250514-v1:0`), not just `claude-sonnet`
+````
+
+---
+
+## Deploying the Telemetry Backend
+
+If you haven't set up the observability stack yet, use the Agent Health CLI:
+
+```bash
+npx @opensearch-project/agent-health setup-telemetry --deploy
+```
+
+This deploys a CloudFormation stack with:
+- API Gateway (OTLP endpoint with Lambda SigV4 proxy)
+- OSIS pipelines (traces + logs)
+- OpenSearch domain (stores spans at `otel-v1-apm-span-*`)
+
+After deployment, the CLI prints the `OTEL_EXPORTER_OTLP_ENDPOINT` value to use.
+
+## Using as a Claude Code Skill
+
+To make this available as a slash command in Claude Code, add to your project's `.claude/skills/instrument-otel.md`:
+
+```markdown
+---
+description: Instrument the current application with OpenTelemetry for Agent Health
+---
+
+[paste the prompt section above]
+```
+
+Then invoke with `/instrument-otel` in any Claude Code session.
+
+## Using as an MCP Resource
+
+If you run an MCP server, expose this document as a resource at `agent-health://instrumentation-guide` so any connected coding agent can retrieve it on demand.
+
+## Reference
+
+- [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OTel GenAI Agent Spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/)
+- [Agent Health Telemetry Setup](./CLAUDE_CODE_TELEMETRY.md)

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -17,6 +17,10 @@ module.exports = {
     '^@/server/services/configService$': '<rootDir>/__mocks__/@/server/services/configService.ts',
     '^\\.\\./services/configService\\.js$': '<rootDir>/__mocks__/@/server/services/configService.ts',
     '^\\.\\./\\.\\./services/configService\\.js$': '<rootDir>/__mocks__/@/server/services/configService.ts',
+    // Mock observioAgent to avoid import.meta.url issues in Jest
+    '^@/server/services/observioAgent$': '<rootDir>/__mocks__/@/server/services/observioAgent.ts',
+    '^\\.\\./services/observioAgent\\.js$': '<rootDir>/__mocks__/@/server/services/observioAgent.ts',
+    '^\\.\\./\\.\\./services/observioAgent\\.js$': '<rootDir>/__mocks__/@/server/services/observioAgent.ts',
     // Mock version utility to avoid import.meta.url issues in Jest
     '^@/server/utils/version$': '<rootDir>/__mocks__/@/server/utils/version.ts',
     '^\\.\\./utils/version$': '<rootDir>/__mocks__/@/server/utils/version.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/agent-health",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/agent-health",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/agent-health",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Agent Evaluation and Observability Framework",
   "license": "Apache-2.0",

--- a/server/adapters/file/StorageModule.ts
+++ b/server/adapters/file/StorageModule.ts
@@ -762,7 +762,7 @@ export class FileSessionMetadataOperations implements ISessionMetadataOperations
   async put(agentKind: string, sessionId: string, data: Record<string, unknown>): Promise<SessionMetadata> {
     const existing = readJsonFile<SessionMetadata>(this.docPath(agentKind, sessionId));
     const doc: SessionMetadata = {
-      ...existing,
+      ...(existing ?? {}),
       ...data,
       agentKind,
       sessionId,

--- a/server/adapters/file/StorageModule.ts
+++ b/server/adapters/file/StorageModule.ts
@@ -779,7 +779,6 @@ export class FileSessionMetadataOperations implements ISessionMetadataOperations
     const all = readAllFromDir<SessionMetadata>(this.dir);
     return paginate(all, options);
   }
-  }
 }
 
 // ============================================================================

--- a/server/adapters/file/StorageModule.ts
+++ b/server/adapters/file/StorageModule.ts
@@ -749,7 +749,10 @@ export class FileSessionMetadataOperations implements ISessionMetadataOperations
   private get dir() { return path.join(this.baseDir, 'session-metadata'); }
 
   private docPath(agentKind: string, sessionId: string): string {
-    return path.join(this.dir, `${agentKind}--${sessionId}.json`);
+    // Sanitize to prevent path traversal
+    const safeAgent = agentKind.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const safeSession = sessionId.replace(/[^a-zA-Z0-9_\-\.]/g, '_');
+    return path.join(this.dir, `${safeAgent}--${safeSession}.json`);
   }
 
   async get(agentKind: string, sessionId: string): Promise<SessionMetadata | null> {

--- a/server/adapters/file/StorageModule.ts
+++ b/server/adapters/file/StorageModule.ts
@@ -24,6 +24,7 @@ import type {
   BenchmarkRun,
   TestCaseRun,
   RunAnnotation,
+  SessionMetadata,
   HealthStatus,
   Evaluator,
 } from '../../../types/index.js';
@@ -34,6 +35,7 @@ import type {
   IRunOperations,
   IAnalyticsOperations,
   IEvaluatorOperations,
+  ISessionMetadataOperations,
   PaginationOptions,
   TestCaseSearchFilters,
   RunSearchFilters,
@@ -734,6 +736,50 @@ class FileEvaluatorOperations implements IEvaluatorOperations {
 }
 
 // ============================================================================
+// Session Metadata Operations
+// ============================================================================
+
+export class FileSessionMetadataOperations implements ISessionMetadataOperations {
+  private baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir || path.join(process.cwd(), 'agent-health-data');
+  }
+
+  private get dir() { return path.join(this.baseDir, 'session-metadata'); }
+
+  private docPath(agentKind: string, sessionId: string): string {
+    return path.join(this.dir, `${agentKind}--${sessionId}.json`);
+  }
+
+  async get(agentKind: string, sessionId: string): Promise<SessionMetadata | null> {
+    return readJsonFile<SessionMetadata>(this.docPath(agentKind, sessionId));
+  }
+
+  async put(agentKind: string, sessionId: string, data: Record<string, unknown>): Promise<SessionMetadata> {
+    const existing = readJsonFile<SessionMetadata>(this.docPath(agentKind, sessionId));
+    const doc: SessionMetadata = {
+      ...existing,
+      ...data,
+      agentKind,
+      sessionId,
+      updatedAt: new Date().toISOString(),
+    };
+    if (!existing) {
+      (doc as any).createdAt = doc.updatedAt;
+    }
+    writeJsonFile(this.docPath(agentKind, sessionId), doc);
+    return doc;
+  }
+
+  async list(options?: PaginationOptions): Promise<{ items: SessionMetadata[]; total: number }> {
+    const all = readAllFromDir<SessionMetadata>(this.dir);
+    return paginate(all, options);
+  }
+  }
+}
+
+// ============================================================================
 // File Storage Module
 // ============================================================================
 
@@ -745,6 +791,7 @@ export class FileStorageModule implements IStorageModule {
   readonly runs: IRunOperations;
   readonly analytics: IAnalyticsOperations;
   readonly evaluators: IEvaluatorOperations;
+  readonly sessionMetadata: ISessionMetadataOperations;
 
   private readonly baseDir: string;
 
@@ -757,6 +804,7 @@ export class FileStorageModule implements IStorageModule {
     this.runs = new FileRunOperations(this.baseDir);
     this.analytics = new FileAnalyticsOperations(this.baseDir);
     this.evaluators = new FileEvaluatorOperations(this.baseDir);
+    this.sessionMetadata = new FileSessionMetadataOperations(this.baseDir);
   }
 
   async health(): Promise<HealthStatus> {

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -278,6 +278,6 @@ export function isFileStorage(): boolean {
 // ============================================================================
 
 export { STORAGE_INDEXES, DEFAULT_OTEL_INDEXES };
-export { FileStorageModule } from './file/StorageModule.js';
+export { FileStorageModule, FileSessionMetadataOperations } from './file/StorageModule.js';
 export { OpenSearchStorageModule } from './opensearch/StorageModule.js';
-export type { IStorageModule } from './types.js';
+export type { IStorageModule, ISessionMetadataOperations } from './types.js';

--- a/server/adapters/opensearch/StorageModule.ts
+++ b/server/adapters/opensearch/StorageModule.ts
@@ -34,6 +34,7 @@ import type {
   IRunOperations,
   IAnalyticsOperations,
   IEvaluatorOperations,
+  ISessionMetadataOperations,
   PaginationOptions,
   TestCaseSearchFilters,
   RunSearchFilters,
@@ -1104,13 +1105,15 @@ export class OpenSearchStorageModule implements IStorageModule {
   readonly runs: IRunOperations;
   readonly analytics: IAnalyticsOperations;
   readonly evaluators: IEvaluatorOperations;
+  readonly sessionMetadata: ISessionMetadataOperations;
 
-  constructor(private client: Client) {
+  constructor(private client: Client, sessionMetadata: ISessionMetadataOperations) {
     this.testCases = new OpenSearchTestCaseOperations(client);
     this.benchmarks = new OpenSearchBenchmarkOperations(client);
     this.runs = new OpenSearchRunOperations(client);
     this.analytics = new OpenSearchAnalyticsOperations(client);
     this.evaluators = new OpenSearchEvaluatorOperations(client);
+    this.sessionMetadata = sessionMetadata;
   }
 
   async health(): Promise<HealthStatus> {

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -16,6 +16,7 @@ import type {
   BenchmarkRun,
   TestCaseRun,
   RunAnnotation,
+  SessionMetadata,
   OpenSearchLog,
   Span,
   HealthStatus,
@@ -195,6 +196,15 @@ export interface IMetricsOperations {
   // Future: Add metrics query operations
 }
 
+/**
+ * @experimental Session metadata operations (generic sidecar for coding agent sessions)
+ */
+export interface ISessionMetadataOperations {
+  get(agentKind: string, sessionId: string): Promise<SessionMetadata | null>;
+  put(agentKind: string, sessionId: string, data: Record<string, unknown>): Promise<SessionMetadata>;
+  list(options?: PaginationOptions): Promise<{ items: SessionMetadata[]; total: number }>;
+}
+
 // ============================================================================
 // Storage Module Interface
 // ============================================================================
@@ -208,6 +218,7 @@ export interface IStorageModule {
   runs: IRunOperations;
   analytics: IAnalyticsOperations;
   evaluators: IEvaluatorOperations;
+  sessionMetadata: ISessionMetadataOperations;
   health(): Promise<HealthStatus>;
   isConfigured(): boolean;
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -50,7 +50,7 @@ router.use(debugRoutes);         // /api/debug
 if (codingAnalyticsEnabled) {
   router.use(codingAgentsRoutes);  // /api/coding-agents/*
   router.use(claudeCodeWorkspaceRoutes);  // /api/coding-agents/claude-code/*
-  router.use(sessionAnnotationsRoutes);  // /api/coding-agents/sessions/:agent/:sessionId/annotations
+  router.use(sessionAnnotationsRoutes);  // /api/coding-agents/sessions/*/metadata
 }
 
 export default router;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -22,6 +22,7 @@ import evaluationRoutes from './evaluation';
 import debugRoutes from './debug';
 import codingAgentsRoutes from './codingAgents';
 import claudeCodeWorkspaceRoutes from './claudeCodeWorkspace';
+import sessionAnnotationsRoutes from './sessionAnnotations';
 import { codingAnalyticsEnabled } from '../services/codingAgents';
 
 const router = Router();
@@ -49,6 +50,7 @@ router.use(debugRoutes);         // /api/debug
 if (codingAnalyticsEnabled) {
   router.use(codingAgentsRoutes);  // /api/coding-agents/*
   router.use(claudeCodeWorkspaceRoutes);  // /api/coding-agents/claude-code/*
+  router.use(sessionAnnotationsRoutes);  // /api/coding-agents/sessions/:agent/:sessionId/annotations
 }
 
 export default router;

--- a/server/routes/sessionAnnotations.ts
+++ b/server/routes/sessionAnnotations.ts
@@ -42,6 +42,9 @@ router.put('/api/coding-agents/sessions/:agent/:sessionId/metadata', async (req:
     if (!data || typeof data !== 'object' || Array.isArray(data)) {
       return res.status(400).json({ error: 'Body must be a JSON object' });
     }
+    if ('agentKind' in data || 'sessionId' in data) {
+      return res.status(400).json({ error: 'agentKind and sessionId cannot be set in body' });
+    }
 
     const storage = getStorageModule();
     const doc = await storage.sessionMetadata.put(agent, sessionId, data);

--- a/server/routes/sessionAnnotations.ts
+++ b/server/routes/sessionAnnotations.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @experimental Session Metadata Routes
+ *
+ * Generic sidecar metadata for coding agent sessions.
+ * One GET, one PUT — callers define the schema.
+ */
+
+import { Router, Request, Response } from 'express';
+import { getStorageModule } from '../adapters/index.js';
+
+const router = Router();
+
+/**
+ * GET /api/coding-agents/sessions/:agent/:sessionId/metadata
+ * Read session metadata. Returns null body if none exists.
+ */
+router.get('/api/coding-agents/sessions/:agent/:sessionId/metadata', async (req: Request, res: Response) => {
+  try {
+    const { agent, sessionId } = req.params;
+    const storage = getStorageModule();
+    const doc = await storage.sessionMetadata.get(agent, sessionId);
+    res.json(doc || null);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * PUT /api/coding-agents/sessions/:agent/:sessionId/metadata
+ * Upsert session metadata. Merges with existing data; agentKind/sessionId are immutable.
+ */
+router.put('/api/coding-agents/sessions/:agent/:sessionId/metadata', async (req: Request, res: Response) => {
+  try {
+    const { agent, sessionId } = req.params;
+    const data = req.body;
+
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return res.status(400).json({ error: 'Body must be a JSON object' });
+    }
+
+    const storage = getStorageModule();
+    const doc = await storage.sessionMetadata.put(agent, sessionId, data);
+    res.json(doc);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * GET /api/coding-agents/sessions/metadata
+ * List all sessions that have metadata.
+ */
+router.get('/api/coding-agents/sessions/metadata', async (req: Request, res: Response) => {
+  try {
+    const size = parseInt(req.query.size as string) || 100;
+    const from = parseInt(req.query.from as string) || 0;
+    const storage = getStorageModule();
+    const result = await storage.sessionMetadata.list({ size, from });
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/server/routes/storage/admin.ts
+++ b/server/routes/storage/admin.ts
@@ -14,7 +14,7 @@
 import { Router, Request, Response } from 'express';
 import { isStorageAvailable, requireStorageClient, INDEXES } from '../../middleware/storageClient.js';
 import { INDEX_MAPPINGS } from '../../constants/indexMappings';
-import { getStorageModule, testStorageConnection, isFileStorage, setStorageModule, getStorageState, OpenSearchStorageModule, FileStorageModule } from '../../adapters/index.js';
+import { getStorageModule, testStorageConnection, isFileStorage, setStorageModule, getStorageState, OpenSearchStorageModule, FileStorageModule, FileSessionMetadataOperations } from '../../adapters/index.js';
 import type { StorageState } from '../../adapters/index.js';
 import { resolveStorageConfig } from '../../middleware/dataSourceConfig.js';
 import { createOpenSearchClient, configToCacheKey } from '../../services/opensearchClientFactory.js';
@@ -315,7 +315,7 @@ router.post('/api/storage/config/storage', async (req: Request, res: Response) =
       error: null,
       configuredEndpoint: endpoint,
     };
-    setStorageModule(new OpenSearchStorageModule(client), state);
+    setStorageModule(new OpenSearchStorageModule(client, new FileSessionMetadataOperations()), state);
 
     const hasFixFailures = setupResult.fixResults?.some((f) => f.status === 'failed') ?? false;
     const hadIssues = setupResult.validationResults.some((r) => r.status === 'needs_reindex');

--- a/server/routes/traces.ts
+++ b/server/routes/traces.ts
@@ -11,7 +11,7 @@
  */
 
 import { Request, Response, Router } from 'express';
-import { fetchTraces, checkTracesHealth, classifyOpenSearchError } from '../services/tracesService.js';
+import { fetchTraces, checkTracesHealth, classifyOpenSearchError, type ErrorCategory } from '../services/tracesService.js';
 import {
   getSampleSpansForRunIds,
   getSampleSpansByTraceId,
@@ -31,6 +31,10 @@ const router = Router();
 router.post('/api/traces', async (req: Request, res: Response) => {
   try {
     const { traceId, runIds, sessionId, startTime, endTime, size = 100, serviceName, textSearch, cursor } = req.body;
+
+    if (sessionId !== undefined && typeof sessionId !== 'string') {
+      return res.status(400).json({ error: 'sessionId must be a string' });
+    }
 
     // Validate request - allow time range queries for live tailing
     const hasTimeRange = startTime || endTime;
@@ -54,7 +58,7 @@ router.post('/api/traces', async (req: Request, res: Response) => {
     // 2. Query live OpenSearch traces (independent of sample logic)
     let realSpans: Span[] = [];
     let warning: string | undefined;
-    let warningCategory: string | undefined;
+    let warningCategory: ErrorCategory | undefined;
     let suggestion: string | undefined;
     let nextCursor: string | null = null;
     let hasMore: boolean = false;

--- a/server/services/storageInitializer.ts
+++ b/server/services/storageInitializer.ts
@@ -12,7 +12,7 @@
 
 import type { StorageClusterConfig } from '../../types/index.js';
 import type { StorageState } from '../adapters/index.js';
-import { setStorageModule, setStorageError, FileStorageModule, OpenSearchStorageModule } from '../adapters/index.js';
+import { setStorageModule, setStorageError, FileStorageModule, FileSessionMetadataOperations, OpenSearchStorageModule } from '../adapters/index.js';
 import { createOpenSearchClient, configToCacheKey } from './opensearchClientFactory.js';
 import { ensureIndexesWithValidation } from './indexInitializer.js';
 
@@ -73,7 +73,7 @@ export async function initializeStorageFromConfig(
       }
     }
 
-    const osModule = new OpenSearchStorageModule(client);
+    const osModule = new OpenSearchStorageModule(client, new FileSessionMetadataOperations());
     const state: StorageState = {
       backend: 'opensearch',
       configKey,

--- a/server/services/tracesService.ts
+++ b/server/services/tracesService.ts
@@ -73,7 +73,7 @@ export interface TracesResponse {
   hasMore?: boolean; // Whether more results are available
 }
 
-export type ErrorCategory = 'auth' | 'connection' | 'index_not_found' | 'unknown';
+export type ErrorCategory = 'auth' | 'connection' | 'index_not_found' | 'not_configured' | 'unknown';
 
 export interface HealthStatus {
   status: 'ok' | 'error';

--- a/services/client/index.ts
+++ b/services/client/index.ts
@@ -23,3 +23,9 @@ export {
   type ServerEvaluationReport,
   type ServerEvaluationResult,
 } from './evaluationApi';
+
+export {
+  getSessionMetadata,
+  putSessionMetadata,
+  listSessionMetadata,
+} from './sessionAnnotationsApi';

--- a/services/client/sessionAnnotationsApi.ts
+++ b/services/client/sessionAnnotationsApi.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @experimental Client API for session metadata.
+ * Generic GET/PUT for any sidecar data on coding agent sessions.
+ */
+
+import type { SessionMetadata } from '@/types';
+import { ENV_CONFIG } from '@/lib/config';
+
+const BASE = () => `${ENV_CONFIG.backendUrl}/api/coding-agents/sessions`;
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...options,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(body.error || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+/** Get session metadata (returns null if none exists) */
+export function getSessionMetadata(agentKind: string, sessionId: string): Promise<SessionMetadata | null> {
+  return fetchJson<SessionMetadata | null>(`${BASE()}/${agentKind}/${sessionId}/metadata`);
+}
+
+/** Upsert session metadata (merges with existing) */
+export function putSessionMetadata(agentKind: string, sessionId: string, data: Record<string, unknown>): Promise<SessionMetadata> {
+  return fetchJson<SessionMetadata>(`${BASE()}/${agentKind}/${sessionId}/metadata`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+/** List all sessions that have metadata */
+export function listSessionMetadata(options?: { size?: number; from?: number }): Promise<{ items: SessionMetadata[]; total: number }> {
+  const params = new URLSearchParams();
+  if (options?.size) params.set('size', String(options.size));
+  if (options?.from) params.set('from', String(options.from));
+  const qs = params.toString();
+  return fetchJson(`${BASE()}/metadata${qs ? `?${qs}` : ''}`);
+}

--- a/tests/e2e/session-metadata.spec.ts
+++ b/tests/e2e/session-metadata.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from './fixtures/test-fixtures';
+
+test.describe.configure({ mode: 'serial' });
+
+const testAgent = 'claude-code';
+const testSessionId = `e2e-test-${Date.now()}`;
+
+test.describe('Session Metadata API E2E', () => {
+  test('GET metadata for non-existent session returns null', async ({ request }) => {
+    const response = await request.get(
+      `/api/coding-agents/sessions/${testAgent}/nonexistent-e2e-session/metadata`
+    );
+    expect(response.ok()).toBe(true);
+    const data = await response.json();
+    expect(data).toBeNull();
+  });
+
+  test('PUT creates session metadata', async ({ request }) => {
+    const payload = {
+      status: 'interesting',
+      annotations: [{ id: 'ann-1', text: 'E2E test annotation', tags: ['e2e'] }],
+      bookmarked: true,
+    };
+
+    const response = await request.put(
+      `/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+      { data: payload }
+    );
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json();
+    expect(data.agentKind).toBe(testAgent);
+    expect(data.sessionId).toBe(testSessionId);
+    expect(data.status).toBe('interesting');
+    expect(data.bookmarked).toBe(true);
+    expect(data.annotations).toHaveLength(1);
+    expect(data.createdAt).toBeDefined();
+    expect(data.updatedAt).toBeDefined();
+  });
+
+  test('PUT merges with existing metadata', async ({ request }) => {
+    const response = await request.put(
+      `/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+      { data: { rating: 5, status: 'problematic' } }
+    );
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json();
+    expect(data.bookmarked).toBe(true); // preserved from first PUT
+    expect(data.rating).toBe(5);
+    expect(data.status).toBe('problematic');
+  });
+
+  test('PUT rejects non-object body', async ({ request }) => {
+    const response = await request.put(
+      `/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+      { data: [1, 2, 3] }
+    );
+    expect(response.status()).toBe(400);
+  });
+
+  test('GET returns previously stored metadata', async ({ request }) => {
+    const response = await request.get(
+      `/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`
+    );
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json();
+    expect(data.agentKind).toBe(testAgent);
+    expect(data.sessionId).toBe(testSessionId);
+    expect(data.status).toBe('problematic');
+    expect(data.bookmarked).toBe(true);
+    expect(data.rating).toBe(5);
+  });
+
+  test('GET list includes the test session', async ({ request }) => {
+    const response = await request.get('/api/coding-agents/sessions/metadata');
+    expect(response.ok()).toBe(true);
+
+    const data = await response.json();
+    expect(data.items).toBeDefined();
+    expect(data.total).toBeGreaterThanOrEqual(1);
+
+    const found = data.items.find((i: any) => i.sessionId === testSessionId);
+    expect(found).toBeDefined();
+  });
+});

--- a/tests/integration/server/routes/sessionMetadata.integration.test.ts
+++ b/tests/integration/server/routes/sessionMetadata.integration.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for session metadata API
+ *
+ * Tests the GET/PUT/LIST endpoints against a running server.
+ *
+ * Prerequisites:
+ *   - Backend server running: npm run dev:server
+ */
+
+const TEST_TIMEOUT = 30000;
+
+const getTestConfig = () => ({
+  backendUrl: process.env.TEST_BACKEND_URL || 'http://localhost:4011',
+});
+
+const checkBackend = async (backendUrl: string): Promise<boolean> => {
+  try {
+    const response = await fetch(`${backendUrl}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+describe('Session Metadata API Integration Tests', () => {
+  let backendAvailable = false;
+  let config: ReturnType<typeof getTestConfig>;
+  const testAgent = 'claude-code';
+  const testSessionId = `integ-test-${Date.now()}`;
+
+  beforeAll(async () => {
+    config = getTestConfig();
+    backendAvailable = await checkBackend(config.backendUrl);
+    if (!backendAvailable) {
+      console.warn('Backend not available at', config.backendUrl, '- skipping integration tests');
+    }
+  }, TEST_TIMEOUT);
+
+  afterAll(async () => {
+    // Clean up: there's no DELETE endpoint, but the file will be in agent-health-data/session-metadata/
+    // which is ephemeral test data
+  });
+
+  describe('GET /api/coding-agents/sessions/:agent/:sessionId/metadata', () => {
+    it('should return null for non-existent session', async () => {
+      if (!backendAvailable) return;
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/${testAgent}/nonexistent-session/metadata`
+      );
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data).toBeNull();
+    }, TEST_TIMEOUT);
+  });
+
+  describe('PUT /api/coding-agents/sessions/:agent/:sessionId/metadata', () => {
+    it('should create metadata for a session', async () => {
+      if (!backendAvailable) return;
+
+      const payload = {
+        status: 'interesting',
+        annotations: [{ id: 'a1', text: 'Test annotation', tags: ['test'] }],
+        bookmarked: true,
+      };
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.agentKind).toBe(testAgent);
+      expect(data.sessionId).toBe(testSessionId);
+      expect(data.status).toBe('interesting');
+      expect(data.bookmarked).toBe(true);
+      expect(data.annotations).toHaveLength(1);
+      expect(data.updatedAt).toBeDefined();
+      expect(data.createdAt).toBeDefined();
+    }, TEST_TIMEOUT);
+
+    it('should merge on subsequent PUT', async () => {
+      if (!backendAvailable) return;
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rating: 5, status: 'problematic' }),
+        }
+      );
+
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      // Merged fields
+      expect(data.bookmarked).toBe(true);
+      expect(data.rating).toBe(5);
+      expect(data.status).toBe('problematic');
+    }, TEST_TIMEOUT);
+
+    it('should reject non-object body', async () => {
+      if (!backendAvailable) return;
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify([1, 2, 3]),
+        }
+      );
+
+      expect(response.status).toBe(400);
+    }, TEST_TIMEOUT);
+  });
+
+  describe('GET /api/coding-agents/sessions/:agent/:sessionId/metadata (after PUT)', () => {
+    it('should return previously stored metadata', async () => {
+      if (!backendAvailable) return;
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/${testAgent}/${testSessionId}/metadata`
+      );
+
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.agentKind).toBe(testAgent);
+      expect(data.sessionId).toBe(testSessionId);
+      expect(data.status).toBe('problematic');
+      expect(data.bookmarked).toBe(true);
+      expect(data.rating).toBe(5);
+    }, TEST_TIMEOUT);
+  });
+
+  describe('GET /api/coding-agents/sessions/metadata (list)', () => {
+    it('should include the test session in results', async () => {
+      if (!backendAvailable) return;
+
+      const response = await fetch(
+        `${config.backendUrl}/api/coding-agents/sessions/metadata`
+      );
+
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.items).toBeDefined();
+      expect(data.total).toBeGreaterThanOrEqual(1);
+      const found = data.items.find((i: any) => i.sessionId === testSessionId);
+      expect(found).toBeDefined();
+    }, TEST_TIMEOUT);
+  });
+});

--- a/tests/unit/server/adapters/file/StorageModule.test.ts
+++ b/tests/unit/server/adapters/file/StorageModule.test.ts
@@ -77,4 +77,47 @@ describe('FileStorageModule', () => {
       });
     });
   });
+
+  describe('sessionMetadata', () => {
+    it('should return null for nonexistent session', async () => {
+      const result = await mod.sessionMetadata.get('claude-code', 'nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should put and get metadata', async () => {
+      const saved = await mod.sessionMetadata.put('claude-code', 's1', {
+        status: 'interesting',
+        notes: 'great session',
+        rating: 5,
+      });
+
+      expect(saved.agentKind).toBe('claude-code');
+      expect(saved.sessionId).toBe('s1');
+      expect(saved.status).toBe('interesting');
+      expect((saved as any).notes).toBe('great session');
+      expect((saved as any).rating).toBe(5);
+      expect(saved.updatedAt).toBeDefined();
+
+      const fetched = await mod.sessionMetadata.get('claude-code', 's1');
+      expect(fetched).toEqual(saved);
+    });
+
+    it('should merge on subsequent put', async () => {
+      await mod.sessionMetadata.put('claude-code', 's2', { status: 'normal', bookmarked: true });
+      const merged = await mod.sessionMetadata.put('claude-code', 's2', { status: 'problematic', rating: 3 });
+
+      expect((merged as any).bookmarked).toBe(true);
+      expect(merged.status).toBe('problematic');
+      expect((merged as any).rating).toBe(3);
+    });
+
+    it('should list all metadata docs', async () => {
+      await mod.sessionMetadata.put('claude-code', 'a', { x: 1 });
+      await mod.sessionMetadata.put('kiro', 'b', { x: 2 });
+
+      const { items, total } = await mod.sessionMetadata.list();
+      expect(total).toBe(2);
+      expect(items.map(i => i.sessionId).sort()).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/tests/unit/server/adapters/opensearch/StorageModule.test.ts
+++ b/tests/unit/server/adapters/opensearch/StorageModule.test.ts
@@ -96,7 +96,8 @@ describe('OpenSearchStorageModule', () => {
     const { OpenSearchStorageModule } = await import(
       '@/server/adapters/opensearch/StorageModule'
     );
-    mod = new OpenSearchStorageModule(mockClient as any);
+    const mockSessionMetadata = { get: jest.fn(), put: jest.fn(), list: jest.fn() };
+    mod = new OpenSearchStorageModule(mockClient as any, mockSessionMetadata as any);
   });
 
   // ==========================================================================

--- a/tests/unit/server/routes/index.test.ts
+++ b/tests/unit/server/routes/index.test.ts
@@ -31,6 +31,7 @@ jest.mock('@/server/routes/observability', () => ({ __esModule: true, default: '
 jest.mock('@/server/routes/config', () => ({ __esModule: true, default: 'configRoutes' }));
 jest.mock('@/server/routes/evaluation', () => ({ __esModule: true, default: 'evaluationRoutes' }));
 jest.mock('@/server/routes/debug', () => ({ __esModule: true, default: 'debugRoutes' }));
+jest.mock('@/server/routes/sessionAnnotations', () => ({ __esModule: true, default: 'sessionAnnotationsRoutes' }));
 
 describe('Routes Aggregator', () => {
   beforeEach(() => {

--- a/tests/unit/server/routes/storage/admin.test.ts
+++ b/tests/unit/server/routes/storage/admin.test.ts
@@ -96,6 +96,7 @@ jest.mock('@/server/adapters/index', () => ({
   }),
   OpenSearchStorageModule: jest.fn().mockImplementation(() => ({ type: 'opensearch' })),
   FileStorageModule: jest.fn().mockImplementation(() => ({ type: 'file' })),
+  FileSessionMetadataOperations: jest.fn().mockImplementation(() => ({ type: 'file-session-metadata' })),
 }));
 
 // Mock indexInitializer

--- a/tests/unit/server/services/observioAgent.test.ts
+++ b/tests/unit/server/services/observioAgent.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * observioAgent tests
+ *
+ * Note: The real observioAgent uses import.meta.url which Jest cannot handle.
+ * These tests verify the mock behavior and serve as documentation for expected API.
+ * The actual implementation is tested via integration tests.
+ */
+
+import {
+  OBSERVIO_PORT,
+  findObservioRoot,
+  isPortFree,
+  spawnObservioAgent,
+  killObservioAgent,
+} from '@/server/services/observioAgent';
+
+describe('observioAgent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('OBSERVIO_PORT', () => {
+    it('exports the default port constant', () => {
+      expect(OBSERVIO_PORT).toBe(3001);
+    });
+  });
+
+  describe('findObservioRoot', () => {
+    it('returns null by default (not found)', () => {
+      const result = findObservioRoot();
+      expect(result).toBeNull();
+    });
+
+    it('can be configured to return a path', () => {
+      (findObservioRoot as jest.Mock).mockReturnValueOnce('/fake/observio-sample-agent');
+      expect(findObservioRoot()).toBe('/fake/observio-sample-agent');
+    });
+  });
+
+  describe('isPortFree', () => {
+    it('resolves true by default (port is free)', async () => {
+      const result = await isPortFree(3001);
+      expect(result).toBe(true);
+    });
+
+    it('can be configured to report port in use', async () => {
+      (isPortFree as jest.Mock).mockResolvedValueOnce(false);
+      const result = await isPortFree(3001);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('spawnObservioAgent', () => {
+    it('returns null by default (deps not installed)', () => {
+      const result = spawnObservioAgent('/fake/dir');
+      expect(result).toBeNull();
+      expect(spawnObservioAgent).toHaveBeenCalledWith('/fake/dir');
+    });
+
+    it('can be configured to return a child process', () => {
+      const mockChild = { pid: 12345, killed: false, kill: jest.fn() };
+      (spawnObservioAgent as jest.Mock).mockReturnValueOnce(mockChild);
+      const result = spawnObservioAgent('/fake/dir');
+      expect(result).toEqual(mockChild);
+    });
+  });
+
+  describe('killObservioAgent', () => {
+    it('resolves false by default (nothing to kill)', async () => {
+      const result = await killObservioAgent();
+      expect(result).toBe(false);
+    });
+
+    it('can be configured to report successful kill', async () => {
+      (killObservioAgent as jest.Mock).mockResolvedValueOnce(true);
+      const result = await killObservioAgent(3001);
+      expect(result).toBe(true);
+    });
+
+    it('accepts optional port parameter', async () => {
+      await killObservioAgent(4000);
+      expect(killObservioAgent).toHaveBeenCalledWith(4000);
+    });
+  });
+});

--- a/tests/unit/server/services/storageInitializer.test.ts
+++ b/tests/unit/server/services/storageInitializer.test.ts
@@ -20,6 +20,7 @@ jest.mock('@/server/adapters/index', () => ({
   setStorageModule: mockSetStorageModule,
   setStorageError: mockSetStorageError,
   FileStorageModule: jest.fn().mockImplementation(() => ({ type: 'file' })),
+  FileSessionMetadataOperations: jest.fn().mockImplementation(() => ({ type: 'file-session-metadata' })),
   OpenSearchStorageModule: jest.fn().mockImplementation(() => ({ type: 'opensearch' })),
 }));
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -240,6 +240,19 @@ export interface RunAnnotation {
   author?: string;
 }
 
+/**
+ * @experimental Generic sidecar metadata for coding agent sessions.
+ * One document per session — stores annotations, status, tags, or any
+ * user-defined fields. The shape is intentionally open so callers can
+ * store whatever debug/analysis data they need.
+ */
+export interface SessionMetadata {
+  agentKind: string;
+  sessionId: string;
+  /** Open-ended — callers define the schema. */
+  [key: string]: unknown;
+}
+
 // Metrics status for trace-mode runs (traces take ~5 min to propagate)
 export type MetricsStatus = 'pending' | 'calculating' | 'ready' | 'error';
 


### PR DESCRIPTION
## Summary
- **Session metadata API** (`@experimental`): Generic GET/PUT/LIST sidecar storage for annotating read-only JSONL coding agent sessions. File-based storage at `agent-health-data/session-metadata/`. Includes UI Annotations tab in session detail panel.
- **OTel instrumentation skill**: Claude Code skill (`/instrument-otel`) and comprehensive guide (`docs/INSTRUMENT_WITH_OTEL.md`) for instrumenting agents with OpenTelemetry GenAI semantic conventions.
- **CFN resource tags**: Consistent `agent-health: observability` + `ManagedBy: AgentHealthCFN` tags on all stack resources (IAM roles, Lambda, API Gateway, OSIS pipelines, OpenSearch domain) for cost tracking via AWS Cost Explorer.
- **CFN FGAC role mapping**: Auto-maps IAM roles to OpenSearch backend roles via custom resource during stack create/update.

## Test plan
- [x] Unit tests for file storage adapter (session metadata CRUD)
- [x] Unit tests for OpenSearch storage adapter mock
- [x] Unit tests for route registration and storage initializer
- [x] Integration tests against running server (6 tests)
- [x] E2E Playwright test for session metadata API
- [x] Manual smoke test via curl (GET null, PUT create, PUT merge, LIST)
- [ ] Deploy CFN stack update to verify tags appear in Cost Explorer
- [ ] Verify Annotations tab in UI with real session data

🤖 Generated with [Claude Code](https://claude.com/claude-code)