### PR TITLE
feat: enforce high coverage standards on PRs with ratchet and patch gates

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -15,8 +15,9 @@ coverage:
     # Overall project coverage (combines all flagged uploads)
     project:
       default:
-        target: 90%
-        threshold: 2%
+        # "auto" = ratchet: never allow overall coverage to decrease
+        target: auto
+        threshold: 1%
         if_ci_failed: error
         flags:
           - unit
@@ -25,8 +26,8 @@ coverage:
 
       # Unit tests coverage target
       unit:
-        target: 90%
-        threshold: 2%
+        target: auto
+        threshold: 1%
         flags:
           - unit
 
@@ -41,14 +42,15 @@ coverage:
       e2e:
         target: 50%
         threshold: 5%
+        informational: true  # Don't block PRs on E2E coverage
         flags:
           - e2e
 
-    # Per-patch (changed lines) coverage
+    # Per-patch (changed lines) coverage — ensures new code is tested
     patch:
       default:
         target: 90%
-        threshold: 2%
+        threshold: 5%
 
 # Flag definitions for different test suites
 flags:
@@ -59,6 +61,8 @@ flags:
       - lib/
       - cli/
       - types/
+      - components/
+      - hooks/
     carryforward: true
 
   integration:
@@ -66,17 +70,18 @@ flags:
       - services/
       - server/
       - lib/
+      - cli/
     carryforward: true
 
   e2e:
     paths:
       - components/
       - hooks/
-      - lib/
+      - services/client/
     carryforward: true
 
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,flags,components"
   behavior: default
   require_changes: false
   require_base: false
@@ -91,4 +96,33 @@ ignore:
   - "playwright-report/**"
   - "coverage/**"
   - "docs/**"
+  - "scripts/**"
+  - "deployment/**"
+  - "cli/demo/**"
   - "observio-sample-agent/**"
+
+# Component-level coverage breakdown shown in PR comments
+component_management:
+  individual_components:
+    - component_id: server
+      name: Backend (Server)
+      paths:
+        - server/**
+    - component_id: services
+      name: Services
+      paths:
+        - services/**
+    - component_id: cli
+      name: CLI
+      paths:
+        - cli/**
+    - component_id: ui
+      name: UI Components
+      paths:
+        - components/**
+        - hooks/**
+    - component_id: lib
+      name: Shared Libraries
+      paths:
+        - lib/**
+        - types/**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+<!-- What does this PR do and why? Keep it brief (1-3 bullets) -->
+
+-
+
+## Test Plan
+<!-- How was this tested? What tests were added/modified? -->
+
+- [ ] Unit tests added/updated for new logic
+- [ ] Integration tests added for new API endpoints or service changes
+- [ ] E2E tests added for new UI workflows (if applicable)
+- [ ] `npm run build:all && npm run test:all` passes locally
+
+## Coverage Checklist
+<!-- Codecov will enforce these automatically, but self-check before pushing -->
+
+- [ ] New/modified code has ≥ 90% line coverage (patch coverage)
+- [ ] Overall project coverage does not decrease
+- [ ] No untested critical paths (error handling, edge cases)
+
+## Compliance
+<!-- Required for OpenSearch project -->
+
+- [ ] All commits are signed off (DCO: `git commit -s`)
+- [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] New source files have SPDX license header
+
+---
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           files: coverage/lcov.info
           flags: unit
           name: unit-tests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -292,7 +292,7 @@ jobs:
           directory: coverage-integration/
           flags: integration
           name: integration-tests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

- **Codecov ratchet**: Switch project targets to `target: auto` so overall coverage can never decrease on any PR
- **Patch coverage gate**: New/changed lines must have ≥ 90% coverage (with 5% tolerance)
- **Component breakdown**: PR comments now show per-module coverage (Server, Services, CLI, UI, Lib)
- **CI hardening**: `fail_ci_if_error: true` for unit + integration Codecov uploads
- **PR template**: Added checklist reminding contributors about coverage, testing, and compliance

## Test plan

- [x] `npm run build:all` passes
- [x] `npm run test:all` passes (unit + integration + E2E)
- [x] Changes are config-only — no functional code modified
- [ ] Verify Codecov bot comments on this PR with component breakdown
- [ ] Confirm `codecov/patch` and `codecov/project` status checks appear

## Follow-up (manual)

- Add `codecov/patch` and `codecov/project` as **required status checks** in branch protection rules for `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)