### PR TITLE
fix: use single source of truth for connector types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- Connector type drift: use single source of truth (`CONNECTOR_TYPE_INFO`) in server validation and Settings UI instead of hardcoded arrays ([#176](https://github.com/opensearch-project/agent-health/pull/176))
+
 ## [0.4.0] - 2025-05-05
 
 ### Fixed

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
   type ConfigStatus,
   type SaveStorageConfigResult,
 } from '@/lib/dataSourceConfig';
-import { DEFAULT_CONFIG, refreshConfig, CONNECTOR_TYPE_INFO, ConnectorTypeInfo } from '@/lib/constants';
+import { DEFAULT_CONFIG, refreshConfig, CONNECTOR_TYPE_INFO, type ConnectorTypeInfo } from '@/lib/constants';
 import { ENV_CONFIG } from '@/lib/config';
 
 interface StorageStats {
@@ -1048,7 +1048,7 @@ export const SettingsPage: React.FC = () => {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type, info]) => (
+                    {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type]) => (
                       <SelectItem key={type} value={type}>
                         {type === 'agui-streaming' ? `${type} (default)` : type}
                       </SelectItem>
@@ -1119,7 +1119,7 @@ export const SettingsPage: React.FC = () => {
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type, info]) => (
+                            {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type]) => (
                               <SelectItem key={type} value={type}>
                                 {type === 'agui-streaming' ? `${type} (default)` : type}
                               </SelectItem>

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
   type ConfigStatus,
   type SaveStorageConfigResult,
 } from '@/lib/dataSourceConfig';
-import { DEFAULT_CONFIG, refreshConfig } from '@/lib/constants';
+import { DEFAULT_CONFIG, refreshConfig, CONNECTOR_TYPE_INFO, ConnectorTypeInfo } from '@/lib/constants';
 import { ENV_CONFIG } from '@/lib/config';
 
 interface StorageStats {
@@ -1048,14 +1048,17 @@ export const SettingsPage: React.FC = () => {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="agui-streaming">agui-streaming (default)</SelectItem>
-                    <SelectItem value="rest">rest</SelectItem>
-                    <SelectItem value="litellm">litellm</SelectItem>
-                    <SelectItem value="subprocess">subprocess</SelectItem>
-                    <SelectItem value="claude-code">claude-code</SelectItem>
-                    <SelectItem value="mock">mock</SelectItem>
+                    {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type, info]) => (
+                      <SelectItem key={type} value={type}>
+                        {type === 'agui-streaming' ? `${type} (default)` : type}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
+                <p className="text-xs text-muted-foreground mt-1">{CONNECTOR_TYPE_INFO[newConnectorType]?.description}</p>
+                {CONNECTOR_TYPE_INFO[newConnectorType]?.serverOnly && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">Server-only — runs via CLI or benchmark runner, not from the browser UI.</p>
+                )}
               </div>
               <div className="flex items-center gap-2">
                 <Switch
@@ -1116,14 +1119,17 @@ export const SettingsPage: React.FC = () => {
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="agui-streaming">agui-streaming (default)</SelectItem>
-                            <SelectItem value="rest">rest</SelectItem>
-                            <SelectItem value="litellm">litellm</SelectItem>
-                            <SelectItem value="subprocess">subprocess</SelectItem>
-                            <SelectItem value="claude-code">claude-code</SelectItem>
-                            <SelectItem value="mock">mock</SelectItem>
+                            {(Object.entries(CONNECTOR_TYPE_INFO) as [ConnectorProtocol, ConnectorTypeInfo][]).map(([type, info]) => (
+                              <SelectItem key={type} value={type}>
+                                {type === 'agui-streaming' ? `${type} (default)` : type}
+                              </SelectItem>
+                            ))}
                           </SelectContent>
                         </Select>
+                        <p className="text-xs text-muted-foreground mt-1">{CONNECTOR_TYPE_INFO[newConnectorType]?.description}</p>
+                        {CONNECTOR_TYPE_INFO[newConnectorType]?.serverOnly && (
+                          <p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">Server-only — runs via CLI or benchmark runner, not from the browser UI.</p>
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         <Switch

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -13,7 +13,8 @@
 
 import { Router, Request, Response } from 'express';
 import { loadConfigSync } from '@/lib/config/index';
-import type { AgentConfig, ModelConfig, ConnectorProtocol } from '@/types/index.js';
+import type { AgentConfig, ModelConfig } from '@/types/index.js';
+import { VALID_CONNECTOR_TYPES } from '@/lib/constants';
 import { addCustomAgent, removeCustomAgent, getCustomAgents } from '@/server/services/customAgentStore';
 import { getRemoteServers } from '@/server/services/codingAgents/remoteConfig';
 import fs from 'fs';
@@ -62,14 +63,7 @@ router.get('/api/agents', (req: Request, res: Response) => {
   }
 });
 
-const VALID_CONNECTOR_TYPES: ConnectorProtocol[] = [
-  'agui-streaming',
-  'rest',
-  'openai-compatible',
-  'subprocess',
-  'claude-code',
-  'mock',
-];
+// VALID_CONNECTOR_TYPES imported from @/lib/constants (single source of truth)
 
 /**
  * POST /api/agents/custom - Add a custom agent endpoint

--- a/tests/integration/server/routes/judge.integration.test.ts
+++ b/tests/integration/server/routes/judge.integration.test.ts
@@ -1,0 +1,608 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for the /api/judge endpoint
+ *
+ * Tests the POST /api/judge endpoint which evaluates agent trajectories
+ * against expected outcomes using an LLM judge.
+ *
+ * These tests use the built-in 'demo-model' (demo provider) so that no real
+ * AWS Bedrock credentials or external services are required.
+ *
+ * Requirements:
+ *   - Backend server running: npm run dev:server
+ *
+ * Run:
+ *   npm run test:integration -- --testPathPattern=judge.integration
+ */
+
+import { getTestBackendUrl } from '@/tests/integration/testConfig';
+
+const TEST_TIMEOUT = 30000;
+const BASE_URL = getTestBackendUrl();
+
+const checkBackend = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(`${BASE_URL}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build a sample trajectory with tool calls and a response step.
+ */
+function buildSampleTrajectory() {
+  return [
+    {
+      type: 'thinking',
+      content: 'I need to investigate the cluster health to identify the root cause.',
+    },
+    {
+      type: 'action',
+      toolName: 'get_cluster_health',
+      toolArgs: { cluster: 'production' },
+      content: 'Calling get_cluster_health tool',
+    },
+    {
+      type: 'tool_result',
+      toolName: 'get_cluster_health',
+      content: '{"status": "yellow", "active_shards": 150, "unassigned_shards": 3}',
+      status: 'SUCCESS',
+    },
+    {
+      type: 'response',
+      content: 'The root cause of the issue is 3 unassigned shards causing the cluster to be in yellow state.',
+    },
+  ];
+}
+
+/**
+ * Build a minimal trajectory (single step).
+ */
+function buildMinimalTrajectory() {
+  return [
+    {
+      type: 'response',
+      content: 'The cluster is healthy.',
+    },
+  ];
+}
+
+describe('Judge Route Integration Tests', () => {
+  let backendAvailable = false;
+
+  beforeAll(async () => {
+    backendAvailable = await checkBackend();
+    if (!backendAvailable) {
+      console.warn(
+        'Backend not available at',
+        BASE_URL,
+        '- skipping judge route integration tests'
+      );
+    }
+  }, TEST_TIMEOUT);
+
+  // ---------------------------------------------------------------------------
+  // Request Validation
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/judge - request validation', () => {
+    it(
+      'should return 400 when trajectory is missing',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/[Tt]rajectory/);
+        expect(data.error).toMatch(/required/i);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return 400 when trajectory is an empty array',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: [],
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/[Tt]rajectory/);
+        expect(data.error).toMatch(/non-empty/i);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return 400 when trajectory is not an array',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: 'not-an-array',
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/[Tt]rajectory/);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return 400 when both expectedOutcomes and expectedTrajectory are missing',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/expectedOutcomes|expectedTrajectory/);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return 400 when expectedOutcomes is an empty array and expectedTrajectory is missing',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: [],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/expectedOutcomes|expectedTrajectory/);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return 400 when evaluatorId refers to a non-existent evaluator',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+            evaluatorId: 'nonexistent-evaluator-xyz-999',
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data.error).toMatch(/[Ee]valuator.*not found/);
+      },
+      TEST_TIMEOUT
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Successful Evaluation (demo provider - no external calls)
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/judge - successful evaluation with demo provider', () => {
+    it(
+      'should return 200 with evaluation result containing passFailStatus',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify unassigned shards as root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(data.passFailStatus).toBeDefined();
+        expect(['passed', 'failed']).toContain(data.passFailStatus);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return metrics including accuracy',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify unassigned shards as root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(data.metrics).toBeDefined();
+        expect(typeof data.metrics.accuracy).toBe('number');
+        expect(data.metrics.accuracy).toBeGreaterThanOrEqual(0);
+        expect(data.metrics.accuracy).toBeLessThanOrEqual(100);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return llmJudgeReasoning as a string',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify unassigned shards as root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(typeof data.llmJudgeReasoning).toBe('string');
+        expect(data.llmJudgeReasoning.length).toBeGreaterThan(0);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return improvementStrategies as an array',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify unassigned shards as root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(Array.isArray(data.improvementStrategies)).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return metrics with faithfulness, latency_score, and trajectory_alignment_score',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify unassigned shards as root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(typeof data.metrics.faithfulness).toBe('number');
+        expect(typeof data.metrics.latency_score).toBe('number');
+        expect(typeof data.metrics.trajectory_alignment_score).toBe('number');
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should accept expectedTrajectory instead of expectedOutcomes',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedTrajectory: [
+              { type: 'action', toolName: 'get_cluster_health' },
+              { type: 'response', content: 'unassigned shards' },
+            ],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(data.passFailStatus).toBeDefined();
+        expect(['passed', 'failed']).toContain(data.passFailStatus);
+        expect(data.metrics).toBeDefined();
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should work with minimal trajectory (single step)',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildMinimalTrajectory(),
+            expectedOutcomes: ['Agent should check cluster health'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        expect(data.passFailStatus).toBeDefined();
+        expect(data.metrics).toBeDefined();
+        expect(data.llmJudgeReasoning).toBeDefined();
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should include mock evaluation note in reasoning for demo provider',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        // Demo provider includes a note about mock/simulated evaluation
+        expect(data.llmJudgeReasoning).toMatch(/[Mm]ock|simulated|demo/);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should accept optional logs field without error',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'demo-model',
+            logs: [
+              { timestamp: '2024-01-01T00:00:00Z', message: 'Error: connection timeout' },
+            ],
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data.passFailStatus).toBeDefined();
+      },
+      TEST_TIMEOUT
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Response format validation
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/judge - response format', () => {
+    it(
+      'should return a complete evaluation result with all expected fields',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: [
+              'Agent should use diagnostic tools',
+              'Agent should identify unassigned shards',
+            ],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        // Top-level fields
+        expect(data).toHaveProperty('passFailStatus');
+        expect(data).toHaveProperty('metrics');
+        expect(data).toHaveProperty('llmJudgeReasoning');
+        expect(data).toHaveProperty('improvementStrategies');
+
+        // passFailStatus is a valid value
+        expect(['passed', 'failed']).toContain(data.passFailStatus);
+
+        // metrics is an object with numeric values
+        expect(typeof data.metrics).toBe('object');
+        expect(typeof data.metrics.accuracy).toBe('number');
+
+        // llmJudgeReasoning is a non-empty string
+        expect(typeof data.llmJudgeReasoning).toBe('string');
+        expect(data.llmJudgeReasoning.length).toBeGreaterThan(0);
+
+        // improvementStrategies is an array
+        expect(Array.isArray(data.improvementStrategies)).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should return improvement strategies with correct structure when evaluation fails',
+      async () => {
+        if (!backendAvailable) return;
+
+        // Use a trajectory without tool calls to increase chance of "failed" result
+        const weakTrajectory = [
+          {
+            type: 'response',
+            content: 'I think the issue might be something.',
+          },
+        ];
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: weakTrajectory,
+            expectedOutcomes: [
+              'Agent should use multiple diagnostic tools',
+              'Agent should identify specific root cause with evidence',
+              'Agent should provide detailed remediation steps',
+            ],
+            modelId: 'demo-model',
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+
+        // Whether passed or failed, improvementStrategies should be a valid array
+        expect(Array.isArray(data.improvementStrategies)).toBe(true);
+
+        // If there are strategies, verify their structure
+        if (data.improvementStrategies.length > 0) {
+          const strategy = data.improvementStrategies[0];
+          expect(strategy).toHaveProperty('category');
+          expect(strategy).toHaveProperty('issue');
+          expect(strategy).toHaveProperty('recommendation');
+          expect(strategy).toHaveProperty('priority');
+          expect(['high', 'medium', 'low']).toContain(strategy.priority);
+        }
+      },
+      TEST_TIMEOUT
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/judge - error handling', () => {
+    it(
+      'should return 500 when an unknown modelId with bedrock provider is used (no credentials)',
+      async () => {
+        if (!backendAvailable) return;
+
+        // This will try to call Bedrock with an unknown model, which should fail
+        // unless the test environment has AWS credentials configured
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            trajectory: buildSampleTrajectory(),
+            expectedOutcomes: ['Agent should identify the root cause'],
+            modelId: 'nonexistent-model-id-xyz',
+          }),
+        });
+
+        // Should either be 500 (bedrock failure) or 200 (if somehow it resolves to demo)
+        // The key is it doesn't crash the server
+        expect([200, 500]).toContain(response.status);
+
+        if (response.status === 500) {
+          const data = await response.json();
+          expect(data.error).toBeDefined();
+          expect(typeof data.error).toBe('string');
+          expect(data.error).toMatch(/[Jj]udge evaluation failed/);
+        }
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should handle malformed JSON body gracefully',
+      async () => {
+        if (!backendAvailable) return;
+
+        const response = await fetch(`${BASE_URL}/api/judge`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: 'not valid json {{{',
+        });
+
+        // Express JSON parser returns 400 for malformed JSON
+        expect(response.status).toBe(400);
+      },
+      TEST_TIMEOUT
+    );
+  });
+});

--- a/tests/integration/server/routes/remote-servers.integration.test.ts
+++ b/tests/integration/server/routes/remote-servers.integration.test.ts
@@ -1,0 +1,404 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for remote servers endpoints (/api/remote-servers)
+ *
+ * These tests verify:
+ * 1. GET /api/remote-servers — lists servers with masked apiKey
+ * 2. POST /api/remote-servers — validates and persists new servers
+ * 3. DELETE /api/remote-servers/:name — removes servers
+ * 4. POST /api/remote-servers/:name/test — tests connectivity
+ *
+ * Uses mocked filesystem (fs) and fetch to avoid real I/O.
+ */
+
+import { jest } from '@jest/globals';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockExistsSync = jest.fn();
+const mockReadFileSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+
+jest.mock('fs', () => ({
+  existsSync: (...args: any[]) => mockExistsSync(...args),
+  readFileSync: (...args: any[]) => mockReadFileSync(...args),
+  writeFileSync: (...args: any[]) => mockWriteFileSync(...args),
+}));
+
+jest.mock('@/lib/config/index', () => ({
+  loadConfigSync: jest.fn().mockReturnValue({
+    agents: [],
+    models: {},
+  }),
+  loadConfig: jest.fn().mockResolvedValue({
+    agents: [],
+    models: {},
+  }),
+}));
+
+jest.mock('@/server/services/customAgentStore', () => ({
+  addCustomAgent: jest.fn(),
+  removeCustomAgent: jest.fn(),
+  getCustomAgents: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('@/server/services/codingAgents/remoteConfig', () => ({
+  getRemoteServers: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('@/lib/constants', () => ({
+  VALID_CONNECTOR_TYPES: ['agui-streaming', 'rest', 'ml-commons', 'holmesgpt'],
+}));
+
+jest.mock('@/lib/debug', () => ({
+  debug: jest.fn(),
+}));
+
+// Mock global fetch for connectivity tests
+const mockFetch = jest.fn() as jest.Mock;
+(globalThis as any).fetch = mockFetch;
+
+import type { Application } from 'express';
+import { getRemoteServers } from '@/server/services/codingAgents/remoteConfig';
+
+// Use require for CommonJS module compatibility in Jest
+const request = require('supertest');
+
+// Silence console output
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('Remote Servers Endpoints', () => {
+  let app: Application;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const express = require('express');
+    app = express();
+    app.use(express.json());
+
+    // Import the config router (which registers remote-servers routes)
+    const { default: configRouter } = await import('@/server/routes/config');
+    app.use(configRouter);
+
+    // Default: config file exists with empty remoteServers
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ remoteServers: [] }));
+    mockWriteFileSync.mockImplementation(() => {});
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GET /api/remote-servers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('GET /api/remote-servers', () => {
+    it('should return 200 with empty servers list when none configured', async () => {
+      (getRemoteServers as jest.Mock).mockReturnValue([]);
+
+      const res = await request(app).get('/api/remote-servers');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ servers: [] });
+    });
+
+    it('should return servers with apiKey masked as hasApiKey boolean', async () => {
+      (getRemoteServers as jest.Mock).mockReturnValue([
+        { name: 'prod', url: 'https://prod.example.com', apiKey: 'secret-key-123' },
+        { name: 'dev', url: 'http://localhost:4001' },
+      ]);
+
+      const res = await request(app).get('/api/remote-servers');
+
+      expect(res.status).toBe(200);
+      expect(res.body.servers).toHaveLength(2);
+      expect(res.body.servers[0]).toEqual({
+        name: 'prod',
+        url: 'https://prod.example.com',
+        hasApiKey: true,
+      });
+      expect(res.body.servers[1]).toEqual({
+        name: 'dev',
+        url: 'http://localhost:4001',
+        hasApiKey: false,
+      });
+      // apiKey should NOT be exposed
+      expect(res.body.servers[0]).not.toHaveProperty('apiKey');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // POST /api/remote-servers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('POST /api/remote-servers', () => {
+    it('should create a remote server and return 201', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'my-server', url: 'https://remote.example.com' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.server).toEqual({
+        name: 'my-server',
+        url: 'https://remote.example.com',
+        hasApiKey: false,
+      });
+      expect(mockWriteFileSync).toHaveBeenCalled();
+    });
+
+    it('should strip trailing slash from url', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'slashy', url: 'https://remote.example.com/' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.server.url).toBe('https://remote.example.com');
+    });
+
+    it('should persist apiKey when provided', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'secure', url: 'https://secure.example.com', apiKey: 'my-secret' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.server.hasApiKey).toBe(true);
+
+      // Verify config was written with apiKey
+      const writtenConfig = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+      const saved = writtenConfig.remoteServers[0];
+      expect(saved.apiKey).toBe('my-secret');
+    });
+
+    it('should return 400 when name is missing', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ url: 'https://example.com' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('name is required');
+    });
+
+    it('should return 400 when name is empty string', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: '   ', url: 'https://example.com' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('name is required');
+    });
+
+    it('should return 400 when url is missing', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'no-url' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('url is required');
+    });
+
+    it('should return 400 when url is empty string', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'empty-url', url: '  ' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('url is required');
+    });
+
+    it('should return 400 for invalid URL format', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'bad-url', url: 'not-a-url' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Invalid URL/i);
+    });
+
+    it('should return 400 for non-http URL', async () => {
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'ftp-server', url: 'ftp://files.example.com' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/http or https/i);
+    });
+
+    it('should return 409 when server name already exists', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ remoteServers: [{ name: 'existing', url: 'https://old.example.com' }] })
+      );
+
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'existing', url: 'https://new.example.com' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toContain('already exists');
+    });
+
+    it('should handle missing config file gracefully (creates from scratch)', async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const res = await request(app)
+        .post('/api/remote-servers')
+        .send({ name: 'first-server', url: 'https://first.example.com' });
+
+      expect(res.status).toBe(201);
+      expect(mockWriteFileSync).toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // DELETE /api/remote-servers/:name
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('DELETE /api/remote-servers/:name', () => {
+    it('should remove existing server and return 204', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          remoteServers: [
+            { name: 'to-remove', url: 'https://remove.example.com' },
+            { name: 'keep', url: 'https://keep.example.com' },
+          ],
+        })
+      );
+
+      const res = await request(app).delete('/api/remote-servers/to-remove');
+
+      expect(res.status).toBe(204);
+      const writtenConfig = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+      expect(writtenConfig.remoteServers).toHaveLength(1);
+      expect(writtenConfig.remoteServers[0].name).toBe('keep');
+    });
+
+    it('should return 404 when server not found', async () => {
+      mockReadFileSync.mockReturnValue(JSON.stringify({ remoteServers: [] }));
+
+      const res = await request(app).delete('/api/remote-servers/nonexistent');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('not found');
+    });
+
+    it('should handle missing config file (empty servers list)', async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const res = await request(app).delete('/api/remote-servers/ghost');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('not found');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // POST /api/remote-servers/:name/test
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('POST /api/remote-servers/:name/test', () => {
+    beforeEach(() => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          remoteServers: [
+            { name: 'prod', url: 'https://prod.example.com', apiKey: 'secret' },
+            { name: 'dev', url: 'http://localhost:5000' },
+          ],
+        })
+      );
+    });
+
+    it('should return ok status when remote responds with agents', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ agents: [{ name: 'agent-1' }, { name: 'agent-2' }] }),
+      });
+
+      const res = await request(app).post('/api/remote-servers/prod/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok', agents: 2 });
+
+      // Verify fetch was called with correct URL and auth header
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://prod.example.com/api/coding-agents/available',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer secret' },
+        })
+      );
+    });
+
+    it('should not send Authorization header when no apiKey', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ agents: [] }),
+      });
+
+      const res = await request(app).post('/api/remote-servers/dev/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok', agents: 0 });
+
+      // No auth header
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:5000/api/coding-agents/available',
+        expect.objectContaining({
+          headers: {},
+        })
+      );
+    });
+
+    it('should return error status when remote returns non-ok response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+
+      const res = await request(app).post('/api/remote-servers/prod/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('error');
+      expect(res.body.message).toContain('503');
+    });
+
+    it('should return error status when fetch throws (connection refused)', async () => {
+      mockFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      const res = await request(app).post('/api/remote-servers/prod/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('error');
+      expect(res.body.message).toContain('ECONNREFUSED');
+    });
+
+    it('should return 404 when server name not found', async () => {
+      const res = await request(app).post('/api/remote-servers/unknown/test');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('not found');
+    });
+
+    it('should handle agents field missing in response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app).post('/api/remote-servers/dev/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok', agents: 0 });
+    });
+  });
+});

--- a/tests/integration/services/connectors/LangGraphConnector.integration.test.ts
+++ b/tests/integration/services/connectors/LangGraphConnector.integration.test.ts
@@ -1,0 +1,477 @@
+/* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for LangGraphConnector
+ *
+ * Tests the LangGraph REST connector logic end-to-end by mocking fetch.
+ * Verifies:
+ * 1. Correct payload construction (messages format)
+ * 2. URL construction (with/without threadId, graphId)
+ * 3. Response parsing (messages, tool calls, intermediate_steps)
+ * 4. Error handling for failed requests
+ * 5. Health check behavior
+ */
+
+import type { ConnectorAuth, ConnectorRequest } from '@/services/connectors/types';
+import type { TestCase } from '@/types';
+import { LangGraphConnector } from '@/services/connectors/langgraph/LangGraphConnector';
+
+describe('LangGraphConnector Integration Tests', () => {
+  let connector: LangGraphConnector;
+  let mockFetch: jest.Mock;
+
+  const makeTestCase = (prompt: string): TestCase => ({
+    id: 'tc-1',
+    name: 'Test Case',
+    initialPrompt: prompt,
+    expectedOutcomes: ['Identify issue'],
+    context: [],
+    labels: [],
+    version: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  const defaultAuth: ConnectorAuth = { type: 'bearer', token: 'test-token-123' };
+
+  beforeEach(() => {
+    connector = new LangGraphConnector();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('buildPayload', () => {
+    it('should construct messages-based payload from test case', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Analyze the error logs'),
+        modelId: 'gpt-4',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.input.messages).toEqual([
+        { role: 'user', content: 'Analyze the error logs' },
+      ]);
+      expect(payload.config.configurable.model).toBe('gpt-4');
+    });
+
+    it('should merge configurable options from connectorConfig', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'claude-3',
+        connectorConfig: {
+          configurable: { temperature: 0.5, custom_param: 'abc' },
+        },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.config.configurable).toEqual({
+        model: 'claude-3',
+        temperature: 0.5,
+        custom_param: 'abc',
+      });
+    });
+
+    it('should omit model from configurable when not provided', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: '',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      // modelId is falsy so it should not appear
+      expect(payload.config.configurable.model).toBeFalsy();
+    });
+  });
+
+  describe('execute', () => {
+    it('should call correct invoke URL without threadId', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: { messages: [{ type: 'ai', content: 'Done' }] },
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test prompt'),
+        modelId: 'model-1',
+        connectorConfig: { graphId: 'my-graph' },
+      };
+
+      await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/my-graph/invoke',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should call thread-based URL when threadId is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          values: { messages: [{ type: 'ai', content: 'Response' }] },
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+        connectorConfig: { threadId: 'thread-abc' },
+      };
+
+      await connector.execute('http://localhost:8123/', request, defaultAuth);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8123/threads/thread-abc/runs/wait',
+        expect.any(Object)
+      );
+    });
+
+    it('should default graphId to "agent"', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/agent/invoke',
+        expect.any(Object)
+      );
+    });
+
+    it('should include auth headers in request', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const headers = fetchCall[1].headers;
+      expect(headers['Authorization']).toBe('Bearer test-token-123');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should throw error on non-OK response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error: graph execution failed',
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await expect(
+        connector.execute('http://localhost:8123', request, defaultAuth)
+      ).rejects.toThrow('LangGraph request failed: 500 - Internal Server Error: graph execution failed');
+    });
+
+    it('should parse AI messages with tool calls into action steps', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: {
+            messages: [
+              {
+                type: 'ai',
+                content: '',
+                tool_calls: [
+                  { name: 'search_logs', args: { query: 'error', limit: 10 } },
+                ],
+              },
+              {
+                type: 'tool',
+                name: 'search_logs',
+                content: 'Found 3 errors',
+              },
+              {
+                type: 'ai',
+                content: 'Based on the logs, the issue is a timeout.',
+              },
+            ],
+          },
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('What is wrong?'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(result.trajectory).toHaveLength(3);
+      expect(result.trajectory[0].type).toBe('action');
+      expect(result.trajectory[0].toolName).toBe('search_logs');
+      expect(result.trajectory[0].toolArgs).toEqual({ query: 'error', limit: 10 });
+      expect(result.trajectory[1].type).toBe('tool_result');
+      expect(result.trajectory[1].content).toBe('Found 3 errors');
+      expect(result.trajectory[2].type).toBe('response');
+      expect(result.trajectory[2].content).toBe('Based on the logs, the issue is a timeout.');
+    });
+
+    it('should parse intermediate_steps format', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          intermediate_steps: [
+            [{ tool: 'get_metrics', tool_input: { metric: 'cpu' } }, 'CPU: 95%'],
+            [{ tool: 'get_metrics', tool_input: { metric: 'memory' } }, 'Memory: 80%'],
+          ],
+          output: 'High CPU usage detected.',
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Check system'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      // intermediate_steps produces action + tool_result pairs, plus the output string
+      expect(result.trajectory.length).toBeGreaterThanOrEqual(4);
+      const actions = result.trajectory.filter(s => s.type === 'action');
+      const toolResults = result.trajectory.filter(s => s.type === 'tool_result');
+      expect(actions).toHaveLength(2);
+      expect(toolResults).toHaveLength(2);
+      expect(actions[0].toolName).toBe('get_metrics');
+      expect(toolResults[0].content).toBe('CPU: 95%');
+    });
+
+    it('should handle array content in messages', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: {
+            messages: [
+              {
+                type: 'ai',
+                content: [
+                  { text: 'Part 1' },
+                  { text: 'Part 2' },
+                ],
+              },
+            ],
+          },
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(result.trajectory[0].content).toBe('Part 1\nPart 2');
+    });
+
+    it('should call onProgress and onRawEvent callbacks', async () => {
+      const responseData = {
+        output: { messages: [{ type: 'ai', content: 'Hello' }] },
+        run_id: 'run-123',
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const onProgress = jest.fn();
+      const onRawEvent = jest.fn();
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('http://localhost:8123', request, defaultAuth, onProgress, onRawEvent);
+
+      expect(onRawEvent).toHaveBeenCalledWith(responseData);
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'response', content: 'Hello' })
+      );
+    });
+
+    it('should return runId and metadata', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: { messages: [{ type: 'ai', content: 'Done' }] },
+          run_id: 'run-xyz',
+          thread_id: 'thread-456',
+        }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(result.runId).toBe('run-xyz');
+      expect(result.metadata?.graphId).toBe('agent');
+      expect(result.metadata?.threadId).toBe('thread-456');
+    });
+
+    it('should use pre-built payload when provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ output: { messages: [{ type: 'ai', content: 'OK' }] } }),
+      });
+
+      const customPayload = { input: { messages: [{ role: 'user', content: 'Custom' }] }, config: {} };
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Ignored'),
+        modelId: 'model-1',
+        payload: customPayload,
+      };
+
+      await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toEqual(customPayload);
+    });
+
+    it('should strip trailing slash from endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ output: { messages: [] } }),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('http://localhost:8123///', request, defaultAuth);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8123/assistants/agent/invoke',
+        expect.any(Object)
+      );
+    });
+
+    it('should fallback to JSON.stringify for unrecognized response', async () => {
+      const weirdData = { custom_field: 'weird value', no_messages: true };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => weirdData,
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('http://localhost:8123', request, defaultAuth);
+
+      expect(result.trajectory).toHaveLength(1);
+      expect(result.trajectory[0].type).toBe('response');
+      expect(result.trajectory[0].content).toContain('custom_field');
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should handle values.messages format (thread-based)', () => {
+      const steps = connector.parseResponse({
+        values: {
+          messages: [
+            { type: 'ai', content: 'Analysis complete.' },
+          ],
+        },
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Analysis complete.');
+    });
+
+    it('should handle direct messages array', () => {
+      const steps = connector.parseResponse({
+        messages: [
+          { role: 'assistant', content: 'Hello' },
+        ],
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+    });
+
+    it('should handle direct string output', () => {
+      const steps = connector.parseResponse({ output: 'Simple string output' });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Simple string output');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should return true when /ok endpoint responds 200', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      const result = await connector.healthCheck('http://localhost:8123', defaultAuth);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8123/ok',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should fall back to root endpoint when /ok fails', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error('Connection refused'))
+        .mockResolvedValueOnce({ ok: true });
+
+      const result = await connector.healthCheck('http://localhost:8123', defaultAuth);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return false when both endpoints fail', async () => {
+      mockFetch.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await connector.healthCheck('http://localhost:8123', defaultAuth);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('connector properties', () => {
+    it('should have correct type and name', () => {
+      expect(connector.type).toBe('langgraph');
+      expect(connector.name).toBe('LangGraph (REST)');
+      expect(connector.supportsStreaming).toBe(false);
+    });
+  });
+});

--- a/tests/integration/services/connectors/OpenAICompatibleConnector.integration.test.ts
+++ b/tests/integration/services/connectors/OpenAICompatibleConnector.integration.test.ts
@@ -1,0 +1,524 @@
+/* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for OpenAICompatibleConnector
+ *
+ * Tests the OpenAI-compatible connector logic end-to-end by mocking fetch.
+ * Verifies:
+ * 1. Correct Chat Completion payload construction
+ * 2. System message from context, user message from prompt
+ * 3. Tool definitions formatting
+ * 4. Response parsing (content, tool_calls, empty response)
+ * 5. Error handling for failed requests
+ */
+
+import type { ConnectorAuth, ConnectorRequest } from '@/services/connectors/types';
+import type { TestCase } from '@/types';
+import { OpenAICompatibleConnector } from '@/services/connectors/openai-compatible/OpenAICompatibleConnector';
+
+describe('OpenAICompatibleConnector Integration Tests', () => {
+  let connector: OpenAICompatibleConnector;
+  let mockFetch: jest.Mock;
+
+  const makeTestCase = (prompt: string, options?: Partial<TestCase>): TestCase => ({
+    id: 'tc-oai-1',
+    name: 'OpenAI Test Case',
+    initialPrompt: prompt,
+    expectedOutcomes: ['Provide analysis'],
+    context: [],
+    labels: [],
+    version: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...options,
+  });
+
+  const defaultAuth: ConnectorAuth = { type: 'bearer', token: 'sk-test-key-123' };
+
+  beforeEach(() => {
+    connector = new OpenAICompatibleConnector();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('buildPayload', () => {
+    it('should construct standard Chat Completion payload', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('What is the root cause?'),
+        modelId: 'gpt-4-turbo',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.model).toBe('gpt-4-turbo');
+      expect(payload.messages).toEqual([
+        { role: 'user', content: 'What is the root cause?' },
+      ]);
+      expect(payload.tools).toBeUndefined();
+    });
+
+    it('should add context as system message', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Analyze this', {
+          context: ['You are an RCA agent.', 'Focus on OpenSearch clusters.'],
+        }),
+        modelId: 'gpt-4',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.messages).toHaveLength(2);
+      expect(payload.messages[0]).toEqual({
+        role: 'system',
+        content: 'You are an RCA agent.\nFocus on OpenSearch clusters.',
+      });
+      expect(payload.messages[1]).toEqual({
+        role: 'user',
+        content: 'Analyze this',
+      });
+    });
+
+    it('should handle object context items by JSON stringifying them', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test', {
+          context: [{ key: 'value', nested: { a: 1 } }] as any,
+        }),
+        modelId: 'gpt-4',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.messages[0].role).toBe('system');
+      expect(payload.messages[0].content).toContain('"key":"value"');
+    });
+
+    it('should not add system message when context is empty', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test', { context: [] }),
+        modelId: 'gpt-4',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.messages).toHaveLength(1);
+      expect(payload.messages[0].role).toBe('user');
+    });
+
+    it('should include tools in OpenAI function format', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Find errors', {
+          tools: [
+            {
+              name: 'search_logs',
+              description: 'Search application logs',
+              parameters: {
+                type: 'object',
+                properties: { query: { type: 'string' } },
+              },
+            },
+            {
+              name: 'get_metrics',
+              description: 'Get system metrics',
+              parameters: {},
+            },
+          ],
+        } as any),
+        modelId: 'gpt-4',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.tools).toHaveLength(2);
+      expect(payload.tools[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'search_logs',
+          description: 'Search application logs',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+          },
+        },
+      });
+      expect(payload.tools[1].function.name).toBe('get_metrics');
+    });
+  });
+
+  describe('execute', () => {
+    const makeChatResponse = (content: string, extras?: any) => ({
+      id: 'chatcmpl-abc123',
+      object: 'chat.completion',
+      created: 1700000000,
+      model: 'gpt-4-turbo',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content, ...extras },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 100, total_tokens: 150 },
+    });
+
+    it('should send request to the correct endpoint with auth', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => makeChatResponse('Hello!'),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Hi'),
+        modelId: 'gpt-4',
+      };
+
+      await connector.execute(
+        'https://api.openai.com/v1/chat/completions',
+        request,
+        defaultAuth
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer sk-test-key-123',
+          }),
+        })
+      );
+    });
+
+    it('should parse content response into trajectory', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => makeChatResponse('The root cause is a memory leak in the indexing service.'),
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Diagnose the issue'),
+        modelId: 'gpt-4',
+      };
+
+      const result = await connector.execute(
+        'http://localhost:11434/v1/chat/completions',
+        request,
+        defaultAuth
+      );
+
+      expect(result.trajectory).toHaveLength(1);
+      expect(result.trajectory[0].type).toBe('response');
+      expect(result.trajectory[0].content).toBe('The root cause is a memory leak in the indexing service.');
+    });
+
+    it('should parse tool_calls in response', async () => {
+      const responseData = {
+        id: 'chatcmpl-xyz',
+        object: 'chat.completion',
+        created: 1700000000,
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'search_logs',
+                    arguments: '{"query": "OutOfMemoryError", "limit": 5}',
+                  },
+                },
+                {
+                  id: 'call_2',
+                  type: 'function',
+                  function: {
+                    name: 'get_cluster_health',
+                    arguments: '{}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Investigate OOM'),
+        modelId: 'gpt-4',
+      };
+
+      const result = await connector.execute('http://localhost/v1/chat/completions', request, defaultAuth);
+
+      expect(result.trajectory).toHaveLength(2);
+      expect(result.trajectory[0].type).toBe('action');
+      expect(result.trajectory[0].toolName).toBe('search_logs');
+      expect(result.trajectory[0].toolArgs).toEqual({ query: 'OutOfMemoryError', limit: 5 });
+      expect(result.trajectory[1].type).toBe('action');
+      expect(result.trajectory[1].toolName).toBe('get_cluster_health');
+      expect(result.trajectory[1].toolArgs).toEqual({});
+    });
+
+    it('should handle tool_calls with invalid JSON arguments gracefully', async () => {
+      const responseData = {
+        id: 'chatcmpl-bad',
+        object: 'chat.completion',
+        created: 1700000000,
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_bad',
+                  type: 'function',
+                  function: {
+                    name: 'broken_tool',
+                    arguments: 'not valid json {{{',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      const result = await connector.execute('http://localhost/v1/chat/completions', request, defaultAuth);
+
+      // Should not throw — falls back to raw string
+      expect(result.trajectory).toHaveLength(1);
+      expect(result.trajectory[0].type).toBe('action');
+      expect(result.trajectory[0].toolName).toBe('broken_tool');
+      expect(result.trajectory[0].toolArgs).toBe('not valid json {{{');
+    });
+
+    it('should throw on non-OK response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        text: async () => 'Rate limit exceeded. Please retry after 60s.',
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      await expect(
+        connector.execute('http://localhost/v1/chat/completions', request, defaultAuth)
+      ).rejects.toThrow('OpenAI-compatible request failed: 429 - Rate limit exceeded');
+    });
+
+    it('should throw on 401 unauthorized', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Invalid API key',
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      await expect(
+        connector.execute('http://localhost/v1/chat/completions', request, defaultAuth)
+      ).rejects.toThrow('OpenAI-compatible request failed: 401 - Invalid API key');
+    });
+
+    it('should return correct runId and metadata', async () => {
+      const responseData = makeChatResponse('Answer');
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      const result = await connector.execute('http://localhost/v1/chat/completions', request, defaultAuth);
+
+      expect(result.runId).toBe('chatcmpl-abc123');
+      expect(result.metadata?.model).toBe('gpt-4-turbo');
+      expect(result.metadata?.usage).toEqual({
+        prompt_tokens: 50,
+        completion_tokens: 100,
+        total_tokens: 150,
+      });
+      expect(result.metadata?.finishReason).toBe('stop');
+      expect(result.rawEvents).toEqual([responseData]);
+    });
+
+    it('should call onProgress and onRawEvent callbacks', async () => {
+      const responseData = makeChatResponse('Result');
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const onProgress = jest.fn();
+      const onRawEvent = jest.fn();
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      await connector.execute(
+        'http://localhost/v1/chat/completions',
+        request,
+        defaultAuth,
+        onProgress,
+        onRawEvent
+      );
+
+      expect(onRawEvent).toHaveBeenCalledWith(responseData);
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'response', content: 'Result' })
+      );
+    });
+
+    it('should use pre-built payload when provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => makeChatResponse('OK'),
+      });
+
+      const customPayload = {
+        model: 'custom-model',
+        messages: [{ role: 'user', content: 'Custom message' }],
+        temperature: 0.9,
+      };
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Ignored'),
+        modelId: 'ignored-model',
+        payload: customPayload,
+      };
+
+      await connector.execute('http://localhost/v1/chat/completions', request, defaultAuth);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toEqual(customPayload);
+    });
+
+    it('should work with api-key auth type', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => makeChatResponse('OK'),
+      });
+
+      const apiKeyAuth: ConnectorAuth = { type: 'api-key', token: 'my-api-key' };
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'gpt-4',
+      };
+
+      await connector.execute('http://localhost/v1/chat/completions', request, apiKeyAuth);
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers['X-API-Key']).toBe('my-api-key');
+    });
+
+    it('should work with no auth', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => makeChatResponse('OK'),
+      });
+
+      const noAuth: ConnectorAuth = { type: 'none' };
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'local-model',
+      };
+
+      await connector.execute('http://localhost:11434/v1/chat/completions', request, noAuth);
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers['Authorization']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should handle response with no choices', () => {
+      const steps = connector.parseResponse({ id: 'x', choices: [] });
+
+      // Falls through to no-choice branch
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+    });
+
+    it('should handle response with null content and no tool_calls', () => {
+      const steps = connector.parseResponse({
+        choices: [{ message: { role: 'assistant', content: null } }],
+      });
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('(empty response)');
+    });
+
+    it('should handle both content and tool_calls together', () => {
+      const steps = connector.parseResponse({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Let me search for that.',
+              tool_calls: [
+                { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } },
+              ],
+            },
+          },
+        ],
+      });
+
+      expect(steps).toHaveLength(2);
+      expect(steps[0].type).toBe('action');
+      expect(steps[0].toolName).toBe('search');
+      expect(steps[1].type).toBe('response');
+      expect(steps[1].content).toBe('Let me search for that.');
+    });
+  });
+
+  describe('connector properties', () => {
+    it('should have correct type and name', () => {
+      expect(connector.type).toBe('openai-compatible');
+      expect(connector.name).toBe('OpenAI-compatible');
+      expect(connector.supportsStreaming).toBe(false);
+    });
+  });
+});

--- a/tests/integration/services/connectors/StrandsConnector.integration.test.ts
+++ b/tests/integration/services/connectors/StrandsConnector.integration.test.ts
@@ -1,0 +1,556 @@
+/* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for StrandsConnector
+ *
+ * Tests the Strands connector logic end-to-end by mocking the AWS SDK.
+ * Verifies:
+ * 1. Correct payload construction from test case
+ * 2. AWS SDK client configuration with credentials
+ * 3. Streaming response parsing (traces + chunks)
+ * 4. Trace event parsing into trajectory steps
+ * 5. Error handling
+ * 6. Health check behavior
+ */
+
+import type { ConnectorAuth, ConnectorRequest } from '@/services/connectors/types';
+import type { TestCase } from '@/types';
+
+// Mock the AWS SDK modules
+const mockSend = jest.fn();
+const mockBedrockAgentRuntimeClient = jest.fn().mockImplementation(() => ({
+  send: mockSend,
+}));
+const mockInvokeAgentCommand = jest.fn().mockImplementation((params) => params);
+
+const mockBedrockAgentClient = jest.fn().mockImplementation(() => ({
+  send: mockSend,
+}));
+const mockGetAgentCommand = jest.fn().mockImplementation((params) => params);
+
+jest.mock('@aws-sdk/client-bedrock-agent-runtime', () => ({
+  BedrockAgentRuntimeClient: mockBedrockAgentRuntimeClient,
+  InvokeAgentCommand: mockInvokeAgentCommand,
+}));
+
+jest.mock('@aws-sdk/client-bedrock-agent', () => ({
+  BedrockAgentClient: mockBedrockAgentClient,
+  GetAgentCommand: mockGetAgentCommand,
+}));
+
+import { StrandsConnector } from '@/services/connectors/strands/StrandsConnector';
+
+describe('StrandsConnector Integration Tests', () => {
+  let connector: StrandsConnector;
+
+  const makeTestCase = (prompt: string): TestCase => ({
+    id: 'test-1',
+    name: 'Test Case',
+    initialPrompt: prompt,
+    expectedOutcomes: ['Find root cause'],
+    context: [],
+    labels: [],
+    version: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  const defaultAuth: ConnectorAuth = {
+    type: 'aws-sigv4',
+    awsRegion: 'us-west-2',
+    awsAccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    awsSecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    awsSessionToken: 'session-token-123',
+  };
+
+  beforeEach(() => {
+    connector = new StrandsConnector();
+    jest.clearAllMocks();
+  });
+
+  describe('buildPayload', () => {
+    it('should construct correct payload from test case', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Why is the cluster unhealthy?'),
+        modelId: 'anthropic.claude-3-sonnet',
+        connectorConfig: {
+          agentAliasId: 'MY_ALIAS',
+          sessionId: 'session-abc',
+          enableTrace: true,
+        },
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.agentAliasId).toBe('MY_ALIAS');
+      expect(payload.sessionId).toBe('session-abc');
+      expect(payload.inputText).toBe('Why is the cluster unhealthy?');
+      expect(payload.enableTrace).toBe(true);
+      expect(payload.agentId).toBe(''); // Set in execute()
+    });
+
+    it('should use default alias when not configured', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Analyze logs'),
+        modelId: 'model-1',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.agentAliasId).toBe('TSTALIASID');
+      expect(payload.enableTrace).toBe(true);
+    });
+
+    it('should generate a session ID when not provided', () => {
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test prompt'),
+        modelId: 'model-1',
+      };
+
+      const payload = connector.buildPayload(request);
+
+      expect(payload.sessionId).toMatch(/^eval-\d+-[a-z0-9]+$/);
+    });
+  });
+
+  describe('execute', () => {
+    // Helper to create an async iterable for the streaming response
+    function createAsyncIterable(events: any[]): AsyncIterable<any> {
+      return {
+        [Symbol.asyncIterator]() {
+          let index = 0;
+          return {
+            async next() {
+              if (index >= events.length) {
+                return { done: true, value: undefined };
+              }
+              return { done: false, value: events[index++] };
+            },
+          };
+        },
+      };
+    }
+
+    it('should configure AWS client with explicit credentials', async () => {
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([]) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+        connectorConfig: { agentAliasId: 'ALIAS1' },
+      };
+
+      await connector.execute('AGENT123', request, defaultAuth);
+
+      expect(mockBedrockAgentRuntimeClient).toHaveBeenCalledWith({
+        region: 'us-west-2',
+        credentials: {
+          accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+          secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+          sessionToken: 'session-token-123',
+        },
+      });
+    });
+
+    it('should use endpoint as agentId', async () => {
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([]) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('MY_AGENT_ID', request, defaultAuth);
+
+      expect(mockInvokeAgentCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'MY_AGENT_ID' })
+      );
+    });
+
+    it('should parse text chunks from streaming response', async () => {
+      const encoder = new TextEncoder();
+      const events = [
+        { chunk: { bytes: encoder.encode('Hello ') } },
+        { chunk: { bytes: encoder.encode('world!') } },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(result.trajectory).toHaveLength(1);
+      expect(result.trajectory[0].type).toBe('response');
+      expect(result.trajectory[0].content).toBe('Hello world!');
+    });
+
+    it('should parse orchestration trace events into trajectory steps', async () => {
+      const events = [
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                rationale: { text: 'I need to search the logs' },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                invocationInput: {
+                  actionGroupInvocationInput: {
+                    actionGroupName: 'LogSearch',
+                    apiPath: '/search',
+                    parameters: [
+                      { name: 'query', value: 'error' },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                observation: {
+                  actionGroupInvocationOutput: { text: 'Found 5 errors in logs' },
+                },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                observation: {
+                  finalResponse: { text: 'The root cause is a memory leak.' },
+                },
+              },
+            },
+          },
+        },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Why is the cluster slow?'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(result.trajectory.length).toBe(4);
+      expect(result.trajectory[0].type).toBe('thinking');
+      expect(result.trajectory[0].content).toBe('I need to search the logs');
+      expect(result.trajectory[1].type).toBe('action');
+      expect(result.trajectory[1].toolName).toBe('LogSearch::/search');
+      expect(result.trajectory[1].toolArgs).toEqual({ query: 'error' });
+      expect(result.trajectory[2].type).toBe('tool_result');
+      expect(result.trajectory[2].content).toBe('Found 5 errors in logs');
+      expect(result.trajectory[3].type).toBe('response');
+      expect(result.trajectory[3].content).toBe('The root cause is a memory leak.');
+    });
+
+    it('should parse pre-processing trace', async () => {
+      const events = [
+        {
+          trace: {
+            trace: {
+              preProcessingTrace: {
+                modelInvocationOutput: {
+                  parsedResponse: { isValid: true, rationale: 'Input is valid RCA query' },
+                },
+              },
+            },
+          },
+        },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Check health'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(result.trajectory[0].type).toBe('thinking');
+      expect(result.trajectory[0].content).toContain('Pre-processing: Input valid');
+      expect(result.trajectory[0].content).toContain('Input is valid RCA query');
+    });
+
+    it('should parse knowledge base lookup traces', async () => {
+      const events = [
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                invocationInput: {
+                  knowledgeBaseLookupInput: { text: 'OpenSearch cluster health' },
+                },
+              },
+            },
+          },
+        },
+        {
+          trace: {
+            trace: {
+              orchestrationTrace: {
+                observation: {
+                  knowledgeBaseLookupOutput: {
+                    retrievedReferences: [
+                      { content: { text: 'Reference content 1' }, location: { s3: 'doc1.pdf' } },
+                      { content: { text: 'Reference content 2' }, location: { s3: 'doc2.pdf' } },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Help'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(result.trajectory[0].type).toBe('action');
+      expect(result.trajectory[0].toolName).toBe('knowledge_base_lookup');
+      expect(result.trajectory[1].type).toBe('tool_result');
+      expect(result.trajectory[1].content).toContain('Retrieved 2 reference(s)');
+    });
+
+    it('should parse failure trace', async () => {
+      const events = [
+        {
+          trace: {
+            trace: {
+              failureTrace: { failureReason: 'Agent timed out' },
+            },
+          },
+        },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(result.trajectory[0].type).toBe('response');
+      expect(result.trajectory[0].content).toContain('Agent error: Agent timed out');
+    });
+
+    it('should call onProgress for each trajectory step', async () => {
+      const events = [
+        { trace: { trace: { orchestrationTrace: { rationale: { text: 'Thinking...' } } } } },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const onProgress = jest.fn();
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('AGENT1', request, defaultAuth, onProgress);
+
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'thinking', content: 'Thinking...' })
+      );
+    });
+
+    it('should call onRawEvent for each streaming event', async () => {
+      const event1 = { chunk: { bytes: new TextEncoder().encode('Hi') } };
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([event1]) });
+
+      const onRawEvent = jest.fn();
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      await connector.execute('AGENT1', request, defaultAuth, undefined, onRawEvent);
+
+      expect(onRawEvent).toHaveBeenCalledWith(event1);
+    });
+
+    it('should not add duplicate response step when trace already has final response', async () => {
+      const encoder = new TextEncoder();
+      const events = [
+        { trace: { trace: { orchestrationTrace: { observation: { finalResponse: { text: 'Done.' } } } } } },
+        { chunk: { bytes: encoder.encode('Done.') } },
+      ];
+
+      mockSend.mockResolvedValue({ completion: createAsyncIterable(events) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const result = await connector.execute('AGENT1', request, defaultAuth);
+
+      const responseSteps = result.trajectory.filter(s => s.type === 'response');
+      expect(responseSteps).toHaveLength(1);
+      expect(responseSteps[0].content).toBe('Done.');
+    });
+
+    it('should return correct metadata', async () => {
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([]) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+        connectorConfig: { agentAliasId: 'PROD_ALIAS', sessionId: 'sess-xyz' },
+      };
+
+      const result = await connector.execute('AGENT_ABC', request, defaultAuth);
+
+      expect(result.runId).toBe('sess-xyz');
+      expect(result.metadata).toEqual({
+        agentId: 'AGENT_ABC',
+        agentAliasId: 'PROD_ALIAS',
+        sessionId: 'sess-xyz',
+        region: 'us-west-2',
+      });
+    });
+
+    it('should use pre-built payload when provided', async () => {
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([]) });
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Ignored prompt'),
+        modelId: 'model-1',
+        payload: {
+          agentId: '',
+          agentAliasId: 'CUSTOM_ALIAS',
+          sessionId: 'custom-session',
+          inputText: 'Custom input text',
+          enableTrace: false,
+        },
+      };
+
+      await connector.execute('AGENT1', request, defaultAuth);
+
+      expect(mockInvokeAgentCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'AGENT1',
+          agentAliasId: 'CUSTOM_ALIAS',
+          inputText: 'Custom input text',
+          enableTrace: false,
+        })
+      );
+    });
+
+    it('should fall back to us-east-1 when no region provided', async () => {
+      mockSend.mockResolvedValue({ completion: createAsyncIterable([]) });
+      const originalRegion = process.env.AWS_REGION;
+      delete process.env.AWS_REGION;
+
+      const request: ConnectorRequest = {
+        testCase: makeTestCase('Test'),
+        modelId: 'model-1',
+      };
+
+      const authNoRegion: ConnectorAuth = { type: 'none' };
+      await connector.execute('AGENT1', request, authNoRegion);
+
+      expect(mockBedrockAgentRuntimeClient).toHaveBeenCalledWith(
+        expect.objectContaining({ region: 'us-east-1' })
+      );
+
+      if (originalRegion) process.env.AWS_REGION = originalRegion;
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should parse trace event from raw response', () => {
+      const raw = {
+        trace: {
+          trace: {
+            orchestrationTrace: {
+              rationale: { text: 'Analyzing...' },
+            },
+          },
+        },
+      };
+
+      const steps = connector.parseResponse(raw);
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('thinking');
+      expect(steps[0].content).toBe('Analyzing...');
+    });
+
+    it('should wrap string response as response step', () => {
+      const steps = connector.parseResponse('Final answer here');
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0].type).toBe('response');
+      expect(steps[0].content).toBe('Final answer here');
+    });
+
+    it('should return empty array for unrecognized data', () => {
+      const steps = connector.parseResponse({ unknown: true });
+      expect(steps).toHaveLength(0);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should return true when agent status is PREPARED', async () => {
+      mockSend.mockResolvedValue({ agent: { agentStatus: 'PREPARED' } });
+
+      const result = await connector.healthCheck('AGENT123', defaultAuth);
+
+      expect(result).toBe(true);
+      expect(mockGetAgentCommand).toHaveBeenCalledWith({ agentId: 'AGENT123' });
+    });
+
+    it('should return false when agent status is not PREPARED', async () => {
+      mockSend.mockResolvedValue({ agent: { agentStatus: 'CREATING' } });
+
+      const result = await connector.healthCheck('AGENT123', defaultAuth);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when SDK call throws', async () => {
+      mockSend.mockRejectedValue(new Error('Access denied'));
+
+      const result = await connector.healthCheck('AGENT123', defaultAuth);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('connector properties', () => {
+    it('should have correct type and name', () => {
+      expect(connector.type).toBe('strands');
+      expect(connector.name).toBe('Amazon Strands');
+      expect(connector.supportsStreaming).toBe(true);
+    });
+  });
+});

--- a/tests/unit/server/routes/config.test.ts
+++ b/tests/unit/server/routes/config.test.ts
@@ -291,7 +291,7 @@ describe('Config Routes', () => {
       expect(mockAddCustomAgent).not.toHaveBeenCalled();
     });
 
-    it('accepts all valid connectorType values from CONNECTOR_TYPE_INFO', () => {
+    it('accepts all valid connectorType values from VALID_CONNECTOR_TYPES', () => {
       const handler = getRouteHandler(configRoutes, 'post', '/api/agents/custom');
 
       // Use the shared constant — ensures test stays in sync with code

--- a/tests/unit/server/routes/config.test.ts
+++ b/tests/unit/server/routes/config.test.ts
@@ -7,6 +7,7 @@ import { Request, Response } from 'express';
 import configRoutes from '@/server/routes/config';
 import { loadConfigSync } from '@/lib/config/index';
 import { addCustomAgent, removeCustomAgent, getCustomAgents, clearCustomAgents } from '@/server/services/customAgentStore';
+import { VALID_CONNECTOR_TYPES } from '@/lib/constants';
 
 // Mock config loader
 jest.mock('@/lib/config/index', () => ({
@@ -290,11 +291,11 @@ describe('Config Routes', () => {
       expect(mockAddCustomAgent).not.toHaveBeenCalled();
     });
 
-    it('accepts all valid connectorType values', () => {
-      const validTypes = ['agui-streaming', 'rest', 'openai-compatible', 'subprocess', 'claude-code', 'mock'] as const;
+    it('accepts all valid connectorType values from CONNECTOR_TYPE_INFO', () => {
       const handler = getRouteHandler(configRoutes, 'post', '/api/agents/custom');
 
-      for (const connectorType of validTypes) {
+      // Use the shared constant — ensures test stays in sync with code
+      for (const connectorType of VALID_CONNECTOR_TYPES) {
         jest.clearAllMocks();
         const { req, res } = createMocks({
           name: 'Agent',
@@ -306,6 +307,34 @@ describe('Config Routes', () => {
         const addedAgent = mockAddCustomAgent.mock.calls[0][0];
         expect(addedAgent.connectorType).toBe(connectorType);
       }
+    });
+
+    it('accepts strands connector type', () => {
+      const { req, res } = createMocks({
+        name: 'Strands Agent',
+        endpoint: 'http://localhost:9000',
+        connectorType: 'strands',
+      });
+      const handler = getRouteHandler(configRoutes, 'post', '/api/agents/custom');
+      handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const addedAgent = mockAddCustomAgent.mock.calls[0][0];
+      expect(addedAgent.connectorType).toBe('strands');
+    });
+
+    it('accepts langgraph connector type', () => {
+      const { req, res } = createMocks({
+        name: 'LangGraph Agent',
+        endpoint: 'http://localhost:8000',
+        connectorType: 'langgraph',
+      });
+      const handler = getRouteHandler(configRoutes, 'post', '/api/agents/custom');
+      handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const addedAgent = mockAddCustomAgent.mock.calls[0][0];
+      expect(addedAgent.connectorType).toBe('langgraph');
     });
 
     it('coerces non-boolean useTraces to false (truthy non-true values)', () => {


### PR DESCRIPTION
## Summary
- Remove hardcoded connector type arrays from `server/routes/config.ts` and `components/SettingsPage.tsx`
- Import `VALID_CONNECTOR_TYPES` and `CONNECTOR_TYPE_INFO` from `@/lib/constants` (single source of truth)
- Fix Settings UI showing invalid `litellm` connector and missing `strands`, `langgraph`, `openai-compatible`
- Add connector description text and server-only warnings in Settings dropdown
- Update tests to use shared constant instead of hardcoded arrays

## Test plan
- [x] `npm run build:all` passes
- [x] `npm run test:all` passes (22 config route tests, agent utils tests)
- [x] Explicit test cases for `strands` and `langgraph` connector types
- [x] All valid connector types accepted via data-driven test using `VALID_CONNECTOR_TYPES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)