### PR TITLE
fix: add EVAL category capsule to span viewer UI

### DIFF
--- a/cli/demo/sampleTraces.ts
+++ b/cli/demo/sampleTraces.ts
@@ -1644,10 +1644,81 @@ function generateBudgetTripVietnamSpans(): Span[] {
 }
 
 /**
+ * Generate eval spans for the Weekend Trip trace (demo-trace-001)
+ *
+ * Evaluation spans emitted by Agent Health after judging the agent's output.
+ * Uses OTel GenAI semantic conventions for evaluation:
+ * - test_suite_run: root eval span covering the full benchmark run
+ * - test_case: child span for a single test case evaluation result
+ *
+ * These spans share the same traceId as the agent spans so they appear
+ * together in the trace viewer — matching real production behavior.
+ */
+function generateEvalSpans(): Span[] {
+  const traceId = 'demo-trace-001';
+  const baseTime = BASE_TIME + 9000; // After agent completes (8500ms)
+
+  return [
+    // Root eval span: test_suite_run
+    {
+      traceId,
+      spanId: 'span-001-eval-suite',
+      name: 'test_suite_run Travel Planning Benchmark',
+      startTime: new Date(baseTime).toISOString(),
+      endTime: new Date(baseTime + 3200).toISOString(),
+      duration: 3200,
+      status: 'OK',
+      attributes: {
+        'service.name': 'agent-health-eval',
+        'gen_ai.operation.name': 'evaluation',
+        'test.suite.name': 'Travel Planning Benchmark',
+        'test.suite.run.id': 'demo-eval-run-001',
+      },
+    },
+    // Child eval span: test_case
+    {
+      traceId,
+      spanId: 'span-001-eval-case',
+      parentSpanId: 'span-001-eval-suite',
+      name: 'test_case',
+      startTime: new Date(baseTime + 100).toISOString(),
+      endTime: new Date(baseTime + 3100).toISOString(),
+      duration: 3000,
+      status: 'OK',
+      attributes: {
+        'service.name': 'agent-health-eval',
+        'gen_ai.operation.name': 'evaluation',
+        'test.suite.name': 'Travel Planning Benchmark',
+        'test.suite.run.id': 'demo-eval-run-001',
+        'test.case.id': 'demo-tc-001',
+        'test.case.name': 'Weekend Getaway Planning',
+        'test.case.result.status': 'pass',
+        'test.case.input': 'Plan a weekend getaway to Napa Valley for two people',
+        'test.case.output': 'Here is your complete Napa Valley weekend itinerary...',
+        'gen_ai.request.id': 'demo-agent-run-001',
+      },
+      events: [
+        {
+          name: 'gen_ai.evaluation.result',
+          time: new Date(baseTime + 3000).toISOString(),
+          attributes: {
+            'gen_ai.evaluation.name': 'accuracy',
+            'gen_ai.evaluation.score.value': 0.92,
+            'gen_ai.evaluation.score.label': 'pass',
+            'gen_ai.evaluation.explanation': 'Agent correctly identified weather, events, and bookings for Napa Valley weekend trip.',
+          },
+        },
+      ],
+    },
+  ];
+}
+
+/**
  * All sample trace spans
  */
 export const SAMPLE_TRACE_SPANS: Span[] = [
   ...generateWeekendTripSpans(),
+  ...generateEvalSpans(),
   ...generateJapanTripSpans(),
   ...generateBudgetTripSpans(),
   ...generateBudgetTripVietnamSpans(),

--- a/components/traces/TraceFlyoutContent.tsx
+++ b/components/traces/TraceFlyoutContent.tsx
@@ -30,6 +30,7 @@ import {
   List,
   GitBranch,
   Info,
+  ClipboardCheck,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -209,6 +210,7 @@ export const TraceFlyoutContent: React.FC<TraceFlyoutContentProps> = ({
       if (category === 'agent') return name.includes('agent');
       if (category === 'llm') return name.includes('llm') || name.includes('bedrock') || name.includes('converse');
       if (category === 'tool') return name.includes('tool') || span.attributes?.['gen_ai.tool.name'];
+      if (category === 'eval') return span.attributes?.['gen_ai.operation.name'] === 'evaluation' || name.includes('test_case') || name.includes('test_suite_run');
       if (category === 'error') return span.status === 'ERROR';
       return false;
     });
@@ -264,6 +266,10 @@ export const TraceFlyoutContent: React.FC<TraceFlyoutContentProps> = ({
         return isDarkMode
           ? { backgroundColor: 'rgba(245, 158, 11, 0.15)', color: 'rgb(251, 191, 36)', border: '1px solid rgba(245, 158, 11, 0.4)' }
           : { backgroundColor: 'rgb(254, 243, 199)', color: 'rgb(146, 64, 14)', border: '1px solid rgb(252, 211, 77)' };
+      case 'eval':
+        return isDarkMode
+          ? { backgroundColor: 'rgba(16, 185, 129, 0.15)', color: 'rgb(110, 231, 183)', border: '1px solid rgba(16, 185, 129, 0.4)' }
+          : { backgroundColor: 'rgb(209, 250, 229)', color: 'rgb(6, 95, 70)', border: '1px solid rgb(110, 231, 183)' };
       case 'error':
         return isDarkMode
           ? { backgroundColor: 'rgba(239, 68, 68, 0.15)', color: 'rgb(248, 113, 113)', border: '1px solid rgba(239, 68, 68, 0.4)' }
@@ -544,6 +550,47 @@ export const TraceFlyoutContent: React.FC<TraceFlyoutContentProps> = ({
                   <span className="font-normal">Tool Calls</span>
                   <span className="text-[10px] opacity-70 ml-auto">{formatDuration(spanStats.byCategory.tool.duration)}</span>
                   {expandedSummary === 'tool' ? (
+                    <ChevronDown size={11} />
+                  ) : (
+                    <ChevronRight size={11} />
+                  )}
+                </button>
+              )}
+              {spanStats.byCategory.eval?.count > 0 && (
+                <button
+                  onClick={() => handleSummaryClick('eval')}
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border-2 transition-all cursor-pointer flex-1"
+                  style={
+                    expandedSummary === 'eval'
+                      ? document.documentElement.classList.contains('dark')
+                        ? { backgroundColor: 'rgba(16, 185, 129, 0.25)', color: 'rgb(167, 243, 208)', border: '2px solid rgba(16, 185, 129, 0.6)' }
+                        : { backgroundColor: 'rgb(209, 250, 229)', color: 'rgb(6, 78, 59)', border: '2px solid rgb(52, 211, 153)' }
+                      : document.documentElement.classList.contains('dark')
+                        ? { backgroundColor: 'rgba(16, 185, 129, 0.12)', color: 'rgb(110, 231, 183)', border: '2px solid rgba(16, 185, 129, 0.35)' }
+                        : { backgroundColor: 'rgb(236, 253, 245)', color: 'rgb(6, 95, 70)', border: '2px solid rgb(110, 231, 183)' }
+                  }
+                  onMouseEnter={(e) => {
+                    if (expandedSummary !== 'eval') {
+                      const isDark = document.documentElement.classList.contains('dark');
+                      e.currentTarget.style.backgroundColor = isDark ? 'rgba(16, 185, 129, 0.2)' : 'rgb(209, 250, 229)';
+                      e.currentTarget.style.borderColor = isDark ? 'rgba(16, 185, 129, 0.5)' : 'rgb(52, 211, 153)';
+                      e.currentTarget.style.boxShadow = '0 4px 6px -1px rgba(0, 0, 0, 0.1)';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (expandedSummary !== 'eval') {
+                      const isDark = document.documentElement.classList.contains('dark');
+                      e.currentTarget.style.backgroundColor = isDark ? 'rgba(16, 185, 129, 0.12)' : 'rgb(236, 253, 245)';
+                      e.currentTarget.style.borderColor = isDark ? 'rgba(16, 185, 129, 0.35)' : 'rgb(110, 231, 183)';
+                      e.currentTarget.style.boxShadow = 'none';
+                    }
+                  }}
+                >
+                  <ClipboardCheck size={11} className="flex-shrink-0" />
+                  <span className="font-medium">{spanStats.byCategory.eval.count}</span>
+                  <span className="font-normal">Eval</span>
+                  <span className="text-[10px] opacity-70 ml-auto">{formatDuration(spanStats.byCategory.eval.duration)}</span>
+                  {expandedSummary === 'eval' ? (
                     <ChevronDown size={11} />
                   ) : (
                     <ChevronRight size={11} />

--- a/components/traces/TraceInfoView.tsx
+++ b/components/traces/TraceInfoView.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { Clock, Bot, MessageSquare, Wrench, XCircle, ChevronDown, ChevronRight, X } from 'lucide-react';
+import { Clock, Bot, MessageSquare, Wrench, XCircle, ChevronDown, ChevronRight, X, ClipboardCheck } from 'lucide-react';
 import { Span } from '@/types';
 import { cn } from '@/lib/utils';
 import { getTheme } from '@/lib/theme';
@@ -98,6 +98,7 @@ const TraceInfoView: React.FC<TraceInfoViewProps> = ({ spanTree, runId }) => {
       if (category === 'agent') return name.includes('agent');
       if (category === 'llm') return name.includes('llm') || name.includes('bedrock') || name.includes('converse');
       if (category === 'tool') return name.includes('tool') || span.attributes?.['gen_ai.tool.name'];
+      if (category === 'eval') return span.category === 'EVAL';
       if (category === 'error') return span.status === 'ERROR';
       return false;
     });
@@ -153,6 +154,10 @@ const TraceInfoView: React.FC<TraceInfoViewProps> = ({ spanTree, runId }) => {
         return isDarkMode
           ? { backgroundColor: 'rgba(245, 158, 11, 0.15)', color: 'rgb(251, 191, 36)', border: '1px solid rgba(245, 158, 11, 0.4)' }
           : { backgroundColor: 'rgb(254, 243, 199)', color: 'rgb(146, 64, 14)', border: '1px solid rgb(252, 211, 77)' };
+      case 'eval':
+        return isDarkMode
+          ? { backgroundColor: 'rgba(16, 185, 129, 0.15)', color: 'rgb(110, 231, 183)', border: '1px solid rgba(16, 185, 129, 0.4)' }
+          : { backgroundColor: 'rgb(209, 250, 229)', color: 'rgb(6, 95, 70)', border: '1px solid rgb(110, 231, 183)' };
       case 'error':
         return isDarkMode
           ? { backgroundColor: 'rgba(239, 68, 68, 0.15)', color: 'rgb(248, 113, 113)', border: '1px solid rgba(239, 68, 68, 0.4)' }
@@ -173,6 +178,8 @@ const TraceInfoView: React.FC<TraceInfoViewProps> = ({ spanTree, runId }) => {
         return 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-500/10 dark:text-purple-300 dark:border-purple-500/30';
       case 'tool':
         return 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-500/10 dark:text-amber-300 dark:border-amber-500/30';
+      case 'eval':
+        return 'bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-500/10 dark:text-emerald-300 dark:border-emerald-500/30';
       case 'error':
         return 'bg-red-100 text-red-800 border-red-300 dark:bg-red-500/10 dark:text-red-300 dark:border-red-500/30';
       default:
@@ -368,6 +375,27 @@ const TraceInfoView: React.FC<TraceInfoViewProps> = ({ spanTree, runId }) => {
               <span className="font-normal">Tool Calls</span>
               <span className="text-[10px] opacity-70 ml-auto">{formatDuration(spanStats.byCategory.tool.duration)}</span>
               {expandedSummary === 'tool' ? (
+                <ChevronDown size={11} />
+              ) : (
+                <ChevronRight size={11} />
+              )}
+            </button>
+          )}
+          {spanStats.byCategory.eval?.count > 0 && (
+            <button
+              onClick={() => handleSummaryClick('eval')}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border-2 transition-all cursor-pointer',
+                expandedSummary === 'eval'
+                  ? 'bg-emerald-100 text-emerald-900 border-emerald-400 dark:bg-emerald-500/20 dark:text-emerald-200 dark:border-emerald-500/50'
+                  : 'bg-emerald-50 text-emerald-800 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:border-emerald-500/30 hover:bg-emerald-100 hover:border-emerald-400 hover:shadow-md dark:hover:bg-emerald-500/20 dark:hover:border-emerald-500/50'
+              )}
+            >
+              <ClipboardCheck size={11} className="flex-shrink-0" />
+              <span className="font-medium">{spanStats.byCategory.eval.count}</span>
+              <span className="font-normal">Eval</span>
+              <span className="text-[10px] opacity-70 ml-auto">{formatDuration(spanStats.byCategory.eval.duration)}</span>
+              {expandedSummary === 'eval' ? (
                 <ChevronDown size={11} />
               ) : (
                 <ChevronRight size={11} />

--- a/tests/e2e/traces-eval-capsule.spec.ts
+++ b/tests/e2e/traces-eval-capsule.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from './fixtures/test-fixtures';
+
+test.describe('Eval Span Category Capsule', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/agent-traces');
+    await page.waitForTimeout(3000);
+  });
+
+  test('should display Eval capsule in span category pills when trace has eval spans', async ({ page }) => {
+    // The first demo trace (demo-trace-001) contains eval spans with
+    // gen_ai.operation.name=evaluation. Click it to open the flyout.
+    const traceRow = page.locator('tbody tr').first();
+    if (!await traceRow.isVisible().catch(() => false)) {
+      // No traces available (e.g. no demo data) — skip gracefully
+      return;
+    }
+
+    await traceRow.click();
+    await page.waitForTimeout(1500);
+
+    // The flyout should be open showing "Span category:" section.
+    // Look for the Eval pill button which contains text "Eval".
+    const evalPill = page.locator('button:has-text("Eval")').first();
+    await expect(evalPill).toBeVisible({ timeout: 5000 });
+
+    // Verify the pill shows a count (the number should be > 0)
+    const pillText = await evalPill.textContent();
+    expect(pillText).toContain('Eval');
+  });
+
+  test('should show Eval in the time distribution bar legend', async ({ page }) => {
+    // Click on the first trace row to open flyout
+    const traceRow = page.locator('tbody tr').first();
+    if (!await traceRow.isVisible().catch(() => false)) {
+      return;
+    }
+
+    await traceRow.click();
+    await page.waitForTimeout(1500);
+
+    // Switch to Info tab if available (in TraceFlyoutContent, default tab is timeline)
+    const infoTab = page.locator('button:has-text("Info"), [role="tab"]:has-text("Info")').first();
+    if (await infoTab.isVisible().catch(() => false)) {
+      await infoTab.click();
+      await page.waitForTimeout(500);
+    }
+
+    // The time distribution legend should include "EVAL" text
+    const evalLegend = page.locator('text=EVAL').first();
+    await expect(evalLegend).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Eval capsule should be expandable to show eval span details', async ({ page }) => {
+    const traceRow = page.locator('tbody tr').first();
+    if (!await traceRow.isVisible().catch(() => false)) {
+      return;
+    }
+
+    await traceRow.click();
+    await page.waitForTimeout(1500);
+
+    // Click the Eval pill to expand details
+    const evalPill = page.locator('button:has-text("Eval")').first();
+    if (!await evalPill.isVisible().catch(() => false)) {
+      return;
+    }
+
+    await evalPill.click();
+    await page.waitForTimeout(500);
+
+    // After expanding, eval span names should be visible (e.g., test_case, test_suite_run)
+    const expandedContent = page.locator('text=test_case').or(page.locator('text=test_suite_run'));
+    await expect(expandedContent.first()).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/tests/unit/services/traces/spanCategorization.test.ts
+++ b/tests/unit/services/traces/spanCategorization.test.ts
@@ -88,6 +88,13 @@ describe('getCategoryMeta', () => {
     expect(meta.color).toContain('amber');
   });
 
+  it('returns metadata for EVAL category', () => {
+    const meta = getCategoryMeta('EVAL');
+    expect(meta.label).toBe('Eval');
+    expect(meta.icon).toBe('ClipboardCheck');
+    expect(meta.color).toContain('emerald');
+  });
+
   it('returns metadata for ERROR category', () => {
     const meta = getCategoryMeta('ERROR');
     expect(meta.label).toBe('Error');
@@ -160,6 +167,14 @@ describe('getSpanCategory', () => {
       });
       expect(getSpanCategory(span)).toBe('TOOL');
     });
+
+    it('returns EVAL for evaluation operation', () => {
+      const span = createSpan({
+        spanId: '1',
+        attributes: { [ATTR_GEN_AI_OPERATION_NAME]: 'evaluation' },
+      });
+      expect(getSpanCategory(span)).toBe('EVAL');
+    });
   });
 
   describe('Name-based fallback categorization', () => {
@@ -201,6 +216,16 @@ describe('getSpanCategory', () => {
     it('returns AGENT for generateResponse spans', () => {
       const span = createSpan({ spanId: '1', name: 'GenerateResponse' });
       expect(getSpanCategory(span)).toBe('AGENT');
+    });
+
+    it('returns EVAL for test_suite_run spans', () => {
+      const span = createSpan({ spanId: '1', name: 'test_suite_run My Benchmark' });
+      expect(getSpanCategory(span)).toBe('EVAL');
+    });
+
+    it('returns EVAL for test_case spans', () => {
+      const span = createSpan({ spanId: '1', name: 'test_case' });
+      expect(getSpanCategory(span)).toBe('EVAL');
     });
 
     it('returns OTHER for unknown spans', () => {
@@ -253,6 +278,32 @@ describe('buildDisplayName', () => {
     });
     const name = buildDisplayName(span, 'TOOL');
     expect(name).toBe('execute_tool SearchDocsTool');
+  });
+
+  it('builds EVAL display name with test case name', () => {
+    const span = createSpan({
+      spanId: '1',
+      name: 'test_case',
+      attributes: {
+        [ATTR_GEN_AI_OPERATION_NAME]: 'evaluation',
+        'test.case.name': 'Login Flow Test',
+      },
+    });
+    const name = buildDisplayName(span, 'EVAL');
+    expect(name).toBe('evaluation Login Flow Test');
+  });
+
+  it('builds EVAL display name with suite name fallback', () => {
+    const span = createSpan({
+      spanId: '1',
+      name: 'test_suite_run My Benchmark',
+      attributes: {
+        [ATTR_GEN_AI_OPERATION_NAME]: 'evaluation',
+        'test.suite.name': 'My Benchmark',
+      },
+    });
+    const name = buildDisplayName(span, 'EVAL');
+    expect(name).toBe('evaluation My Benchmark');
   });
 
   it('returns span name for ERROR category', () => {


### PR DESCRIPTION
## Summary
- Add missing EVAL category pill/capsule to span viewer in both `TraceInfoView` and `TraceFlyoutContent` components
- EVAL spans (with `gen_ai.operation.name=evaluation`) were correctly categorized and shown in the time distribution bar (green), but had no corresponding clickable pill in the "Span category" section
- Add unit tests for EVAL categorization (OTel attribute-based and name-based fallback) to prevent regression

## Test plan
- [x] Unit tests added for `getSpanCategory` returning EVAL for `evaluation` operation name
- [x] Unit tests added for name-based fallback (`test_suite_run`, `test_case`)
- [x] Unit tests added for `buildDisplayName` with EVAL spans
- [x] Unit tests added for `getCategoryMeta` returning correct EVAL metadata
- [x] TypeScript compiles without errors
- [x] Full build succeeds
- [ ] Manual: run a benchmark, open trace viewer, verify emerald EVAL capsule appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)