### PR TITLE
fix(settings): test-connection reads stored credentials from config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - DocType discriminator for shared storage and PATCH sanitization in evaluation runs ([#205](https://github.com/opensearch-project/agent-health/pull/205))
 - Connector type drift: use single source of truth (`CONNECTOR_TYPE_INFO`) in server validation and Settings UI instead of hardcoded arrays ([#176](https://github.com/opensearch-project/agent-health/pull/176))
 - `useTraces: true` causes benchmark judge to never evaluate — runs permanently show 0% pass rate. Benchmark runner now awaits trace polling completion before reporting results ([#184](https://github.com/opensearch-project/agent-health/issues/184))
+- Settings “Test Connection” failed when credentials were saved via the UI: backend now falls back to file config (then env vars) for missing fields, with the request endpoint required to match the configured endpoint to avoid forwarding stored credentials to arbitrary hosts ([#213](https://github.com/opensearch-project/agent-health/pull/213))
 
 ## [0.4.0] - 2025-05-05
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -86,10 +86,11 @@ async function startServer() {
 
   const tryListen = (port: number): Promise<void> => {
     return new Promise((resolve, reject) => {
-      const server = app.listen(port, '0.0.0.0');
+      const host = process.env.HOST || '0.0.0.0';
+      const server = app.listen(port, host);
 
       server.on('listening', () => {
-        console.log(`\n  Backend Server running on http://0.0.0.0:${port}`);
+        console.log(`\n  Backend Server running on http://${host}:${port}`);
         console.log(`   Health check: http://localhost:${port}/health`);
         console.log(`   AWS Region: ${process.env.AWS_REGION || 'us-west-2'}`);
         console.log(`   Bedrock Model: ${process.env.BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'}`);

--- a/server/routes/observability.ts
+++ b/server/routes/observability.ts
@@ -42,8 +42,27 @@ router.get('/api/observability/health', async (req: Request, res: Response) => {
 // ============================================================================
 
 /**
+ * Normalize an endpoint URL for safe comparison: trims trailing slashes and
+ * lowercases the value. Returns undefined for empty/missing inputs.
+ */
+function normalizeEndpoint(value: string | undefined | null): string | undefined {
+  if (!value) return undefined;
+  return value.trim().replace(/\/+$/, '').toLowerCase();
+}
+
+/**
  * POST /api/observability/test-connection
- * Test connection to an observability data source with provided credentials
+ * Test connection to an observability data source with provided credentials.
+ *
+ * Credential resolution order: request body → file config → env vars.
+ *
+ * Stored credentials (file config / env vars) are only used as fallbacks when
+ * the request `endpoint` matches the corresponding configured endpoint. This
+ * prevents sending saved credentials to an arbitrary endpoint specified in the
+ * request body (credential exfiltration). Callers wanting to test a different
+ * endpoint must provide credentials explicitly in the request body. Index
+ * pattern fallbacks are not credentials and are always honored.
+ *
  * Body: { endpoint, username?, password?, indexes?: { traces?, logs?, metrics? } }
  */
 router.post('/api/observability/test-connection', async (req: Request, res: Response) => {
@@ -54,18 +73,27 @@ router.post('/api/observability/test-connection', async (req: Request, res: Resp
       return res.status(400).json({ status: 'error', message: 'Endpoint is required' });
     }
 
-    // Fall back to file config, then env vars, for any missing credentials
+    // Only fall back to stored credentials when the request endpoint matches
+    // the configured endpoint, to avoid forwarding saved creds to other hosts.
     const fileConfig = getObservabilityConfigFromFile();
+    const envEndpoint = process.env.OPENSEARCH_LOGS_ENDPOINT;
+    const reqNorm = normalizeEndpoint(endpoint);
+    const fileMatches = !!(fileConfig?.endpoint && normalizeEndpoint(fileConfig.endpoint) === reqNorm);
+    const envMatches = !!(envEndpoint && normalizeEndpoint(envEndpoint) === reqNorm);
+
+    const safeFile = fileMatches ? fileConfig : null;
+    const useEnv = envMatches;
 
     const result = await testObservabilityConnection({
       endpoint,
-      authType: authType ?? fileConfig?.authType ?? process.env.OPENSEARCH_LOGS_AUTH_TYPE,
-      username: username ?? fileConfig?.username ?? process.env.OPENSEARCH_LOGS_USERNAME,
-      password: password ?? fileConfig?.password ?? process.env.OPENSEARCH_LOGS_PASSWORD,
-      awsProfile: awsProfile ?? fileConfig?.awsProfile ?? process.env.OPENSEARCH_LOGS_AWS_PROFILE,
-      awsRegion: awsRegion ?? fileConfig?.awsRegion ?? process.env.OPENSEARCH_LOGS_AWS_REGION,
-      awsService: awsService ?? fileConfig?.awsService ?? process.env.OPENSEARCH_LOGS_AWS_SERVICE,
-      tlsSkipVerify: tlsSkipVerify ?? fileConfig?.tlsSkipVerify ?? (process.env.OPENSEARCH_LOGS_TLS_SKIP_VERIFY === 'true'),
+      authType: authType ?? safeFile?.authType ?? (useEnv ? process.env.OPENSEARCH_LOGS_AUTH_TYPE : undefined),
+      username: username ?? safeFile?.username ?? (useEnv ? process.env.OPENSEARCH_LOGS_USERNAME : undefined),
+      password: password ?? safeFile?.password ?? (useEnv ? process.env.OPENSEARCH_LOGS_PASSWORD : undefined),
+      awsProfile: awsProfile ?? safeFile?.awsProfile ?? (useEnv ? process.env.OPENSEARCH_LOGS_AWS_PROFILE : undefined),
+      awsRegion: awsRegion ?? safeFile?.awsRegion ?? (useEnv ? process.env.OPENSEARCH_LOGS_AWS_REGION : undefined),
+      awsService: awsService ?? safeFile?.awsService ?? (useEnv ? process.env.OPENSEARCH_LOGS_AWS_SERVICE : undefined),
+      tlsSkipVerify: tlsSkipVerify ?? safeFile?.tlsSkipVerify ?? (useEnv ? (process.env.OPENSEARCH_LOGS_TLS_SKIP_VERIFY === 'true') : undefined),
+      // Index patterns aren't credentials — always allow file-config fallback.
       indexes: {
         traces: indexes?.traces || fileConfig?.indexes?.traces || DEFAULT_OTEL_INDEXES.traces,
         logs: indexes?.logs || fileConfig?.indexes?.logs || DEFAULT_OTEL_INDEXES.logs,

--- a/server/routes/observability.ts
+++ b/server/routes/observability.ts
@@ -13,6 +13,7 @@
 import { Router, Request, Response } from 'express';
 import { testObservabilityConnection, checkObservabilityHealth } from '../adapters/index.js';
 import { resolveObservabilityConfig, DEFAULT_OTEL_INDEXES } from '../middleware/dataSourceConfig.js';
+import { getObservabilityConfigFromFile } from '../services/configService.js';
 
 const router = Router();
 
@@ -53,19 +54,22 @@ router.post('/api/observability/test-connection', async (req: Request, res: Resp
       return res.status(400).json({ status: 'error', message: 'Endpoint is required' });
     }
 
+    // Fall back to file config, then env vars, for any missing credentials
+    const fileConfig = getObservabilityConfigFromFile();
+
     const result = await testObservabilityConnection({
       endpoint,
-      authType: authType ?? process.env.OPENSEARCH_LOGS_AUTH_TYPE,
-      username: username ?? process.env.OPENSEARCH_LOGS_USERNAME,
-      password: password ?? process.env.OPENSEARCH_LOGS_PASSWORD,
-      awsProfile: awsProfile ?? process.env.OPENSEARCH_LOGS_AWS_PROFILE,
-      awsRegion: awsRegion ?? process.env.OPENSEARCH_LOGS_AWS_REGION,
-      awsService: awsService ?? process.env.OPENSEARCH_LOGS_AWS_SERVICE,
-      tlsSkipVerify: tlsSkipVerify ?? (process.env.OPENSEARCH_LOGS_TLS_SKIP_VERIFY === 'true'),
+      authType: authType ?? fileConfig?.authType ?? process.env.OPENSEARCH_LOGS_AUTH_TYPE,
+      username: username ?? fileConfig?.username ?? process.env.OPENSEARCH_LOGS_USERNAME,
+      password: password ?? fileConfig?.password ?? process.env.OPENSEARCH_LOGS_PASSWORD,
+      awsProfile: awsProfile ?? fileConfig?.awsProfile ?? process.env.OPENSEARCH_LOGS_AWS_PROFILE,
+      awsRegion: awsRegion ?? fileConfig?.awsRegion ?? process.env.OPENSEARCH_LOGS_AWS_REGION,
+      awsService: awsService ?? fileConfig?.awsService ?? process.env.OPENSEARCH_LOGS_AWS_SERVICE,
+      tlsSkipVerify: tlsSkipVerify ?? fileConfig?.tlsSkipVerify ?? (process.env.OPENSEARCH_LOGS_TLS_SKIP_VERIFY === 'true'),
       indexes: {
-        traces: indexes?.traces || DEFAULT_OTEL_INDEXES.traces,
-        logs: indexes?.logs || DEFAULT_OTEL_INDEXES.logs,
-        metrics: indexes?.metrics || DEFAULT_OTEL_INDEXES.metrics,
+        traces: indexes?.traces || fileConfig?.indexes?.traces || DEFAULT_OTEL_INDEXES.traces,
+        logs: indexes?.logs || fileConfig?.indexes?.logs || DEFAULT_OTEL_INDEXES.logs,
+        metrics: indexes?.metrics || fileConfig?.indexes?.metrics || DEFAULT_OTEL_INDEXES.metrics,
       },
     });
 

--- a/server/routes/storage/admin.ts
+++ b/server/routes/storage/admin.ts
@@ -94,15 +94,18 @@ router.post('/api/storage/test-connection', async (req: Request, res: Response) 
       return res.status(400).json({ status: 'error', message: 'Endpoint is required' });
     }
 
+    // Fall back to file config, then env vars, for any missing credentials
+    const fileConfig = getStorageConfigFromFile();
+
     const result = await testStorageConnection({
       endpoint,
-      authType: authType ?? process.env.OPENSEARCH_STORAGE_AUTH_TYPE,
-      username: username ?? process.env.OPENSEARCH_STORAGE_USERNAME,
-      password: password ?? process.env.OPENSEARCH_STORAGE_PASSWORD,
-      awsProfile: awsProfile ?? process.env.OPENSEARCH_STORAGE_AWS_PROFILE,
-      awsRegion: awsRegion ?? process.env.OPENSEARCH_STORAGE_AWS_REGION,
-      awsService: awsService ?? process.env.OPENSEARCH_STORAGE_AWS_SERVICE,
-      tlsSkipVerify: tlsSkipVerify ?? (process.env.OPENSEARCH_STORAGE_TLS_SKIP_VERIFY === 'true'),
+      authType: authType ?? fileConfig?.authType ?? process.env.OPENSEARCH_STORAGE_AUTH_TYPE,
+      username: username ?? fileConfig?.username ?? process.env.OPENSEARCH_STORAGE_USERNAME,
+      password: password ?? fileConfig?.password ?? process.env.OPENSEARCH_STORAGE_PASSWORD,
+      awsProfile: awsProfile ?? fileConfig?.awsProfile ?? process.env.OPENSEARCH_STORAGE_AWS_PROFILE,
+      awsRegion: awsRegion ?? fileConfig?.awsRegion ?? process.env.OPENSEARCH_STORAGE_AWS_REGION,
+      awsService: awsService ?? fileConfig?.awsService ?? process.env.OPENSEARCH_STORAGE_AWS_SERVICE,
+      tlsSkipVerify: tlsSkipVerify ?? fileConfig?.tlsSkipVerify ?? (process.env.OPENSEARCH_STORAGE_TLS_SKIP_VERIFY === 'true'),
     });
     res.json(result);
   } catch (error: any) {

--- a/server/routes/storage/admin.ts
+++ b/server/routes/storage/admin.ts
@@ -81,10 +81,27 @@ router.get('/api/storage/health', async (req: Request, res: Response) => {
 // ============================================================================
 
 /**
+ * Normalize an endpoint URL for safe comparison: trims trailing slashes and
+ * lowercases the value. Returns undefined for empty/missing inputs.
+ */
+function normalizeEndpoint(value: string | undefined | null): string | undefined {
+  if (!value) return undefined;
+  return value.trim().replace(/\/+$/, '').toLowerCase();
+}
+
+/**
  * POST /api/storage/test-connection
- * Test connection to a storage cluster with provided credentials
- * Falls back to env vars for any missing fields
- * Body: { endpoint, username?, password?, tlsSkipVerify? }
+ * Test connection to a storage cluster with provided credentials.
+ *
+ * Credential resolution order: request body → file config → env vars.
+ *
+ * Stored credentials (file config / env vars) are only used as fallbacks when
+ * the request `endpoint` matches the corresponding configured endpoint. This
+ * prevents sending saved credentials to an arbitrary endpoint specified in the
+ * request body (credential exfiltration). Callers wanting to test a different
+ * endpoint must provide credentials explicitly in the request body.
+ *
+ * Body: { endpoint, username?, password?, tlsSkipVerify?, authType?, awsProfile?, awsRegion?, awsService? }
  */
 router.post('/api/storage/test-connection', async (req: Request, res: Response) => {
   try {
@@ -94,18 +111,26 @@ router.post('/api/storage/test-connection', async (req: Request, res: Response) 
       return res.status(400).json({ status: 'error', message: 'Endpoint is required' });
     }
 
-    // Fall back to file config, then env vars, for any missing credentials
+    // Only fall back to stored credentials when the request endpoint matches
+    // the configured endpoint, to avoid forwarding saved creds to other hosts.
     const fileConfig = getStorageConfigFromFile();
+    const envEndpoint = process.env.OPENSEARCH_STORAGE_ENDPOINT;
+    const reqNorm = normalizeEndpoint(endpoint);
+    const fileMatches = !!(fileConfig?.endpoint && normalizeEndpoint(fileConfig.endpoint) === reqNorm);
+    const envMatches = !!(envEndpoint && normalizeEndpoint(envEndpoint) === reqNorm);
+
+    const safeFile = fileMatches ? fileConfig : null;
+    const useEnv = envMatches;
 
     const result = await testStorageConnection({
       endpoint,
-      authType: authType ?? fileConfig?.authType ?? process.env.OPENSEARCH_STORAGE_AUTH_TYPE,
-      username: username ?? fileConfig?.username ?? process.env.OPENSEARCH_STORAGE_USERNAME,
-      password: password ?? fileConfig?.password ?? process.env.OPENSEARCH_STORAGE_PASSWORD,
-      awsProfile: awsProfile ?? fileConfig?.awsProfile ?? process.env.OPENSEARCH_STORAGE_AWS_PROFILE,
-      awsRegion: awsRegion ?? fileConfig?.awsRegion ?? process.env.OPENSEARCH_STORAGE_AWS_REGION,
-      awsService: awsService ?? fileConfig?.awsService ?? process.env.OPENSEARCH_STORAGE_AWS_SERVICE,
-      tlsSkipVerify: tlsSkipVerify ?? fileConfig?.tlsSkipVerify ?? (process.env.OPENSEARCH_STORAGE_TLS_SKIP_VERIFY === 'true'),
+      authType: authType ?? safeFile?.authType ?? (useEnv ? process.env.OPENSEARCH_STORAGE_AUTH_TYPE : undefined),
+      username: username ?? safeFile?.username ?? (useEnv ? process.env.OPENSEARCH_STORAGE_USERNAME : undefined),
+      password: password ?? safeFile?.password ?? (useEnv ? process.env.OPENSEARCH_STORAGE_PASSWORD : undefined),
+      awsProfile: awsProfile ?? safeFile?.awsProfile ?? (useEnv ? process.env.OPENSEARCH_STORAGE_AWS_PROFILE : undefined),
+      awsRegion: awsRegion ?? safeFile?.awsRegion ?? (useEnv ? process.env.OPENSEARCH_STORAGE_AWS_REGION : undefined),
+      awsService: awsService ?? safeFile?.awsService ?? (useEnv ? process.env.OPENSEARCH_STORAGE_AWS_SERVICE : undefined),
+      tlsSkipVerify: tlsSkipVerify ?? safeFile?.tlsSkipVerify ?? (useEnv ? (process.env.OPENSEARCH_STORAGE_TLS_SKIP_VERIFY === 'true') : undefined),
     });
     res.json(result);
   } catch (error: any) {

--- a/tests/unit/server/routes/observability.test.ts
+++ b/tests/unit/server/routes/observability.test.ts
@@ -68,9 +68,36 @@ function getRouteHandler(router: any, method: string, path: string) {
 }
 
 describe('Observability Routes', () => {
+  // Save and restore env vars touched by these tests so we don't leak state.
+  const ENV_KEYS = [
+    'OPENSEARCH_LOGS_ENDPOINT',
+    'OPENSEARCH_LOGS_AUTH_TYPE',
+    'OPENSEARCH_LOGS_USERNAME',
+    'OPENSEARCH_LOGS_PASSWORD',
+    'OPENSEARCH_LOGS_AWS_PROFILE',
+    'OPENSEARCH_LOGS_AWS_REGION',
+    'OPENSEARCH_LOGS_AWS_SERVICE',
+    'OPENSEARCH_LOGS_TLS_SKIP_VERIFY',
+  ] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetObservabilityConfigFromFile.mockReturnValue(null);
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key]!;
+      }
+    }
   });
 
   describe('POST /api/observability/test-connection', () => {
@@ -110,7 +137,7 @@ describe('Observability Routes', () => {
       expect(res.json).toHaveBeenCalledWith({ status: 'ok', clusterName: 'obs-cluster' });
     });
 
-    it('should fall back to file config when credentials are not in request body', async () => {
+    it('should fall back to file config when endpoint matches and credentials are not in request body', async () => {
       mockGetObservabilityConfigFromFile.mockReturnValue({
         endpoint: 'https://file-obs:9200',
         authType: 'sigv4',
@@ -150,8 +177,32 @@ describe('Observability Routes', () => {
       );
     });
 
-    it('should fall back to env vars when neither request body nor file config has credentials', async () => {
+    it('should NOT fall back to file config credentials when request endpoint differs', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue({
+        endpoint: 'https://stored-obs:9200',
+        authType: 'basic',
+        username: 'file-user',
+        password: 'file-pass',
+      });
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'error', message: 'auth failed' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://attacker-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      const args = mockTestObservabilityConnection.mock.calls[0][0];
+      expect(args.endpoint).toBe('https://attacker-obs:9200');
+      expect(args.username).toBeUndefined();
+      expect(args.password).toBeUndefined();
+      expect(args.authType).toBeUndefined();
+    });
+
+    it('should fall back to env vars when endpoint matches OPENSEARCH_LOGS_ENDPOINT and no file/body creds', async () => {
       mockGetObservabilityConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_LOGS_ENDPOINT = 'https://env-obs:9200';
       process.env.OPENSEARCH_LOGS_USERNAME = 'env-user';
       process.env.OPENSEARCH_LOGS_PASSWORD = 'env-pass';
       process.env.OPENSEARCH_LOGS_AUTH_TYPE = 'basic';
@@ -172,19 +223,36 @@ describe('Observability Routes', () => {
           authType: 'basic',
         })
       );
-
-      delete process.env.OPENSEARCH_LOGS_USERNAME;
-      delete process.env.OPENSEARCH_LOGS_PASSWORD;
-      delete process.env.OPENSEARCH_LOGS_AUTH_TYPE;
     });
 
-    it('should prefer request body over file config and env vars', async () => {
+    it('should NOT fall back to env vars when endpoint differs from OPENSEARCH_LOGS_ENDPOINT', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_LOGS_ENDPOINT = 'https://env-obs:9200';
+      process.env.OPENSEARCH_LOGS_USERNAME = 'env-user';
+      process.env.OPENSEARCH_LOGS_PASSWORD = 'env-pass';
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'error', message: 'auth failed' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://other-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      const args = mockTestObservabilityConnection.mock.calls[0][0];
+      expect(args.endpoint).toBe('https://other-obs:9200');
+      expect(args.username).toBeUndefined();
+      expect(args.password).toBeUndefined();
+    });
+
+    it('should prefer request body over file config and env vars (even when endpoints match)', async () => {
       mockGetObservabilityConfigFromFile.mockReturnValue({
-        endpoint: 'https://file-obs:9200',
+        endpoint: 'https://my-obs:9200',
         authType: 'basic',
         username: 'file-user',
         password: 'file-pass',
       });
+      process.env.OPENSEARCH_LOGS_ENDPOINT = 'https://my-obs:9200';
       process.env.OPENSEARCH_LOGS_USERNAME = 'env-user';
       process.env.OPENSEARCH_LOGS_PASSWORD = 'env-pass';
       mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
@@ -205,9 +273,6 @@ describe('Observability Routes', () => {
           password: 'body-pass',
         })
       );
-
-      delete process.env.OPENSEARCH_LOGS_USERNAME;
-      delete process.env.OPENSEARCH_LOGS_PASSWORD;
     });
 
     it('should use file config index patterns as fallback', async () => {

--- a/tests/unit/server/routes/observability.test.ts
+++ b/tests/unit/server/routes/observability.test.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Request, Response } from 'express';
+import observabilityRoutes from '@/server/routes/observability';
+
+// Mock adapters
+jest.mock('@/server/adapters/index', () => ({
+  testObservabilityConnection: jest.fn(),
+  checkObservabilityHealth: jest.fn(),
+}));
+
+// Mock dataSourceConfig
+jest.mock('@/server/middleware/dataSourceConfig', () => ({
+  resolveObservabilityConfig: jest.fn(),
+  DEFAULT_OTEL_INDEXES: {
+    traces: 'otel-v1-apm-span-*',
+    logs: 'ml-commons-logs-*',
+    metrics: 'otel-v1-apm-service-map*',
+  },
+}));
+
+// Mock configService
+jest.mock('@/server/services/configService', () => ({
+  getObservabilityConfigFromFile: jest.fn(),
+}));
+
+import { testObservabilityConnection, checkObservabilityHealth } from '@/server/adapters/index';
+import { resolveObservabilityConfig } from '@/server/middleware/dataSourceConfig';
+import { getObservabilityConfigFromFile } from '@/server/services/configService';
+
+const mockTestObservabilityConnection = testObservabilityConnection as jest.Mock;
+const mockCheckObservabilityHealth = checkObservabilityHealth as jest.Mock;
+const mockResolveObservabilityConfig = resolveObservabilityConfig as jest.Mock;
+const mockGetObservabilityConfigFromFile = getObservabilityConfigFromFile as jest.Mock;
+
+// Silence console output
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+function createMocks(body: any = {}) {
+  const req = { body } as unknown as Request;
+  const res = {
+    json: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { req, res };
+}
+
+function getRouteHandler(router: any, method: string, path: string) {
+  const routes = router.stack;
+  const route = routes.find(
+    (layer: any) =>
+      layer.route &&
+      layer.route.path === path &&
+      layer.route.methods[method.toLowerCase()]
+  );
+  return route?.route.stack[0].handle;
+}
+
+describe('Observability Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetObservabilityConfigFromFile.mockReturnValue(null);
+  });
+
+  describe('POST /api/observability/test-connection', () => {
+    it('should return error when endpoint is missing', async () => {
+      const { req, res } = createMocks({});
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Endpoint is required' });
+    });
+
+    it('should use credentials from request body when provided', async () => {
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'obs-cluster' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://obs-cluster:9200',
+        authType: 'sigv4',
+        awsRegion: 'us-west-2',
+        awsProfile: 'my-profile',
+        awsService: 'aoss',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://obs-cluster:9200',
+          authType: 'sigv4',
+          awsRegion: 'us-west-2',
+          awsProfile: 'my-profile',
+          awsService: 'aoss',
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith({ status: 'ok', clusterName: 'obs-cluster' });
+    });
+
+    it('should fall back to file config when credentials are not in request body', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue({
+        endpoint: 'https://file-obs:9200',
+        authType: 'sigv4',
+        username: 'file-user',
+        password: 'file-pass',
+        awsProfile: 'file-profile',
+        awsRegion: 'eu-west-1',
+        awsService: 'aoss',
+        tlsSkipVerify: true,
+        indexes: { traces: 'custom-traces-*', logs: 'custom-logs-*', metrics: 'custom-metrics-*' },
+      });
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'file-obs' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://file-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://file-obs:9200',
+          authType: 'sigv4',
+          username: 'file-user',
+          password: 'file-pass',
+          awsProfile: 'file-profile',
+          awsRegion: 'eu-west-1',
+          awsService: 'aoss',
+          tlsSkipVerify: true,
+          indexes: expect.objectContaining({
+            traces: 'custom-traces-*',
+            logs: 'custom-logs-*',
+            metrics: 'custom-metrics-*',
+          }),
+        })
+      );
+    });
+
+    it('should fall back to env vars when neither request body nor file config has credentials', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_LOGS_USERNAME = 'env-user';
+      process.env.OPENSEARCH_LOGS_PASSWORD = 'env-pass';
+      process.env.OPENSEARCH_LOGS_AUTH_TYPE = 'basic';
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'env-obs' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://env-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://env-obs:9200',
+          username: 'env-user',
+          password: 'env-pass',
+          authType: 'basic',
+        })
+      );
+
+      delete process.env.OPENSEARCH_LOGS_USERNAME;
+      delete process.env.OPENSEARCH_LOGS_PASSWORD;
+      delete process.env.OPENSEARCH_LOGS_AUTH_TYPE;
+    });
+
+    it('should prefer request body over file config and env vars', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue({
+        endpoint: 'https://file-obs:9200',
+        authType: 'basic',
+        username: 'file-user',
+        password: 'file-pass',
+      });
+      process.env.OPENSEARCH_LOGS_USERNAME = 'env-user';
+      process.env.OPENSEARCH_LOGS_PASSWORD = 'env-pass';
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://my-obs:9200',
+        username: 'body-user',
+        password: 'body-pass',
+        authType: 'basic',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'body-user',
+          password: 'body-pass',
+        })
+      );
+
+      delete process.env.OPENSEARCH_LOGS_USERNAME;
+      delete process.env.OPENSEARCH_LOGS_PASSWORD;
+    });
+
+    it('should use file config index patterns as fallback', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue({
+        endpoint: 'https://file-obs:9200',
+        indexes: { traces: 'file-traces-*', logs: 'file-logs-*', metrics: 'file-metrics-*' },
+      });
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://file-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexes: {
+            traces: 'file-traces-*',
+            logs: 'file-logs-*',
+            metrics: 'file-metrics-*',
+          },
+        })
+      );
+    });
+
+    it('should use default index patterns when none provided anywhere', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue(null);
+      mockTestObservabilityConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
+
+      const { req, res } = createMocks({
+        endpoint: 'https://obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestObservabilityConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexes: {
+            traces: 'otel-v1-apm-span-*',
+            logs: 'ml-commons-logs-*',
+            metrics: 'otel-v1-apm-service-map*',
+          },
+        })
+      );
+    });
+
+    it('should return 500 when testObservabilityConnection throws', async () => {
+      mockGetObservabilityConfigFromFile.mockReturnValue(null);
+      mockTestObservabilityConnection.mockRejectedValue(new Error('Network timeout'));
+
+      const { req, res } = createMocks({
+        endpoint: 'https://timeout-obs:9200',
+      });
+      const handler = getRouteHandler(observabilityRoutes, 'post', '/api/observability/test-connection');
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Network timeout' });
+    });
+  });
+
+  describe('GET /api/observability/health', () => {
+    it('should return health check result', async () => {
+      mockResolveObservabilityConfig.mockReturnValue({ endpoint: 'https://obs:9200' });
+      mockCheckObservabilityHealth.mockResolvedValue({ status: 'ok', clusterName: 'obs' });
+
+      const req = {} as unknown as Request;
+      const res = { json: jest.fn().mockReturnThis(), status: jest.fn().mockReturnThis() } as unknown as Response;
+      const handler = getRouteHandler(observabilityRoutes, 'get', '/api/observability/health');
+
+      await handler(req, res);
+
+      expect(mockCheckObservabilityHealth).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({ status: 'ok', clusterName: 'obs' });
+    });
+  });
+
+  describe('GET /api/observability/defaults', () => {
+    it('should return default index patterns', async () => {
+      const req = {} as unknown as Request;
+      const res = { json: jest.fn().mockReturnThis() } as unknown as Response;
+      const handler = getRouteHandler(observabilityRoutes, 'get', '/api/observability/defaults');
+
+      handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        indexes: {
+          traces: 'otel-v1-apm-span-*',
+          logs: 'ml-commons-logs-*',
+          metrics: 'otel-v1-apm-service-map*',
+        },
+      });
+    });
+  });
+});

--- a/tests/unit/server/routes/storage/admin.test.ts
+++ b/tests/unit/server/routes/storage/admin.test.ts
@@ -996,6 +996,37 @@ describe('Admin Storage Routes', () => {
   // ============================================================================
 
   describe('POST /api/storage/test-connection', () => {
+    // Save and restore env vars touched by these tests so we don't leak state
+    // (or accidentally clobber pre-existing values in dev/CI).
+    const ENV_KEYS = [
+      'OPENSEARCH_STORAGE_ENDPOINT',
+      'OPENSEARCH_STORAGE_AUTH_TYPE',
+      'OPENSEARCH_STORAGE_USERNAME',
+      'OPENSEARCH_STORAGE_PASSWORD',
+      'OPENSEARCH_STORAGE_AWS_PROFILE',
+      'OPENSEARCH_STORAGE_AWS_REGION',
+      'OPENSEARCH_STORAGE_AWS_SERVICE',
+      'OPENSEARCH_STORAGE_TLS_SKIP_VERIFY',
+    ] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key]!;
+        }
+      }
+    });
+
     it('should return error when endpoint is missing', async () => {
       const { req, res } = createMocks({}, {});
       const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
@@ -1030,7 +1061,7 @@ describe('Admin Storage Routes', () => {
       expect(res.json).toHaveBeenCalledWith({ status: 'ok', clusterName: 'test' });
     });
 
-    it('should fall back to file config when credentials are not in request body', async () => {
+    it('should fall back to file config when endpoint matches and credentials are not in request body', async () => {
       mockGetStorageConfigFromFile.mockReturnValue({
         endpoint: 'https://file-cluster:9200',
         authType: 'basic',
@@ -1064,8 +1095,56 @@ describe('Admin Storage Routes', () => {
       );
     });
 
-    it('should fall back to env vars when neither request body nor file config has credentials', async () => {
+    it('should treat trailing slash and case differences as the same endpoint when matching file config', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue({
+        endpoint: 'https://File-Cluster:9200/',
+        authType: 'basic',
+        username: 'file-user',
+        password: 'file-pass',
+      });
+      mockTestStorageConnection.mockResolvedValue({ status: 'ok' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://file-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestStorageConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'file-user',
+          password: 'file-pass',
+        })
+      );
+    });
+
+    it('should NOT fall back to file config credentials when request endpoint differs', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue({
+        endpoint: 'https://stored-cluster:9200',
+        authType: 'basic',
+        username: 'file-user',
+        password: 'file-pass',
+      });
+      mockTestStorageConnection.mockResolvedValue({ status: 'error', message: 'auth failed' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://attacker-host:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      const args = mockTestStorageConnection.mock.calls[0][0];
+      expect(args.endpoint).toBe('https://attacker-host:9200');
+      expect(args.username).toBeUndefined();
+      expect(args.password).toBeUndefined();
+      expect(args.authType).toBeUndefined();
+    });
+
+    it('should fall back to env vars when endpoint matches OPENSEARCH_STORAGE_ENDPOINT and no file/body creds', async () => {
       mockGetStorageConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_STORAGE_ENDPOINT = 'https://env-cluster:9200';
       process.env.OPENSEARCH_STORAGE_USERNAME = 'env-user';
       process.env.OPENSEARCH_STORAGE_PASSWORD = 'env-pass';
       mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'env-cluster' });
@@ -1084,17 +1163,35 @@ describe('Admin Storage Routes', () => {
           password: 'env-pass',
         })
       );
-
-      delete process.env.OPENSEARCH_STORAGE_USERNAME;
-      delete process.env.OPENSEARCH_STORAGE_PASSWORD;
     });
 
-    it('should prefer request body over file config and env vars', async () => {
+    it('should NOT fall back to env vars when endpoint differs from OPENSEARCH_STORAGE_ENDPOINT', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_STORAGE_ENDPOINT = 'https://env-cluster:9200';
+      process.env.OPENSEARCH_STORAGE_USERNAME = 'env-user';
+      process.env.OPENSEARCH_STORAGE_PASSWORD = 'env-pass';
+      mockTestStorageConnection.mockResolvedValue({ status: 'error', message: 'auth failed' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://other-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      const args = mockTestStorageConnection.mock.calls[0][0];
+      expect(args.endpoint).toBe('https://other-cluster:9200');
+      expect(args.username).toBeUndefined();
+      expect(args.password).toBeUndefined();
+    });
+
+    it('should prefer request body over file config and env vars (even when endpoints match)', async () => {
       mockGetStorageConfigFromFile.mockReturnValue({
-        endpoint: 'https://file-cluster:9200',
+        endpoint: 'https://my-cluster:9200',
         username: 'file-user',
         password: 'file-pass',
       });
+      process.env.OPENSEARCH_STORAGE_ENDPOINT = 'https://my-cluster:9200';
       process.env.OPENSEARCH_STORAGE_USERNAME = 'env-user';
       process.env.OPENSEARCH_STORAGE_PASSWORD = 'env-pass';
       mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
@@ -1114,9 +1211,6 @@ describe('Admin Storage Routes', () => {
           password: 'body-pass',
         })
       );
-
-      delete process.env.OPENSEARCH_STORAGE_USERNAME;
-      delete process.env.OPENSEARCH_STORAGE_PASSWORD;
     });
 
     it('should return error result from testStorageConnection', async () => {

--- a/tests/unit/server/routes/storage/admin.test.ts
+++ b/tests/unit/server/routes/storage/admin.test.ts
@@ -990,4 +990,162 @@ describe('Admin Storage Routes', () => {
       });
     });
   });
+
+  // ============================================================================
+  // Test Connection Tests
+  // ============================================================================
+
+  describe('POST /api/storage/test-connection', () => {
+    it('should return error when endpoint is missing', async () => {
+      const { req, res } = createMocks({}, {});
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Endpoint is required' });
+    });
+
+    it('should use credentials from request body when provided', async () => {
+      mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://my-cluster:9200',
+        username: 'admin',
+        password: 'secret',
+        authType: 'basic',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestStorageConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://my-cluster:9200',
+          username: 'admin',
+          password: 'secret',
+          authType: 'basic',
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith({ status: 'ok', clusterName: 'test' });
+    });
+
+    it('should fall back to file config when credentials are not in request body', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue({
+        endpoint: 'https://file-cluster:9200',
+        authType: 'basic',
+        username: 'file-user',
+        password: 'file-pass',
+        awsProfile: 'file-profile',
+        awsRegion: 'us-east-1',
+        awsService: 'es',
+        tlsSkipVerify: true,
+      });
+      mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'file-cluster' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://file-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestStorageConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://file-cluster:9200',
+          username: 'file-user',
+          password: 'file-pass',
+          authType: 'basic',
+          awsProfile: 'file-profile',
+          awsRegion: 'us-east-1',
+          awsService: 'es',
+          tlsSkipVerify: true,
+        })
+      );
+    });
+
+    it('should fall back to env vars when neither request body nor file config has credentials', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue(null);
+      process.env.OPENSEARCH_STORAGE_USERNAME = 'env-user';
+      process.env.OPENSEARCH_STORAGE_PASSWORD = 'env-pass';
+      mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'env-cluster' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://env-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestStorageConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://env-cluster:9200',
+          username: 'env-user',
+          password: 'env-pass',
+        })
+      );
+
+      delete process.env.OPENSEARCH_STORAGE_USERNAME;
+      delete process.env.OPENSEARCH_STORAGE_PASSWORD;
+    });
+
+    it('should prefer request body over file config and env vars', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue({
+        endpoint: 'https://file-cluster:9200',
+        username: 'file-user',
+        password: 'file-pass',
+      });
+      process.env.OPENSEARCH_STORAGE_USERNAME = 'env-user';
+      process.env.OPENSEARCH_STORAGE_PASSWORD = 'env-pass';
+      mockTestStorageConnection.mockResolvedValue({ status: 'ok', clusterName: 'test' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://my-cluster:9200',
+        username: 'body-user',
+        password: 'body-pass',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(mockTestStorageConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'body-user',
+          password: 'body-pass',
+        })
+      );
+
+      delete process.env.OPENSEARCH_STORAGE_USERNAME;
+      delete process.env.OPENSEARCH_STORAGE_PASSWORD;
+    });
+
+    it('should return error result from testStorageConnection', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue(null);
+      mockTestStorageConnection.mockResolvedValue({ status: 'error', message: 'Connection refused' });
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://bad-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Connection refused' });
+    });
+
+    it('should return 500 when testStorageConnection throws', async () => {
+      mockGetStorageConfigFromFile.mockReturnValue(null);
+      mockTestStorageConnection.mockRejectedValue(new Error('Unexpected failure'));
+
+      const { req, res } = createMocks({}, {
+        endpoint: 'https://crash-cluster:9200',
+      });
+      const handler = getRouteHandler(adminRoutes, 'post', '/api/storage/test-connection');
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Unexpected failure' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed a bug where "Test Connection" always returned an error when credentials were saved via the Settings UI
- The test-connection routes for both storage and observability clusters now fall back to the config file (`agent-health.config.json`) before falling back to environment variables
- Added comprehensive unit tests for both `/api/storage/test-connection` and `/api/observability/test-connection` endpoints

## Root Cause
When clicking "Test Connection" without re-typing the password (shown as dots via a `__STORED__` sentinel), the frontend strips it to `undefined`. Previously, the backend only fell back to environment variables — which are typically unset when credentials were saved through the UI. This caused every test to fail with a generic auth error.

## Fix
Credential resolution priority is now: **request body → file config → env vars**, matching the resolution order used by the rest of the server.

## Test plan
- [ ] Save storage credentials via Settings UI, click "Test Connection" → should succeed
- [ ] Save observability credentials (SigV4) via Settings UI, click "Test Connection" → should succeed
- [ ] Verify env-var-only users are unaffected (no file config present)
- [ ] `npm run build:all && npm run test:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)