### PR TITLE
fix(ui): unify sidebar background and apply gradient to all pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+- **UI:** Sidebar now uses a uniform near-black background (`hsl(var(--background))`) in dark mode instead of the previous dark gray (`#1D1E24`), so the sidebar header / nav region matches the existing footer (which already used `bg-background`). Removes the visible top-vs-bottom seam in the left navigation. Light mode unchanged.
+- **UI:** The radial gradient background previously seen only on the Dashboard / Overview page now applies on every page. The `dashboard-gradient-bg` class is now attached to the `SidebarInset` `<main>` in `Layout.tsx`, replacing the per-page `useEffect` toggle in `Dashboard.tsx`.
+
 ### Added
 - Cross-page user preferences are now stored under a single shared `agent-health:prefs:*` namespace, so picking a value once is reflected on every other page that exposes the same control. Shared keys:
   - `prefs:timeRange` — Benchmarks / Test Cases / Evaluation Runs / Agent Traces (Agent Traces converts the shared `'1h' | '6h' | '1d' | '7d' | '30d' | 'all'` enum to its internal minute-based query cutoff).

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -187,14 +187,7 @@ export const Dashboard: React.FC = () => {
   const [timeRange, setTimeRange] = usePersistedState<TimeRange>('dashboard:timeRange', '7d');
   const [selectedMetric, setSelectedMetric] = usePersistedState<TrendMetric>('dashboard:selectedMetric', 'passRate');
 
-  // Apply gradient background to the scrollable main container
-  useEffect(() => {
-    const main = document.querySelector('main');
-    if (main) {
-      main.classList.add('dashboard-gradient-bg');
-      return () => { main.classList.remove('dashboard-gradient-bg'); };
-    }
-  }, []);
+  // Gradient background is now applied globally via SidebarInset in Layout.tsx
 
   // Fetch test case count (independent of benchmark data)
   useEffect(() => {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -121,7 +121,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
         className="h-screen flex-shrink-0 transition-all duration-300"
         style={{
           width: isCollapsed ? '64px' : '180px',
-          background: isDarkMode ? '#1D1E24' : '#FFFFFF',
+          background: isDarkMode ? 'hsl(var(--background))' : '#FFFFFF',
           borderRight: isDarkMode ? '1px solid #343741' : '1px solid #D3DAE6',
           boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.05), 0px 0px 4px rgba(0, 0, 0, 0.05), 0px 0px 2px rgba(0, 0, 0, 0.05)',
           borderRadius: '0px 24px 24px 0px',
@@ -362,7 +362,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
         </SidebarFooter>
       </Sidebar>
 
-      <SidebarInset className="overflow-y-auto">
+      <SidebarInset className="overflow-y-auto dashboard-gradient-bg">
         <AssistantProvider>
           {children}
           <AssistantModal />


### PR DESCRIPTION
## Description

Two small UI polish fixes:

### 1. Sidebar — uniform background color

The left sidebar previously rendered with a dark-gray inline background (`#1D1E24`) on the header / nav region while the `SidebarFooter` already used the theme's `bg-background` (near-black `hsl(222 47% 3%)`). The result in dark mode was a visible seam: the top ~95% of the sidebar was a lighter gray and the bottom (Status / Server Online block) was black.

Changed the inline background on `<Sidebar>` from `#1D1E24` to `hsl(var(--background))`, so the entire sidebar — header, search, nav, sub-nav, and footer — is one uniform color matching the existing footer. Light mode is unchanged (`#FFFFFF`).

### 2. Radial gradient background applies to all pages

The dashboard radial gradient (`dashboard-gradient-bg`) was previously toggled on the `<main>` element only by `Dashboard.tsx` via a `useEffect`, so it appeared only on `/`. Other pages had a flat dark background.

Moved the class to `SidebarInset` (the `<main>` content wrapper) in `Layout.tsx`, and removed the per-page `useEffect` from `Dashboard.tsx`. The gradient now renders on every page (Overview, Agent Traces, Benchmarks, Test Cases, Evaluation Runs, Evaluators, Settings, AI Dev Tools, Assistant).

## Issues Resolved

UI polish — no related issue.

## Testing

**Local checks (matching the AGENTS.md "Before Raising a PR" list):**

| Check | Result |
|---|---|
| `npm run build:all` | ✅ pass |
| `npm run test:unit` | ✅ no regressions (only the pre-existing `tests/unit/cli/sampleTraces.test.ts` `rootSpans.length).toBe(1)` failure on `origin/main` remains; same failure reproduced on a clean checkout of `origin/main`) |
| `npm run test:integration` | ✅ no regressions (only pre-existing `PiConnector.integration.test.ts` and `traceBlocking.integration.test.ts` failures, also reproduced on clean `origin/main`) |
| `npm audit --audit-level=high` | ✅ 0 vulnerabilities |
| Production server smoke test (`node server/dist/index.js`) | ✅ `/health` 200, `/` 200, `/api/storage/test-cases` 200, `/api/storage/benchmarks` 200 |
| DCO signoff on commit | ✅ `git commit -s` |
| `CHANGELOG.md` updated under `[Unreleased]` | ✅ |

**Visual verification (Playwright + headless Chromium against the production server build, dark mode, viewport 1440×900):**

Before / after of the left sidebar (Overview):
- Before: top section dark gray (`#1D1E24`), footer near-black — visible seam.
- After: uniform near-black top to bottom.

Verified the gradient now appears on:
- `/` (Overview)
- `/agent-traces`
- `/evaluations/benchmarks`
- `/evaluations/test-cases`
- `/evaluations/runs`
- `/settings`

Tested both via Vite dev (`npm run dev`) on port 4010 and against the production build served by `node server/dist/index.js` on port 4011 — both render correctly with no console errors.

## Check List

- [x] New functionality includes testing (visual regression via Playwright; no logic changes that would need new unit tests — pure CSS/className changes)
- [x] All tests pass (no regressions; pre-existing failures on `origin/main` are documented above)
- [x] New functionality has been documented (CHANGELOG.md under `[Unreleased]`)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
