### PR TITLE
fix(ui): theming paper cuts in dark/light mode (Scope B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **MetricsTimeSeriesChart** — Recharts `CartesianGrid` / `XAxis` / `YAxis` / dot strokes now drive from `hsl(var(--border))` and `hsl(var(--muted-foreground))` instead of literal hex; chart axes flip with the theme.
   - **React Flow surfaces** (TraceFlowView, AgentMapView, TraceFlowComparison, SpanNode) — `Background` color, `MiniMap` mask/className, and `SpanNode` `Handle` styles use `hsl(var(--border))`, `bg-card`, `border-border`, `bg-muted-foreground/60` instead of `slate-*` `!important` overrides; minimap and connector handles render in both themes.
   - **Tooltip** — shadcn `TooltipContent` default migrated from `bg-gray-900 dark:bg-gray-800` + `text-white` to `bg-popover` + `text-popover-foreground`; the per-row Time Distribution tooltip on Agent Traces no longer fights the theme. Light tooltip is now darker than its surrounding surface (and dark tooltip lighter), as expected.
-- **Tests:** New `tests/unit/components/uxThemingRegression.test.ts` (16 cases) reads each fixed source file and fails if the bad patterns return.
+- **UI theming (paper cuts, Scope B — 7 HIGH-severity fixes):**
+  - **RunSummaryPanel** — donut chart slices now read from `hsl(var(--primary))` and `hsl(var(--destructive))` instead of hardcoded `#015aa3` / `#ef4444`, so the chart picks up the active theme.
+  - **QuickRunModal** — error banner gains `dark:` variants (`dark:text-red-300 dark:bg-red-500/10 dark:border-red-500/30`); the previously pure white-pink box no longer hangs in dark mode.
+  - **TrajectoryView** — failed-step header text uses `text-red-600 dark:text-red-400` instead of `text-red-400` only (raised contrast from 3.4:1 to AA on white).
+  - **RunDetailsContent** — log-level coloring (`ERROR` / `WARN`) now has both light and dark variants (`text-red-600 dark:text-red-400`, `text-amber-600 dark:text-amber-400`); previously illegible on the light theme.
+  - **ReportsPage** — difficulty badges (Easy / Medium / Hard) gain full light-mode token sets (`bg-{c}-50 text-{c}-700/800 border-{c}-200`) alongside the existing dark variants; previously dark-only.
+  - **CodingAgentsPage** — active search highlight migrated from `bg-yellow-400 text-black` to themed `bg-yellow-200 text-yellow-900 dark:bg-yellow-500/30 dark:text-yellow-200`; the active match no longer screams against surrounding chrome.
+  - **Layout** — sidebar inline `style.background` and `style.borderRight` now use `hsl(var(--background))` and `hsl(var(--border))` instead of branched `isDarkMode ? '#1D1E24' : '#FFFFFF'` / `#343741` / `#D3DAE6`; one rule, two themes, no drift.
+- **Tests:** `tests/unit/components/uxThemingRegression.test.ts` extended with 10 Scope B regression guards (26 total) — each reads the fixed source file and fails if the bad pattern is reintroduced.
 - **Tests:** Repaired three pre-existing test failures unrelated to the theming work that were blocking the local pre-push hook:
   - `tests/integration/services/evaluation/traceBlocking.integration.test.ts` — duplicate `return; }` from a bad merge made the file fail to parse.
   - `tests/unit/cli/sampleTraces.test.ts` — root-span count assertion stale after eval spans were added to `demo-trace-001` (now 2 roots: agent + eval suite).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **React Flow surfaces** (TraceFlowView, AgentMapView, TraceFlowComparison, SpanNode) — `Background` color, `MiniMap` mask/className, and `SpanNode` `Handle` styles use `hsl(var(--border))`, `bg-card`, `border-border`, `bg-muted-foreground/60` instead of `slate-*` `!important` overrides; minimap and connector handles render in both themes.
   - **Tooltip** — shadcn `TooltipContent` default migrated from `bg-gray-900 dark:bg-gray-800` + `text-white` to `bg-popover` + `text-popover-foreground`; the per-row Time Distribution tooltip on Agent Traces no longer fights the theme. Light tooltip is now darker than its surrounding surface (and dark tooltip lighter), as expected.
 - **Tests:** New `tests/unit/components/uxThemingRegression.test.ts` (16 cases) reads each fixed source file and fails if the bad patterns return.
+- **Tests:** Repaired three pre-existing test failures unrelated to the theming work that were blocking the local pre-push hook:
+  - `tests/integration/services/evaluation/traceBlocking.integration.test.ts` — duplicate `return; }` from a bad merge made the file fail to parse.
+  - `tests/unit/cli/sampleTraces.test.ts` — root-span count assertion stale after eval spans were added to `demo-trace-001` (now 2 roots: agent + eval suite).
+  - `tests/integration/services/connectors/PiConnector.integration.test.ts` — assertion expected a `--package` arg but `createAgentHealthPiConnector` actually passes `--skill` / `--extension` / `--append-system-prompt`.
 
 ### Changed
 - **UI:** Sidebar now uses a uniform near-black background (`hsl(var(--background))`) in dark mode instead of the previous dark gray (`#1D1E24`), so the sidebar header / nav region matches the existing footer (which already used `bg-background`). Removes the visible top-vs-bottom seam in the left navigation. Light mode unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- **UI theming (paper cuts):** Five high-impact light/dark theming regressions:
+  - **RawEventsPanel** — replaced hardcoded `bg-gray-*` / `text-gray-*` with theme tokens (`bg-card`, `bg-muted`, `text-foreground`, `text-muted-foreground`) so the AG-UI raw-events viewer is legible in light mode.
+  - **LatencyHistogram & MetricsOverview** — bar palettes now include `dark:bg-*/80` variants; bars are no longer near-invisible at 0.3 alpha in dark mode.
+  - **MetricsTimeSeriesChart** — Recharts `CartesianGrid` / `XAxis` / `YAxis` / dot strokes now drive from `hsl(var(--border))` and `hsl(var(--muted-foreground))` instead of literal hex; chart axes flip with the theme.
+  - **React Flow surfaces** (TraceFlowView, AgentMapView, TraceFlowComparison, SpanNode) — `Background` color, `MiniMap` mask/className, and `SpanNode` `Handle` styles use `hsl(var(--border))`, `bg-card`, `border-border`, `bg-muted-foreground/60` instead of `slate-*` `!important` overrides; minimap and connector handles render in both themes.
+  - **Tooltip** — shadcn `TooltipContent` default migrated from `bg-gray-900 dark:bg-gray-800` + `text-white` to `bg-popover` + `text-popover-foreground`; the per-row Time Distribution tooltip on Agent Traces no longer fights the theme. Light tooltip is now darker than its surrounding surface (and dark tooltip lighter), as expected.
+- **Tests:** New `tests/unit/components/uxThemingRegression.test.ts` (16 cases) reads each fixed source file and fails if the bad patterns return.
+
 ### Changed
 - **UI:** Sidebar now uses a uniform near-black background (`hsl(var(--background))`) in dark mode instead of the previous dark gray (`#1D1E24`), so the sidebar header / nav region matches the existing footer (which already used `bg-background`). Removes the visible top-vs-bottom seam in the left navigation. Light mode unchanged.
 - **UI:** The radial gradient background previously seen only on the Dashboard / Overview page now applies on every page. The `dashboard-gradient-bg` class is now attached to the `SidebarInset` `<main>` in `Layout.tsx`, replacing the per-page `useEffect` toggle in `Dashboard.tsx`.

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -121,8 +121,8 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
         className="h-screen flex-shrink-0 transition-all duration-300"
         style={{
           width: isCollapsed ? '64px' : '180px',
-          background: isDarkMode ? 'hsl(var(--background))' : '#FFFFFF',
-          borderRight: isDarkMode ? '1px solid #343741' : '1px solid #D3DAE6',
+          background: 'hsl(var(--background))',
+          borderRight: '1px solid hsl(var(--border))',
           boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.05), 0px 0px 4px rgba(0, 0, 0, 0.05), 0px 0px 2px rgba(0, 0, 0, 0.05)',
           borderRadius: '0px 24px 24px 0px',
           display: 'flex',

--- a/components/QuickRunModal.tsx
+++ b/components/QuickRunModal.tsx
@@ -521,7 +521,7 @@ export const QuickRunModal: React.FC<QuickRunModalProps> = ({
             {/* Results Area */}
             <div className="flex-1 min-h-0 overflow-y-auto p-4">
               {errorMessage && (
-                <div className="mb-4 p-3 text-sm text-red-600 bg-red-50 rounded border border-red-200">
+                <div className="mb-4 p-3 text-sm rounded border text-red-600 bg-red-50 border-red-200 dark:text-red-300 dark:bg-red-500/10 dark:border-red-500/30">
                   {errorMessage}
                 </div>
               )}

--- a/components/RawEventsPanel.tsx
+++ b/components/RawEventsPanel.tsx
@@ -80,13 +80,14 @@ function getEventSummary(event: AGUIEvent): string {
  * Get color classes for event type badge
  */
 function getEventTypeColor(type: string | undefined): string {
-  if (!type) return 'text-gray-700 bg-gray-100 dark:text-gray-400 dark:bg-gray-800';
-  if (type.includes('ERROR')) return 'text-red-700 bg-red-100 dark:text-red-400 dark:bg-red-500/10';
-  if (type.includes('TOOL')) return 'text-blue-700 bg-blue-100 dark:text-blue-400 dark:bg-blue-500/10';
-  if (type.includes('TEXT')) return 'text-blue-700 bg-blue-100 dark:text-blue-600 dark:bg-blue-500/10';
-  if (type.includes('RUN')) return 'text-purple-700 bg-purple-100 dark:text-purple-400 dark:bg-purple-500/10';
-  if (type.includes('ACTIVITY')) return 'text-amber-700 bg-amber-100 dark:text-amber-400 dark:bg-amber-500/10';
-  return 'text-gray-700 bg-gray-100 dark:text-gray-400 dark:bg-gray-800';
+  const neutral = 'text-muted-foreground bg-muted';
+  if (!type) return neutral;
+  if (type.includes('ERROR')) return 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-500/15';
+  if (type.includes('TOOL')) return 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-500/15';
+  if (type.includes('TEXT')) return 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-500/15';
+  if (type.includes('RUN')) return 'text-purple-700 bg-purple-100 dark:text-purple-300 dark:bg-purple-500/15';
+  if (type.includes('ACTIVITY')) return 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-500/15';
+  return neutral;
 }
 
 export const RawEventsPanel: React.FC<RawEventsPanelProps> = ({ events }) => {
@@ -125,41 +126,41 @@ export const RawEventsPanel: React.FC<RawEventsPanelProps> = ({ events }) => {
   };
 
   return (
-    <div className="bg-gray-900 rounded-lg border border-gray-800 p-3">
+    <div className="bg-card rounded-lg border border-border p-3">
       <details className="group" open>
         <summary className="flex items-center justify-between cursor-pointer list-none">
-          <div className="flex items-center text-[10px] font-bold text-gray-300 uppercase">
+          <div className="flex items-center text-[10px] font-bold text-muted-foreground uppercase">
             <Terminal className="mr-1" size={10} />
             Raw AG UI Events
-            <span className="ml-1.5 text-[10px] font-normal text-gray-500">
+            <span className="ml-1.5 text-[10px] font-normal text-muted-foreground/70">
               ({filteredEvents.length}{searchTerm ? ` of ${events.length}` : ''} events)
             </span>
           </div>
-          <span className="text-gray-500 group-open:rotate-180 transition-transform text-xs">▼</span>
+          <span className="text-muted-foreground/70 group-open:rotate-180 transition-transform text-xs">▼</span>
         </summary>
 
         <div className="mt-3">
           {/* Search Input */}
           <div className="flex items-center gap-2 mb-3">
             <div className="relative flex-1">
-              <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500" />
+              <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/70" />
               <input
                 type="text"
                 placeholder="Search events..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full bg-gray-950 border border-gray-700 rounded pl-8 pr-3 py-1.5 text-xs text-gray-200 placeholder-gray-500 focus:border-opensearch-blue focus:outline-none"
+                className="w-full bg-background border border-input rounded pl-8 pr-3 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/70 focus:border-opensearch-blue focus:outline-none"
               />
             </div>
             <button
               onClick={expandAll}
-              className="px-2 py-1.5 text-[10px] text-gray-400 hover:text-gray-200 bg-gray-800 hover:bg-gray-700 rounded transition-colors"
+              className="px-2 py-1.5 text-[10px] text-muted-foreground hover:text-foreground bg-muted hover:bg-muted/80 rounded transition-colors"
             >
               Expand All
             </button>
             <button
               onClick={collapseAll}
-              className="px-2 py-1.5 text-[10px] text-gray-400 hover:text-gray-200 bg-gray-800 hover:bg-gray-700 rounded transition-colors"
+              className="px-2 py-1.5 text-[10px] text-muted-foreground hover:text-foreground bg-muted hover:bg-muted/80 rounded transition-colors"
             >
               Collapse All
             </button>
@@ -173,32 +174,32 @@ export const RawEventsPanel: React.FC<RawEventsPanelProps> = ({ events }) => {
               const summary = getEventSummary(event);
 
               return (
-                <div key={index} className="bg-gray-950 rounded border border-gray-800">
+                <div key={index} className="bg-background rounded border border-border">
                   {/* Event Header */}
                   <button
                     onClick={() => toggleExpand(index)}
-                    className="w-full flex items-start gap-2 p-2 text-left hover:bg-gray-900/50 transition-colors"
+                    className="w-full flex items-start gap-2 p-2 text-left hover:bg-muted/50 transition-colors"
                   >
-                    <span className="text-gray-500 text-[9px] font-mono w-6 flex-shrink-0">
+                    <span className="text-muted-foreground/70 text-[9px] font-mono w-6 flex-shrink-0">
                       #{originalIndex + 1}
                     </span>
                     {isExpanded ? (
-                      <ChevronDown size={12} className="text-gray-500 mt-0.5 flex-shrink-0" />
+                      <ChevronDown size={12} className="text-muted-foreground/70 mt-0.5 flex-shrink-0" />
                     ) : (
-                      <ChevronRight size={12} className="text-gray-500 mt-0.5 flex-shrink-0" />
+                      <ChevronRight size={12} className="text-muted-foreground/70 mt-0.5 flex-shrink-0" />
                     )}
                     <span className={`text-[9px] font-semibold px-1.5 py-0.5 rounded flex-shrink-0 ${getEventTypeColor(event.type)}`}>
                       {event.type || 'UNKNOWN'}
                     </span>
-                    <span className="text-[10px] text-gray-300 flex-1 truncate">
+                    <span className="text-[10px] text-foreground/80 flex-1 truncate">
                       {summary}
                     </span>
                   </button>
 
                   {/* Expanded JSON View */}
                   {isExpanded && (
-                    <div className="border-t border-gray-800 p-2">
-                      <pre className="text-[9px] text-gray-400 overflow-x-auto whitespace-pre-wrap font-mono bg-gray-900/50 p-2 rounded">
+                    <div className="border-t border-border p-2">
+                      <pre className="text-[9px] text-muted-foreground overflow-x-auto whitespace-pre-wrap font-mono bg-muted/50 p-2 rounded">
                         {JSON.stringify(event, null, 2)}
                       </pre>
                     </div>
@@ -208,7 +209,7 @@ export const RawEventsPanel: React.FC<RawEventsPanelProps> = ({ events }) => {
             })}
 
             {filteredEvents.length === 0 && (
-              <div className="text-center py-4 text-gray-500 text-xs">
+              <div className="text-center py-4 text-muted-foreground text-xs">
                 {searchTerm ? 'No events match your search' : 'No events captured'}
               </div>
             )}

--- a/components/ReportsPage.tsx
+++ b/components/ReportsPage.tsx
@@ -250,10 +250,10 @@ export const ReportsPage: React.FC = () => {
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Badge variant="outline" className={
                   testCase.difficulty === 'Easy'
-                    ? 'bg-blue-900/30 text-blue-400 border-blue-800'
+                    ? 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-500/15 dark:text-blue-300 dark:border-blue-500/30'
                     : testCase.difficulty === 'Medium'
-                    ? 'bg-yellow-900/30 text-yellow-400 border-yellow-800'
-                    : 'bg-red-900/30 text-red-400 border-red-800'
+                    ? 'bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-500/15 dark:text-yellow-300 dark:border-yellow-500/30'
+                    : 'bg-red-50 text-red-700 border-red-200 dark:bg-red-500/15 dark:text-red-300 dark:border-red-500/30'
                 }>
                   {testCase.difficulty}
                 </Badge>

--- a/components/RunDetailsContent.tsx
+++ b/components/RunDetailsContent.tsx
@@ -1149,8 +1149,8 @@ export const RunDetailsContent: React.FC<RunDetailsContentProps> = ({
                             {new Date(log.timestamp).toLocaleTimeString()}
                           </span>
                           <span className={`text-xs font-semibold ${
-                            log.level === 'ERROR' ? 'text-red-400' :
-                            log.level === 'WARN' ? 'text-yellow-400' :
+                            log.level === 'ERROR' ? 'text-red-600 dark:text-red-400' :
+                            log.level === 'WARN' ? 'text-amber-600 dark:text-amber-400' :
                             'text-muted-foreground'
                           }`}>
                             [{log.level || 'INFO'}]

--- a/components/RunSummaryPanel.tsx
+++ b/components/RunSummaryPanel.tsx
@@ -90,10 +90,10 @@ export const RunSummaryPanel: React.FC<RunSummaryPanelProps> = ({
     }
   }, [reports]);
 
-  // Donut chart data
+  // Donut chart data — colors via theme tokens so the donut tracks the active theme.
   const pieData = [
-    { name: 'Passed', value: stats.passed, color: '#015aa3' },
-    { name: 'Failed', value: stats.failed, color: '#ef4444' },
+    { name: 'Passed', value: stats.passed, color: 'hsl(var(--primary))' },
+    { name: 'Failed', value: stats.failed, color: 'hsl(var(--destructive))' },
   ].filter(d => d.value > 0);
 
   return (

--- a/components/TrajectoryView.tsx
+++ b/components/TrajectoryView.tsx
@@ -93,7 +93,7 @@ export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }
         const collapsible = isCollapsible(step);
         const latency = formatLatency(step.latencyMs);
         const failed = step.status === ToolCallStatus.FAILURE;
-        const typeColor = failed ? 'text-red-400' : (typeColors[step.type] || 'text-muted-foreground');
+        const typeColor = failed ? 'text-red-600 dark:text-red-400' : (typeColors[step.type] || 'text-muted-foreground');
         const bgColor = failed ? 'bg-red-500/5 border-red-500/20' : (typeBgColors[step.type] || 'bg-muted/30 border-border/50');
 
         return (

--- a/components/codingAgents/CodingAgentsPage.tsx
+++ b/components/codingAgents/CodingAgentsPage.tsx
@@ -968,7 +968,7 @@ function SessionDetailPanel({ session, onClose }: { session: Session; onClose: (
         <mark
           key={`${idx}-${localMatch}`}
           ref={el => { matchRefs.current[gIdx] = el; }}
-          className={isActive ? 'bg-yellow-400 text-black rounded-sm px-0.5' : 'bg-yellow-200/60 dark:bg-yellow-700/40 rounded-sm px-0.5'}
+          className={isActive ? 'bg-yellow-200 text-yellow-900 dark:bg-yellow-500/30 dark:text-yellow-200 rounded-sm px-0.5' : 'bg-yellow-200/60 dark:bg-yellow-700/40 rounded-sm px-0.5'}
         >
           {text.slice(idx, idx + msgSearch.length)}
         </mark>

--- a/components/comparison/MetricsTimeSeriesChart.tsx
+++ b/components/comparison/MetricsTimeSeriesChart.tsx
@@ -276,20 +276,23 @@ export const MetricsTimeSeriesChart: React.FC<MetricsTimeSeriesChartProps> = ({
 
       <ResponsiveContainer width="100%" height={height}>
         <LineChart data={chartData} margin={{ top: 5, right: showRightAxis ? 60 : 20, bottom: 5, left: 20 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          {/* Theme-driven axes: previously used dark-grey hex (#374151, #9ca3af, #4b5563)
+              that vanished against the light-mode background. `hsl(var(--…))` resolves
+              against the current theme automatically. */}
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
           <XAxis
             dataKey="name"
-            tick={{ fill: '#9ca3af', fontSize: 11 }}
-            tickLine={{ stroke: '#4b5563' }}
-            axisLine={{ stroke: '#4b5563' }}
+            tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+            tickLine={{ stroke: 'hsl(var(--border))' }}
+            axisLine={{ stroke: 'hsl(var(--border))' }}
           />
           {/* Left Y-axis for percentage metrics */}
           <YAxis
             yAxisId="left"
             domain={[0, 100]}
-            tick={{ fill: '#9ca3af', fontSize: 11 }}
-            tickLine={{ stroke: '#4b5563' }}
-            axisLine={{ stroke: '#4b5563' }}
+            tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+            tickLine={{ stroke: 'hsl(var(--border))' }}
+            axisLine={{ stroke: 'hsl(var(--border))' }}
             tickFormatter={(v) => `${v}%`}
             width={45}
           />
@@ -298,9 +301,9 @@ export const MetricsTimeSeriesChart: React.FC<MetricsTimeSeriesChartProps> = ({
             <YAxis
               yAxisId="right"
               orientation="right"
-              tick={{ fill: '#9ca3af', fontSize: 11 }}
-              tickLine={{ stroke: '#4b5563' }}
-              axisLine={{ stroke: '#4b5563' }}
+              tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+              tickLine={{ stroke: 'hsl(var(--border))' }}
+              axisLine={{ stroke: 'hsl(var(--border))' }}
               width={55}
             />
           )}
@@ -318,8 +321,8 @@ export const MetricsTimeSeriesChart: React.FC<MetricsTimeSeriesChartProps> = ({
                 name={metric.label}
                 stroke={metric.color}
                 strokeWidth={2}
-                dot={{ r: 4, fill: metric.color, stroke: '#1f2937', strokeWidth: 1 }}
-                activeDot={{ r: 6, fill: metric.color, stroke: '#fff', strokeWidth: 2 }}
+                dot={{ r: 4, fill: metric.color, stroke: 'hsl(var(--background))', strokeWidth: 1 }}
+                activeDot={{ r: 6, fill: metric.color, stroke: 'hsl(var(--background))', strokeWidth: 2 }}
                 connectNulls
               />
             );

--- a/components/comparison/sections/TraceFlowComparison.tsx
+++ b/components/comparison/sections/TraceFlowComparison.tsx
@@ -261,12 +261,12 @@ const FlowPanelInner: React.FC<{
         variant={BackgroundVariant.Dots}
         gap={16}
         size={1}
-        color="#334155"
+        color="hsl(var(--border))"
       />
       <MiniMap
         nodeColor={minimapNodeColor}
-        maskColor="rgba(15, 23, 42, 0.8)"
-        className="!bg-slate-900/50 !border-slate-700 !bottom-2 !right-2"
+        maskColor="hsl(var(--background) / 0.8)"
+        className="!bg-card/80 !border !border-border !bottom-2 !right-2"
         style={{ width: 100, height: 60 }}
         pannable
         zoomable
@@ -506,12 +506,12 @@ const MergedFlowViewInner: React.FC<{
         variant={BackgroundVariant.Dots}
         gap={16}
         size={1}
-        color="#334155"
+        color="hsl(var(--border))"
       />
       <MiniMap
         nodeColor={minimapNodeColor}
-        maskColor="rgba(15, 23, 42, 0.8)"
-        className="!bg-slate-900/50 !border-slate-700"
+        maskColor="hsl(var(--background) / 0.8)"
+        className="!bg-card/80 !border !border-border"
         pannable
         zoomable
       />

--- a/components/traces/AgentMapView.tsx
+++ b/components/traces/AgentMapView.tsx
@@ -217,13 +217,13 @@ export const AgentMapView: React.FC<AgentMapViewProps> = ({
           variant={BackgroundVariant.Dots}
           gap={16}
           size={1}
-          color="#334155"
+          color="hsl(var(--border))"
         />
         {showMinimap && (
           <MiniMap
             nodeColor={minimapNodeColor}
-            maskColor="rgba(15, 23, 42, 0.8)"
-            className="!bg-slate-900/50 !border-slate-700"
+            maskColor="hsl(var(--background) / 0.8)"
+            className="!bg-card/80 !border !border-border"
             pannable
             zoomable
           />

--- a/components/traces/LatencyHistogram.tsx
+++ b/components/traces/LatencyHistogram.tsx
@@ -20,43 +20,28 @@ interface LatencyHistogramProps {
   data: HistogramBucket[];
 }
 
+// Tailwind classes per latency bucket. Dark variants stay near-fully saturated
+// (`dark:bg-{c}-400/80`) so bars remain visible against `bg-card`, instead of the
+// previous 0.3-alpha overlay that disappeared into dark backgrounds. Driving this
+// from the cascade also means the bars react to theme toggles without re-render.
+const BAR_CLASSES = [
+  'bg-emerald-300 border border-emerald-500 dark:bg-emerald-400/80 dark:border-emerald-300/70',
+  'bg-lime-300 border border-lime-500 dark:bg-lime-400/80 dark:border-lime-300/70',
+  'bg-yellow-300 border border-yellow-500 dark:bg-yellow-400/80 dark:border-yellow-300/70',
+  'bg-amber-400 border border-amber-500 dark:bg-amber-400/80 dark:border-amber-300/70',
+  'bg-orange-400 border border-orange-500 dark:bg-orange-400/80 dark:border-orange-300/70',
+  'bg-red-400 border border-red-500 dark:bg-red-400/80 dark:border-red-300/70',
+];
+const FALLBACK_BAR_CLASSES = 'bg-gray-300 border border-gray-400 dark:bg-gray-400/70 dark:border-gray-300/60';
+
 export const LatencyHistogram: React.FC<LatencyHistogramProps> = ({ data }) => {
   const maxCount = Math.max(...data.map(b => b.count), 1);
-
-  // Aggro-style-edit: Softer color gradient using border-like colors (theme-aware)
-  const getBarStyle = (index: number): React.CSSProperties => {
-    const isDarkMode = document.documentElement.classList.contains('dark');
-    
-    // Softer colors that work in both light and dark modes
-    const lightColors = [
-      { backgroundColor: 'rgb(134, 239, 172)', border: '1px solid rgb(74, 222, 128)' },    // <100ms - soft green
-      { backgroundColor: 'rgb(163, 230, 53)', border: '1px solid rgb(132, 204, 22)' },     // 100-500ms - lime
-      { backgroundColor: 'rgb(253, 224, 71)', border: '1px solid rgb(234, 179, 8)' },      // 500ms-1s - yellow
-      { backgroundColor: 'rgb(251, 191, 36)', border: '1px solid rgb(245, 158, 11)' },     // 1-5s - amber
-      { backgroundColor: 'rgb(251, 146, 60)', border: '1px solid rgb(249, 115, 22)' },     // 5-10s - orange
-      { backgroundColor: 'rgb(248, 113, 113)', border: '1px solid rgb(239, 68, 68)' },     // >10s - red
-    ];
-    
-    const darkColors = [
-      { backgroundColor: 'rgba(134, 239, 172, 0.3)', border: '1px solid rgba(134, 239, 172, 0.5)' },  // <100ms
-      { backgroundColor: 'rgba(163, 230, 53, 0.3)', border: '1px solid rgba(163, 230, 53, 0.5)' },    // 100-500ms
-      { backgroundColor: 'rgba(253, 224, 71, 0.3)', border: '1px solid rgba(253, 224, 71, 0.5)' },    // 500ms-1s
-      { backgroundColor: 'rgba(251, 191, 36, 0.3)', border: '1px solid rgba(251, 191, 36, 0.5)' },    // 1-5s
-      { backgroundColor: 'rgba(251, 146, 60, 0.3)', border: '1px solid rgba(251, 146, 60, 0.5)' },    // 5-10s
-      { backgroundColor: 'rgba(248, 113, 113, 0.3)', border: '1px solid rgba(248, 113, 113, 0.5)' },  // >10s
-    ];
-    
-    const colors = isDarkMode ? darkColors : lightColors;
-    return colors[index] || (isDarkMode 
-      ? { backgroundColor: 'rgba(156, 163, 175, 0.3)', border: '1px solid rgba(156, 163, 175, 0.5)' }
-      : { backgroundColor: 'rgb(209, 213, 219)', border: '1px solid rgb(156, 163, 175)' }
-    );
-  };
 
   return (
     <div className="flex items-end gap-2 h-24">
       {data.map((bucket, index) => {
         const heightPercent = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
+        const barClass = BAR_CLASSES[index] || FALLBACK_BAR_CLASSES;
 
         return (
           <div
@@ -71,11 +56,8 @@ export const LatencyHistogram: React.FC<LatencyHistogramProps> = ({ data }) => {
                 </span>
               )}
               <div
-                className="w-full rounded-t transition-all"
-                style={{
-                  height: `${Math.max(heightPercent, bucket.count > 0 ? 4 : 0)}%`,
-                  ...getBarStyle(index)
-                }}
+                className={`w-full rounded-t transition-all ${barClass}`}
+                style={{ height: `${Math.max(heightPercent, bucket.count > 0 ? 4 : 0)}%` }}
                 title={`${bucket.label}: ${bucket.count} traces`}
               />
             </div>

--- a/components/traces/MetricsOverview.tsx
+++ b/components/traces/MetricsOverview.tsx
@@ -69,13 +69,13 @@ export const MetricsOverview: React.FC<MetricsOverviewProps> = ({
   const maxErrors = Math.max(...errorTimeSeries.map(p => p.value), 1);
   const maxRequests = Math.max(...requestTimeSeries.map(p => p.value), 1);
 
-  // Get color for latency bucket
+  // Get color for latency bucket — uses softer shades in dark mode for visibility
   const getLatencyColor = (bucket: LatencyBucket) => {
-    if (bucket.max <= 100) return 'bg-green-500';
-    if (bucket.max <= 500) return 'bg-blue-500';
-    if (bucket.max <= 1000) return 'bg-yellow-500';
-    if (bucket.max <= 5000) return 'bg-orange-500';
-    return 'bg-red-500';
+    if (bucket.max <= 100) return 'bg-green-500 dark:bg-green-400/80';
+    if (bucket.max <= 500) return 'bg-blue-500 dark:bg-blue-400/80';
+    if (bucket.max <= 1000) return 'bg-yellow-500 dark:bg-yellow-400/80';
+    if (bucket.max <= 5000) return 'bg-orange-500 dark:bg-orange-400/80';
+    return 'bg-red-500 dark:bg-red-400/80';
   };
 
   // Generate smooth cubic bezier SVG path from data points

--- a/components/traces/TraceFlowView.tsx
+++ b/components/traces/TraceFlowView.tsx
@@ -213,12 +213,12 @@ export const TraceFlowView: React.FC<TraceFlowViewProps> = ({
               variant={BackgroundVariant.Dots}
               gap={16}
               size={1}
-              color="#334155"
+              color="hsl(var(--border))"
             />
             <MiniMap
               nodeColor={minimapNodeColor}
-              maskColor="rgba(15, 23, 42, 0.8)"
-              className="!bg-slate-900/50 !border-slate-700"
+              maskColor="hsl(var(--background) / 0.8)"
+              className="!bg-card/80 !border !border-border"
               pannable
               zoomable
             />

--- a/components/traces/TraceFlyoutContent.tsx
+++ b/components/traces/TraceFlyoutContent.tsx
@@ -398,16 +398,16 @@ export const TraceFlyoutContent: React.FC<TraceFlyoutContentProps> = ({
                       })}
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent 
-                    side="bottom" 
-                    className="bg-gray-900 dark:bg-gray-800 border-gray-800 p-3 max-w-xs text-white [&>svg]:fill-gray-900 dark:[&>svg]:fill-gray-800"
+                  <TooltipContent
+                    side="bottom"
+                    className="p-3 max-w-xs"
                   >
                     <div className="space-y-1.5">
                       <div className="text-xs font-semibold mb-2">Time Distribution</div>
                       {categoryStats.map((stat) => {
                         const colors = getCategoryColors(stat.category);
-                        const formattedPercent = stat.percentage < 1 
-                          ? stat.percentage.toFixed(1) 
+                        const formattedPercent = stat.percentage < 1
+                          ? stat.percentage.toFixed(1)
                           : stat.percentage.toFixed(0);
                         return (
                           <div key={stat.category} className="flex items-center justify-between gap-4 text-xs">
@@ -415,9 +415,9 @@ export const TraceFlyoutContent: React.FC<TraceFlyoutContentProps> = ({
                               <div className={cn('w-2.5 h-2.5 rounded-sm flex-shrink-0', colors.bar)} />
                               <span className="font-medium">{stat.category}</span>
                             </div>
-                            <div className="flex items-center gap-2 text-gray-300">
+                            <div className="flex items-center gap-2 text-muted-foreground">
                               <span>{formatDuration(stat.totalDuration)}</span>
-                              <span className="text-gray-400">({formattedPercent}%)</span>
+                              <span className="text-muted-foreground/70">({formattedPercent}%)</span>
                             </div>
                           </div>
                         );

--- a/components/traces/flow/SpanNode.tsx
+++ b/components/traces/flow/SpanNode.tsx
@@ -116,7 +116,7 @@ function SpanNodeComponent({ data, selected }: SpanNodeProps) {
       <Handle
         type="target"
         position={Position.Top}
-        className="!w-2 !h-2 !bg-slate-400 !border-slate-600"
+        className="!w-2 !h-2 !bg-muted-foreground/60 !border-border"
       />
 
       {/* Header: Icon + Category Badge */}
@@ -187,7 +187,7 @@ function SpanNodeComponent({ data, selected }: SpanNodeProps) {
       <Handle
         type="source"
         position={Position.Bottom}
-        className="!w-2 !h-2 !bg-slate-400 !border-slate-600"
+        className="!w-2 !h-2 !bg-muted-foreground/60 !border-border"
       />
     </div>
   );

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -23,13 +23,13 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-gray-900 dark:bg-gray-800 px-3 py-1.5 text-xs text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
         className
       )}
       {...props}
     >
       {props.children}
-      <TooltipPrimitive.Arrow className="fill-gray-900 dark:fill-gray-800" />
+      <TooltipPrimitive.Arrow className="fill-popover" />
     </TooltipPrimitive.Content>
   </TooltipPrimitive.Portal>
 ))

--- a/scripts/ux-review/screenshot.mjs
+++ b/scripts/ux-review/screenshot.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0 */
+
+// Captures before/after screenshots for the top-5 UX paper-cut fixes.
+// Usage: node scripts/ux-review/screenshot.mjs <stage> [--only=<id>]
+//   stage = "before" | "after"
+
+import { chromium } from 'playwright';
+import { mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { argv } from 'node:process';
+
+const stage = argv[2];
+if (!['before', 'after'].includes(stage)) {
+  console.error('Usage: node screenshot.mjs <before|after> [--only=id]');
+  process.exit(1);
+}
+const only = (argv.find((a) => a.startsWith('--only=')) || '').split('=')[1];
+
+const BASE = process.env.BASE_URL || 'http://localhost:4001';
+// Per-feature layout: ~/ux-review-shots/<feature>/{before,after}-{light,dark}.png
+const ROOT = process.env.SHOT_ROOT || `${process.env.HOME}/ux-review-shots`;
+mkdirSync(ROOT, { recursive: true });
+
+// Known-good IDs in this project's OpenSearch:
+const RUN_ID = 'run-1779332071373-z6mfu2tdn';
+const BENCHMARK_RUN_ID = 'run-1779332065086-18ed2gnbs';
+const BENCHMARK_ID = 'bench-1779332063830-1dfywimjg';
+// Benchmark with 40 runs, suitable for the time-series chart
+const COMPARE_BENCHMARK_ID = 'exp-1765401828206-yq9ychdhu';
+
+const SHOTS = [
+  // 1. RawEventsPanel: open run detail by reportId, switch trajectory toggle to "Raw Events"
+  {
+    id: '01-raw-events-panel',
+    label: 'RawEventsPanel — broken-in-light hardcoded grays',
+    url: `${BASE}/runs/${RUN_ID}`,
+    setup: async (page) => {
+      await page.waitForTimeout(1500);
+      // Click "Conversation History" tab first
+      const convTab = page.getByRole('tab', { name: /conversation history/i }).first();
+      if (await convTab.count()) await convTab.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(800);
+      // Click "Raw Events" toggle inside the tab
+      const rawBtn = page.getByRole('button', { name: /^raw events$/i }).first();
+      if (await rawBtn.count()) await rawBtn.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(1000);
+      // Scroll to the panel
+      const panel = page.locator('text=/Raw AG UI Events/i').first();
+      if (await panel.count()) {
+        await panel.scrollIntoViewIfNeeded().catch(() => {});
+      }
+      await page.waitForTimeout(500);
+    },
+    selector: 'main',
+  },
+  // 2. LatencyHistogram: agent-traces page — expand Metrics card to show the distribution histogram
+  {
+    id: '02-latency-histogram',
+    label: 'LatencyHistogram — dark bars near-invisible at 0.3 alpha',
+    url: `${BASE}/agent-traces`,
+    setup: async (page) => {
+      await page.waitForTimeout(3000);
+      // Click the "Metrics" card header to expand the latency distribution section
+      const metricsHeader = page.locator('text=/^Metrics$/').first();
+      if (await metricsHeader.count()) {
+        await metricsHeader.click({ timeout: 2000 }).catch(() => {});
+        await page.waitForTimeout(800);
+      }
+      // Wait for the distribution bars to render
+      await page.locator('text=/Latency Distribution/i').first().waitFor({ timeout: 5000 }).catch(() => {});
+      await page.waitForTimeout(500);
+    },
+    selector: 'main',
+  },
+  // 3. MetricsTimeSeriesChart: comparison page for benchmark
+  {
+    id: '03-metrics-timeseries-chart',
+    label: 'MetricsTimeSeriesChart — Recharts axes hardcoded hex',
+    url: `${BASE}/compare/${COMPARE_BENCHMARK_ID}`,
+    setup: async (page) => {
+      await page.waitForTimeout(3500);
+      // Open the "Compare Summary" collapsible (collapsed by default)
+      const summaryToggle = page.getByRole('button', { name: /compare summary/i }).first();
+      if (await summaryToggle.count()) {
+        await summaryToggle.click({ timeout: 2000 }).catch(() => {});
+        await page.waitForTimeout(800);
+      }
+      // Scroll the chart into view
+      const chart = page.locator('text=/Metrics Over Time/i').first();
+      if (await chart.count()) {
+        await chart.scrollIntoViewIfNeeded().catch(() => {});
+      }
+      await page.waitForTimeout(1000);
+    },
+    selector: 'main',
+  },
+  // 4. Slate !important overrides: agent-traces — open a trace, switch to Agent Map tab
+  {
+    id: '04-slate-overrides',
+    label: 'Slate !important overrides — minimap/background invisible in light mode',
+    url: `${BASE}/agent-traces`,
+    setup: async (page) => {
+      await page.waitForTimeout(3500);
+      // Click first trace row in the table
+      const sessionRow = page.locator('table tbody tr').first();
+      if (await sessionRow.count()) {
+        await sessionRow.click().catch(() => {});
+        await page.waitForTimeout(1500);
+      }
+      // Click "Agent map" button in the view toggle
+      const mapBtn = page.getByRole('button', { name: /agent map/i }).first();
+      if (await mapBtn.count()) {
+        await mapBtn.click({ timeout: 2000 }).catch(() => {});
+        await page.waitForTimeout(2000);
+      }
+    },
+    selector: 'main',
+  },
+  // 5. Tooltip flip: hover the per-row Distribution bar to surface the Time Distribution tooltip
+  {
+    id: '05-tooltip-flip',
+    label: 'Tooltip — dark variant lighter than light variant',
+    url: `${BASE}/agent-traces`,
+    setup: async (page) => {
+      await page.waitForTimeout(3500);
+      // Find a Distribution cell in the table — the colored width bar inside the first data row
+      const distroCell = page.locator('table tbody tr').first().locator('div.h-3\\.5').first();
+      if (await distroCell.count()) {
+        await distroCell.hover().catch(() => {});
+        await page.waitForTimeout(800);
+      }
+    },
+    selector: 'main',
+  },
+];
+
+async function setTheme(page, theme) {
+  await page.evaluate((t) => {
+    localStorage.setItem('agent-health-theme', t);
+    if (t === 'dark') document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+  }, theme);
+}
+
+async function snap(page, shot, theme) {
+  // Navigate first to establish a clean execution context
+  try {
+    await page.goto(shot.url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  } catch (e) {
+    console.warn(`goto err ${shot.id} ${theme}:`, e.message);
+  }
+  // Apply theme after the SPA's bundle has loaded
+  await page.waitForTimeout(500);
+  try {
+    await setTheme(page, theme);
+  } catch (e) {
+    console.warn(`setTheme err ${shot.id} ${theme}:`, e.message);
+  }
+  await page.waitForTimeout(1500);
+
+  if (shot.setup) {
+    await shot.setup(page).catch((e) => console.warn(`setup err for ${shot.id}:`, e.message));
+  }
+
+  await page.waitForTimeout(500);
+  const featureDir = join(ROOT, shot.id);
+  mkdirSync(featureDir, { recursive: true });
+  const fname = `${stage}-${theme}.png`;
+  const outPath = join(featureDir, fname);
+  try {
+    if (shot.elementSelector) {
+      const el = page.locator(shot.elementSelector).first();
+      if (await el.count()) {
+        await el.screenshot({ path: outPath });
+      } else {
+        await page.screenshot({ path: outPath, fullPage: false });
+      }
+    } else {
+      await page.screenshot({ path: outPath, fullPage: false });
+    }
+    console.log(`✓ ${shot.id}/${fname}`);
+  } catch (e) {
+    console.warn(`screenshot err ${shot.id} ${theme}:`, e.message);
+  }
+}
+
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+try {
+  // Single context+page for the whole run — much lighter than per-shot contexts.
+  const ctx = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+  });
+  const page = await ctx.newPage();
+  // Bootstrap once
+  await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+
+  for (const shot of SHOTS) {
+    if (only && shot.id !== only) continue;
+    for (const theme of ['light', 'dark']) {
+      await snap(page, shot, theme);
+    }
+  }
+  await ctx.close();
+} finally {
+  await browser.close();
+}

--- a/tests/unit/components/uxThemingRegression.test.ts
+++ b/tests/unit/components/uxThemingRegression.test.ts
@@ -131,3 +131,94 @@ describe('Scope A theming regressions', () => {
     });
   });
 });
+
+describe('Scope B theming regressions', () => {
+  describe('Fix #7 — RunSummaryPanel donut uses theme tokens', () => {
+    const src = read('components/RunSummaryPanel.tsx');
+
+    it('does not hardcode #015aa3 or #ef4444 in pie data', () => {
+      expect(src).not.toMatch(/color: '#015aa3'/);
+      expect(src).not.toMatch(/color: '#ef4444'/);
+    });
+
+    it('uses hsl(var(--primary)) and hsl(var(--destructive)) for pie cells', () => {
+      expect(src).toMatch(/hsl\(var\(--primary\)\)/);
+      expect(src).toMatch(/hsl\(var\(--destructive\)\)/);
+    });
+  });
+
+  describe('Fix #8 — QuickRunModal error banner has dark variants', () => {
+    const src = read('components/QuickRunModal.tsx');
+
+    it('error banner gains dark: classes', () => {
+      // The errorMessage banner block must include both light and dark
+      // foreground/background classes; previously only light was set.
+      expect(src).toMatch(
+        /text-red-600 bg-red-50 border-red-200 dark:text-red-300 dark:bg-red-500\/10 dark:border-red-500\/30/
+      );
+    });
+  });
+
+  describe('Fix #9 — TrajectoryView failed step has light-mode contrast', () => {
+    const src = read('components/TrajectoryView.tsx');
+
+    it('failed typeColor includes both light and dark variants', () => {
+      // text-red-400 alone is 3.4:1 on white. Pair with text-red-600 for light.
+      expect(src).toMatch(/failed \? 'text-red-600 dark:text-red-400'/);
+      expect(src).not.toMatch(/failed \? 'text-red-400'/);
+    });
+  });
+
+  describe('Fix #10 — RunDetailsContent log levels readable in light mode', () => {
+    const src = read('components/RunDetailsContent.tsx');
+
+    it('ERROR/WARN log levels use both light and dark color variants', () => {
+      expect(src).toMatch(/log\.level === 'ERROR' \? 'text-red-600 dark:text-red-400'/);
+      expect(src).toMatch(/log\.level === 'WARN' \? 'text-amber-600 dark:text-amber-400'/);
+    });
+  });
+
+  describe('Fix #11 — ReportsPage difficulty badges have light variants', () => {
+    const src = read('components/ReportsPage.tsx');
+
+    it('does not use dark-only difficulty badge classes', () => {
+      // bg-yellow-900/30 text-yellow-400 etc. are pure dark variants.
+      expect(src).not.toMatch(/bg-yellow-900\/30 text-yellow-400 border-yellow-800/);
+      expect(src).not.toMatch(/bg-blue-900\/30 text-blue-400 border-blue-800/);
+      expect(src).not.toMatch(/bg-red-900\/30 text-red-400 border-red-800/);
+    });
+
+    it('difficulty badges include both light and dark token sets', () => {
+      expect(src).toMatch(/bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-500\/15/);
+      expect(src).toMatch(/bg-red-50 text-red-700 border-red-200 dark:bg-red-500\/15/);
+    });
+  });
+
+  describe('Fix #12 — CodingAgentsPage active search highlight not screaming', () => {
+    const src = read('components/codingAgents/CodingAgentsPage.tsx');
+
+    it('active <mark> does not use bg-yellow-400 + text-black', () => {
+      expect(src).not.toMatch(/'bg-yellow-400 text-black rounded-sm px-0\.5'/);
+    });
+
+    it('active <mark> uses themed yellow with dark variant', () => {
+      expect(src).toMatch(
+        /bg-yellow-200 text-yellow-900 dark:bg-yellow-500\/30 dark:text-yellow-200/
+      );
+    });
+  });
+
+  describe('Fix #13 — Layout sidebar styles use theme tokens', () => {
+    const src = read('components/Layout.tsx');
+
+    it('sidebar background and border are token-driven (no #FFFFFF / #D3DAE6 / #343741)', () => {
+      // The hardcoded hex values caused drift with .oui-sidebar in index.css
+      // and forced a separate isDarkMode branch for what should be a single
+      // theme-aware rule.
+      expect(src).not.toMatch(/background: isDarkMode \? '[^']*' : '#FFFFFF'/);
+      expect(src).not.toMatch(/borderRight: isDarkMode \? '1px solid #343741' : '1px solid #D3DAE6'/);
+      expect(src).toMatch(/background: 'hsl\(var\(--background\)\)'/);
+      expect(src).toMatch(/borderRight: '1px solid hsl\(var\(--border\)\)'/);
+    });
+  });
+});

--- a/tests/unit/components/uxThemingRegression.test.ts
+++ b/tests/unit/components/uxThemingRegression.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression guards for Scope A UX paper-cut fixes.
+ *
+ * Each fix migrated a component away from hardcoded colors that broke in
+ * one or both themes. These tests read the source files and assert the
+ * specific bad patterns are not re-introduced.
+ *
+ * Why source-level rather than render-level: the breakage is in the class
+ * strings themselves (Tailwind colors that ignore the .dark toggle, or
+ * Recharts props with literal hex). Rendered DOM doesn't surface them
+ * faithfully under JSDOM, but the source string does.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+const read = (rel: string): string => readFileSync(join(ROOT, rel), 'utf8');
+
+describe('Scope A theming regressions', () => {
+  describe('Fix #1 — RawEventsPanel uses theme tokens', () => {
+    const src = read('components/RawEventsPanel.tsx');
+
+    it('does not use hardcoded gray backgrounds', () => {
+      expect(src).not.toMatch(/className="[^"]*\bbg-gray-(50|100|200)\b[^"]*"/);
+    });
+
+    it('does not use hardcoded gray text', () => {
+      expect(src).not.toMatch(/\btext-gray-(500|600|700|800|900)\b/);
+    });
+  });
+
+  describe('Fix #2 — Latency histogram bars are visible in dark mode', () => {
+    it('LatencyHistogram bar palette includes dark variants', () => {
+      const src = read('components/traces/LatencyHistogram.tsx');
+      expect(src).toMatch(/dark:bg-/);
+      // Old palette used bare bg-emerald-500 etc. without a dark: variant.
+      // We accept any dark: counterpart, so just assert at least one exists
+      // alongside each emerald/amber/red bar declaration.
+      expect(src.match(/dark:bg-\w+-\d+\/\d+/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+    });
+
+    it('MetricsOverview latency color helper has dark variants', () => {
+      const src = read('components/traces/MetricsOverview.tsx');
+      expect(src).toMatch(/dark:bg-green/);
+      expect(src).toMatch(/dark:bg-red/);
+    });
+  });
+
+  describe('Fix #3 — MetricsTimeSeriesChart axes are token-driven', () => {
+    const src = read('components/comparison/MetricsTimeSeriesChart.tsx');
+
+    it('axes/grid use CSS variables not hex literals', () => {
+      // Recharts axes/grid must use hsl(var(--*)) so they react to theme.
+      expect(src).toMatch(/CartesianGrid[^/]*stroke="hsl\(var\(--border\)\)"/s);
+      expect(src).toMatch(/hsl\(var\(--muted-foreground\)\)/);
+    });
+
+    it('does not stroke axes with literal hex colors', () => {
+      // Old code used #cbd5e1 / #64748b etc. for tick fill / stroke.
+      expect(src).not.toMatch(/stroke="#[0-9a-fA-F]{3,8}"/);
+      expect(src).not.toMatch(/fill: '#[0-9a-fA-F]{3,8}'/);
+    });
+  });
+
+  describe('Fix #4 — React Flow surfaces use theme tokens', () => {
+    const flowFiles = [
+      'components/traces/TraceFlowView.tsx',
+      'components/traces/AgentMapView.tsx',
+      'components/comparison/sections/TraceFlowComparison.tsx',
+    ];
+
+    it.each(flowFiles)('%s uses CSS-var Background color', (rel) => {
+      const src = read(rel);
+      // Background dots/lines should reference --border, never a slate hex.
+      expect(src).toMatch(/<Background[^>]*color="hsl\(var\(--border\)\)"/s);
+      expect(src).not.toMatch(/color="#334155"/);
+    });
+
+    it.each(flowFiles)('%s MiniMap uses card/border tokens', (rel) => {
+      const src = read(rel);
+      expect(src).toMatch(/maskColor="hsl\(var\(--background\) \/ 0\.8\)"/);
+      expect(src).not.toMatch(/!bg-slate-900\/50/);
+      expect(src).not.toMatch(/!border-slate-700/);
+    });
+
+    it('SpanNode handles use muted-foreground/border tokens', () => {
+      const src = read('components/traces/flow/SpanNode.tsx');
+      expect(src).not.toMatch(/!bg-slate-400/);
+      expect(src).not.toMatch(/!border-slate-600/);
+      expect(src).toMatch(/!bg-muted-foreground\/60/);
+      expect(src).toMatch(/!border-border/);
+    });
+  });
+
+  describe('Fix #5 — Tooltip uses popover tokens, not hardcoded grays', () => {
+    it('TooltipContent default classes use bg-popover + text-popover-foreground', () => {
+      const src = read('components/ui/tooltip.tsx');
+      expect(src).toMatch(/bg-popover/);
+      expect(src).toMatch(/text-popover-foreground/);
+      expect(src).not.toMatch(/bg-gray-900 dark:bg-gray-800/);
+      expect(src).not.toMatch(/fill-gray-900/);
+    });
+
+    it('AgentTracesPage time-distribution tooltip drops hardcoded grays', () => {
+      const src = read('components/traces/AgentTracesPage.tsx');
+      // The Time Distribution TooltipContent should not re-introduce the
+      // hardcoded gray-900/text-white override that fought the theme.
+      expect(src).not.toMatch(
+        /<TooltipContent[^>]*className="[^"]*bg-gray-900 dark:bg-gray-800[^"]*"/s
+      );
+      expect(src).not.toMatch(
+        /<TooltipContent[^>]*className="[^"]*\[&>svg\]:fill-gray-900[^"]*"/s
+      );
+    });
+
+    it('TraceFlyoutContent tooltip drops hardcoded grays', () => {
+      const src = read('components/traces/TraceFlyoutContent.tsx');
+      expect(src).not.toMatch(
+        /<TooltipContent[^>]*className="[^"]*bg-gray-900 dark:bg-gray-800[^"]*"/s
+      );
+      expect(src).not.toMatch(
+        /<TooltipContent[^>]*className="[^"]*\[&>svg\]:fill-gray-900[^"]*"/s
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Continues the UX paper-cut cleanup from #219. Resolves the next 7 HIGH-severity light/dark theming issues found in the design review.

> Stacks on top of #219 — review and merge that one first; this PR's base will rebase to `main` automatically once #219 lands. The diff shown here is only the Scope B changes.

### Fixed
- **RunSummaryPanel** — donut chart slices now read from `hsl(var(--primary))` and `hsl(var(--destructive))` instead of hardcoded `#015aa3` / `#ef4444`.
- **QuickRunModal** — error banner gains `dark:` variants; previously rendered as a pure white-pink box on dark mode.
- **TrajectoryView** — failed-step header text now uses `text-red-600 dark:text-red-400` instead of bare `text-red-400` (3.4:1 → AA on white).
- **RunDetailsContent** — `ERROR` / `WARN` log levels now have both light and dark color variants; previously illegible on the light theme.
- **ReportsPage** — difficulty badges (Easy / Medium / Hard) gain full light-mode token sets next to the existing dark variants.
- **CodingAgentsPage** — active search highlight migrated from `bg-yellow-400 text-black` to themed `bg-yellow-200 text-yellow-900 dark:bg-yellow-500/30 dark:text-yellow-200`.
- **Layout** — sidebar inline `background` and `borderRight` use `hsl(var(--background))` / `hsl(var(--border))` instead of `isDarkMode`-branched literal hex.

### Tests
- Extended `tests/unit/components/uxThemingRegression.test.ts` with 10 Scope B regression guards (26 total). Each reads the fixed source file and fails if the bad pattern is reintroduced.
- Red-green verified by sabotaging the RunSummaryPanel pie color and confirming the test fails.

## Test plan

- [x] `npm run test:unit` — 3554 passed
- [ ] Reviewer spot-check in dark mode: Run Summary donut, QuickRun error banner, log levels in Run Details, Reports page difficulty badges, AI Dev Tools active search match, sidebar background after theme toggle.
