### PR TITLE
feat(config): support storage/observability in defineConfig() (TS config)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -214,13 +214,13 @@ export default defineConfig({
 });
 ```
 
-> **Storage/observability precedence.** These are resolved in the order
+> **Storage/observability precedence.** A cluster is resolved in the order
 > `agent-health.config.json` (written by the Settings UI at runtime) →
 > `agent-health.config.ts` (`defineConfig`, shown above) →
-> `OPENSEARCH_STORAGE_*` / `OPENSEARCH_LOGS_*` env vars → file-based fallback.
-> The JSON stays highest so the admin UI's runtime edits keep winning; the TS
-> config is the committed default for projects that don't mutate storage via the
-> UI. Keep secrets/endpoints in `process.env` so the committed `.ts` carries none.
+> `OPENSEARCH_STORAGE_*` / `OPENSEARCH_LOGS_*` env vars. The JSON stays highest
+> so the admin UI's runtime edits keep winning; the TS config is the committed
+> default for projects that don't mutate storage via the UI. Keep
+> secrets/endpoints in `process.env` so the committed `.ts` carries none.
 
 ### Config File Options
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -191,17 +191,36 @@ export default defineConfig({
     },
   ],
 
-  // Override storage (can also use env vars)
+  // Storage cluster (evaluation data). Read environment-specific values and
+  // secrets from process.env so the committed file carries none.
   storage: {
     endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT,
-    username: 'admin',
-    password: process.env.OPENSEARCH_STORAGE_PASSWORD,
+    authType: 'sigv4',          // 'none' | 'basic' | 'sigv4'
+    awsRegion: 'us-east-1',
+    awsService: 'es',           // 'es' (managed) | 'aoss' (Serverless)
+  },
+
+  // Observability cluster (agent traces/logs/metrics).
+  observability: {
+    endpoint: process.env.OPENSEARCH_LOGS_ENDPOINT,
+    authType: 'sigv4',
+    awsRegion: 'us-east-1',
+    awsService: 'es',
+    indexes: { traces: 'otel-v1-apm-span-*' },
   },
 
   // Custom test cases location
   testCases: './my-tests/*.yaml',
 });
 ```
+
+> **Storage/observability precedence.** These are resolved in the order
+> `agent-health.config.json` (written by the Settings UI at runtime) →
+> `agent-health.config.ts` (`defineConfig`, shown above) →
+> `OPENSEARCH_STORAGE_*` / `OPENSEARCH_LOGS_*` env vars → file-based fallback.
+> The JSON stays highest so the admin UI's runtime edits keep winning; the TS
+> config is the committed default for projects that don't mutate storage via the
+> UI. Keep secrets/endpoints in `process.env` so the committed `.ts` carries none.
 
 ### Config File Options
 

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -32,5 +32,7 @@ export {
   findConfigFile,
   getConfigFileInfo,
   clearConfigCache,
+  getStorageConfigFromCode,
+  getObservabilityConfigFromCode,
   DEFAULT_SERVER_CONFIG,
 } from './loader';

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -26,6 +26,7 @@ import type {
   JudgeConfig,
   TelemetryConfig,
 } from './types';
+import type { StorageClusterConfig, ObservabilityClusterConfig } from '@/types/index.js';
 
 /**
  * Default server configuration
@@ -193,6 +194,10 @@ function mergeConfigs(
     reporters,
     judge,
     telemetry,
+    // Cluster config authored in defineConfig() (optional). Consumed by the
+    // server's data-source resolution chain below the UI-written JSON.
+    ...(userConfig.storage ? { storage: userConfig.storage } : {}),
+    ...(userConfig.observability ? { observability: userConfig.observability } : {}),
   };
 }
 
@@ -220,6 +225,27 @@ async function loadUserConfig(configPath: string): Promise<UserConfig> {
  */
 let cachedConfig: ResolvedConfig | null = null;
 let cachedConfigPath: string | null = null;
+
+/**
+ * In-process cluster config authored in `defineConfig()` (TS config).
+ *
+ * The server's data-source resolver (`server/middleware/dataSourceConfig.ts`)
+ * has no access to the loaded TS config object, so the loader publishes the
+ * TS-authored storage/observability here for the resolver to consult between
+ * the UI-written JSON (highest) and the OPENSEARCH_*_ env layer (lowest).
+ */
+let tsStorageConfig: StorageClusterConfig | null = null;
+let tsObservabilityConfig: ObservabilityClusterConfig | null = null;
+
+/** TS-authored storage cluster config, or null if none was defined. */
+export function getStorageConfigFromCode(): StorageClusterConfig | null {
+  return tsStorageConfig;
+}
+
+/** TS-authored observability cluster config, or null if none was defined. */
+export function getObservabilityConfigFromCode(): ObservabilityClusterConfig | null {
+  return tsObservabilityConfig;
+}
 
 /**
  * Load and resolve configuration
@@ -264,6 +290,10 @@ export async function loadConfig(
   cachedConfig = resolved;
   cachedConfigPath = configFile?.path ?? null;
 
+  // Publish TS-authored cluster config for the server's data-source resolver.
+  tsStorageConfig = resolved.storage ?? null;
+  tsObservabilityConfig = resolved.observability ?? null;
+
   console.log(`[Config] Loaded ${resolved.agents.length} agents, ${Object.keys(resolved.models).length} models`);
 
   return resolved;
@@ -298,6 +328,8 @@ export function loadConfigSync(cwd: string = process.cwd()): ResolvedConfig {
 export function clearConfigCache(): void {
   cachedConfig = null;
   cachedConfigPath = null;
+  tsStorageConfig = null;
+  tsObservabilityConfig = null;
 }
 
 /**

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -169,31 +169,14 @@ export interface UserConfig {
   testCases?: string | string[];
 
   /**
-   * OpenSearch storage cluster configuration (evaluation data: test cases,
-   * benchmarks, runs, analytics).
-   *
-   * Lets a single committed `agent-health.config.ts` be the source of truth
-   * instead of also maintaining `agent-health.config.json`. Read
-   * environment-specific values and secrets from `process.env` so the
-   * committed file carries none, e.g.:
-   *
-   *   storage: {
-   *     endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT!,
-   *     authType: 'sigv4',
-   *     awsRegion: 'us-east-1',
-   *     awsService: 'es',
-   *   }
-   *
-   * Resolution precedence: agent-health.config.json (UI-written, runtime) →
-   * this `storage` (defineConfig) → OPENSEARCH_STORAGE_* env → file-based
-   * fallback. The JSON stays highest so the admin UI's runtime edits win.
+   * OpenSearch storage cluster config (evaluation data)
+   * Resolved below agent-health.config.json, above OPENSEARCH_STORAGE_* env
    */
   storage?: StorageClusterConfig;
 
   /**
-   * OpenSearch observability cluster configuration (agent traces, logs,
-   * metrics). Same precedence and `process.env` guidance as `storage`;
-   * the env layer is OPENSEARCH_LOGS_*.
+   * OpenSearch observability cluster config (agent traces, logs, metrics)
+   * Resolved below agent-health.config.json, above OPENSEARCH_LOGS_* env
    */
   observability?: ObservabilityClusterConfig;
 
@@ -260,9 +243,7 @@ export interface ResolvedConfig {
   reporters: ReporterConfig[];
   judge: JudgeConfig;
   telemetry: TelemetryConfig;
-  /** Storage cluster config authored in defineConfig() (optional). */
   storage?: StorageClusterConfig;
-  /** Observability cluster config authored in defineConfig() (optional). */
   observability?: ObservabilityClusterConfig;
 }
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -8,7 +8,14 @@
  * Type definitions for agent-health.config.ts files
  */
 
-import type { AgentConfig, ModelConfig, ConnectorProtocol, AgentHooks } from '@/types/index.js';
+import type {
+  AgentConfig,
+  ModelConfig,
+  ConnectorProtocol,
+  AgentHooks,
+  StorageClusterConfig,
+  ObservabilityClusterConfig,
+} from '@/types/index.js';
 import type { AgentConnector } from '@/services/connectors/types.js';
 
 /**
@@ -162,6 +169,35 @@ export interface UserConfig {
   testCases?: string | string[];
 
   /**
+   * OpenSearch storage cluster configuration (evaluation data: test cases,
+   * benchmarks, runs, analytics).
+   *
+   * Lets a single committed `agent-health.config.ts` be the source of truth
+   * instead of also maintaining `agent-health.config.json`. Read
+   * environment-specific values and secrets from `process.env` so the
+   * committed file carries none, e.g.:
+   *
+   *   storage: {
+   *     endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT!,
+   *     authType: 'sigv4',
+   *     awsRegion: 'us-east-1',
+   *     awsService: 'es',
+   *   }
+   *
+   * Resolution precedence: agent-health.config.json (UI-written, runtime) →
+   * this `storage` (defineConfig) → OPENSEARCH_STORAGE_* env → file-based
+   * fallback. The JSON stays highest so the admin UI's runtime edits win.
+   */
+  storage?: StorageClusterConfig;
+
+  /**
+   * OpenSearch observability cluster configuration (agent traces, logs,
+   * metrics). Same precedence and `process.env` guidance as `storage`;
+   * the env layer is OPENSEARCH_LOGS_*.
+   */
+  observability?: ObservabilityClusterConfig;
+
+  /**
    * Output reporters
    */
   reporters?: ReporterConfig[];
@@ -224,6 +260,10 @@ export interface ResolvedConfig {
   reporters: ReporterConfig[];
   judge: JudgeConfig;
   telemetry: TelemetryConfig;
+  /** Storage cluster config authored in defineConfig() (optional). */
+  storage?: StorageClusterConfig;
+  /** Observability cluster config authored in defineConfig() (optional). */
+  observability?: ObservabilityClusterConfig;
 }
 
 /**

--- a/server/middleware/dataSourceConfig.ts
+++ b/server/middleware/dataSourceConfig.ts
@@ -45,13 +45,13 @@ export const STORAGE_INDEXES = {
  * Resolve storage cluster configuration
  *
  * Priority:
- * 1. File config (agent-health.config.json) - UI-written, runtime
+ * 1. File config (agent-health.config.json)
  * 2. Code config (agent-health.config.ts defineConfig storage)
  * 3. Environment variables (OPENSEARCH_STORAGE_*)
  * 4. null (not configured)
  */
 export function resolveStorageConfig(req: Request): StorageClusterConfig | null {
-  // 1. Check file config first (admin UI writes here at runtime, must win)
+  // 1. Check file config first
   const fileConfig = getStorageConfigFromFile();
   if (fileConfig) {
     return fileConfig;
@@ -87,7 +87,7 @@ export function resolveStorageConfig(req: Request): StorageClusterConfig | null 
  * Resolve observability cluster configuration
  *
  * Priority:
- * 1. File config (agent-health.config.json) - UI-written, runtime
+ * 1. File config (agent-health.config.json)
  * 2. Code config (agent-health.config.ts defineConfig observability)
  * 3. Environment variables (OPENSEARCH_LOGS_*)
  * 4. null (not configured)
@@ -95,7 +95,7 @@ export function resolveStorageConfig(req: Request): StorageClusterConfig | null 
  * Index patterns use defaults if not specified in file or env vars.
  */
 export function resolveObservabilityConfig(req: Request): ObservabilityClusterConfig | null {
-  // 1. Check file config first (admin UI writes here at runtime, must win)
+  // 1. Check file config first
   const fileConfig = getObservabilityConfigFromFile();
 
   if (fileConfig) {

--- a/server/middleware/dataSourceConfig.ts
+++ b/server/middleware/dataSourceConfig.ts
@@ -19,6 +19,10 @@ import {
   getStorageConfigFromFile,
   getObservabilityConfigFromFile,
 } from '../services/configService.js';
+import {
+  getStorageConfigFromCode,
+  getObservabilityConfigFromCode,
+} from '../../lib/config/index.js';
 
 // Default OTEL index patterns
 export const DEFAULT_OTEL_INDEXES = {
@@ -41,18 +45,25 @@ export const STORAGE_INDEXES = {
  * Resolve storage cluster configuration
  *
  * Priority:
- * 1. File config (agent-health.config.json)
- * 2. Environment variables (OPENSEARCH_STORAGE_*)
- * 3. null (not configured)
+ * 1. File config (agent-health.config.json) - UI-written, runtime
+ * 2. Code config (agent-health.config.ts defineConfig storage)
+ * 3. Environment variables (OPENSEARCH_STORAGE_*)
+ * 4. null (not configured)
  */
 export function resolveStorageConfig(req: Request): StorageClusterConfig | null {
-  // 1. Check file config first
+  // 1. Check file config first (admin UI writes here at runtime, must win)
   const fileConfig = getStorageConfigFromFile();
   if (fileConfig) {
     return fileConfig;
   }
 
-  // 2. Fall back to environment variables
+  // 2. Code config (defineConfig in agent-health.config.ts)
+  const codeConfig = getStorageConfigFromCode();
+  if (codeConfig) {
+    return codeConfig;
+  }
+
+  // 3. Fall back to environment variables
   const envEndpoint = process.env.OPENSEARCH_STORAGE_ENDPOINT;
 
   if (envEndpoint) {
@@ -76,16 +87,17 @@ export function resolveStorageConfig(req: Request): StorageClusterConfig | null 
  * Resolve observability cluster configuration
  *
  * Priority:
- * 1. File config (agent-health.config.json)
- * 2. Environment variables (OPENSEARCH_LOGS_*)
- * 3. null (not configured)
+ * 1. File config (agent-health.config.json) - UI-written, runtime
+ * 2. Code config (agent-health.config.ts defineConfig observability)
+ * 3. Environment variables (OPENSEARCH_LOGS_*)
+ * 4. null (not configured)
  *
  * Index patterns use defaults if not specified in file or env vars.
  */
 export function resolveObservabilityConfig(req: Request): ObservabilityClusterConfig | null {
-  // 1. Check file config first
+  // 1. Check file config first (admin UI writes here at runtime, must win)
   const fileConfig = getObservabilityConfigFromFile();
-  
+
   if (fileConfig) {
     return {
       endpoint: fileConfig.endpoint,
@@ -104,7 +116,20 @@ export function resolveObservabilityConfig(req: Request): ObservabilityClusterCo
     };
   }
 
-  // 2. Fall back to environment variables
+  // 2. Code config (defineConfig in agent-health.config.ts), with index defaults
+  const codeConfig = getObservabilityConfigFromCode();
+  if (codeConfig) {
+    return {
+      ...codeConfig,
+      indexes: {
+        traces: codeConfig.indexes?.traces || DEFAULT_OTEL_INDEXES.traces,
+        logs: codeConfig.indexes?.logs || DEFAULT_OTEL_INDEXES.logs,
+        metrics: codeConfig.indexes?.metrics || DEFAULT_OTEL_INDEXES.metrics,
+      },
+    };
+  }
+
+  // 3. Fall back to environment variables
   const envEndpoint = process.env.OPENSEARCH_LOGS_ENDPOINT;
 
   if (envEndpoint) {

--- a/server/services/configService.ts
+++ b/server/services/configService.ts
@@ -19,6 +19,10 @@ import path from 'path';
 import { debug } from '../../lib/debug.js';
 import { getStorageState, type StorageBackend } from '../adapters/index.js';
 import { configToCacheKey } from './opensearchClientFactory.js';
+import {
+  getStorageConfigFromCode,
+  getObservabilityConfigFromCode,
+} from '../../lib/config/index.js';
 import type { StorageClusterConfig, ObservabilityClusterConfig, ClusterAuthType } from '../../types/index.js';
 
 // Same filename used by customAgentStore.ts
@@ -58,7 +62,7 @@ interface ConfigFileDataSources {
 export interface ConfigStatus {
   storage: {
     configured: boolean;
-    source: 'file' | 'environment' | 'none';
+    source: 'file' | 'code' | 'environment' | 'none';
     endpoint?: string;
     authType?: ClusterAuthType;
     username?: string;    // Safe to return; lets the form pre-fill the username
@@ -69,7 +73,7 @@ export interface ConfigStatus {
   };
   observability: {
     configured: boolean;
-    source: 'file' | 'environment' | 'none';
+    source: 'file' | 'code' | 'environment' | 'none';
     endpoint?: string;
     authType?: ClusterAuthType;
     username?: string;
@@ -312,21 +316,27 @@ export function clearObservabilityConfig(): void {
  */
 export function getConfigStatus(): ConfigStatus {
   const config = readConfigFromDisk() as ConfigFileDataSources | null;
+  const codeStorage = getStorageConfigFromCode();
+  const codeObs = getObservabilityConfigFromCode();
 
   // Determine storage config source
-  let storageSource: 'file' | 'environment' | 'none' = 'none';
+  // Precedence: file (UI-written) → code (defineConfig) → environment → none.
+  let storageSource: 'file' | 'code' | 'environment' | 'none' = 'none';
   let storageEndpoint: string | undefined;
 
   if (config?.storage?.endpoint) {
     storageSource = 'file';
     storageEndpoint = config.storage.endpoint;
+  } else if (codeStorage?.endpoint) {
+    storageSource = 'code';
+    storageEndpoint = codeStorage.endpoint;
   } else if (process.env.OPENSEARCH_STORAGE_ENDPOINT) {
     storageSource = 'environment';
     storageEndpoint = process.env.OPENSEARCH_STORAGE_ENDPOINT;
   }
 
   // Determine observability config source
-  let obsSource: 'file' | 'environment' | 'none' = 'none';
+  let obsSource: 'file' | 'code' | 'environment' | 'none' = 'none';
   let obsEndpoint: string | undefined;
   let obsIndexes: ConfigStatus['observability']['indexes'];
 
@@ -334,6 +344,10 @@ export function getConfigStatus(): ConfigStatus {
     obsSource = 'file';
     obsEndpoint = config.observability.endpoint;
     obsIndexes = config.observability.indexes;
+  } else if (codeObs?.endpoint) {
+    obsSource = 'code';
+    obsEndpoint = codeObs.endpoint;
+    obsIndexes = codeObs.indexes;
   } else if (process.env.OPENSEARCH_LOGS_ENDPOINT) {
     obsSource = 'environment';
     obsEndpoint = process.env.OPENSEARCH_LOGS_ENDPOINT;
@@ -343,36 +357,52 @@ export function getConfigStatus(): ConfigStatus {
     };
   }
 
-  // Resolve SigV4 fields
+  // Resolve SigV4 fields per source
   const storageAuthType: ClusterAuthType | undefined = storageSource === 'file'
     ? config?.storage?.authType
-    : (process.env.OPENSEARCH_STORAGE_AUTH_TYPE as ClusterAuthType) || undefined;
+    : storageSource === 'code'
+      ? codeStorage?.authType
+      : (process.env.OPENSEARCH_STORAGE_AUTH_TYPE as ClusterAuthType) || undefined;
   const storageAwsProfile = storageSource === 'file'
     ? config?.storage?.awsProfile
-    : process.env.OPENSEARCH_STORAGE_AWS_PROFILE;
+    : storageSource === 'code'
+      ? codeStorage?.awsProfile
+      : process.env.OPENSEARCH_STORAGE_AWS_PROFILE;
   const storageAwsRegion = storageSource === 'file'
     ? config?.storage?.awsRegion
-    : process.env.OPENSEARCH_STORAGE_AWS_REGION;
+    : storageSource === 'code'
+      ? codeStorage?.awsRegion
+      : process.env.OPENSEARCH_STORAGE_AWS_REGION;
   const storageAwsService = storageSource === 'file'
     ? config?.storage?.awsService
-    : (process.env.OPENSEARCH_STORAGE_AWS_SERVICE as 'es' | 'aoss') || undefined;
+    : storageSource === 'code'
+      ? codeStorage?.awsService
+      : (process.env.OPENSEARCH_STORAGE_AWS_SERVICE as 'es' | 'aoss') || undefined;
 
   const obsAuthType: ClusterAuthType | undefined = obsSource === 'file'
     ? config?.observability?.authType
-    : (process.env.OPENSEARCH_LOGS_AUTH_TYPE as ClusterAuthType) || undefined;
+    : obsSource === 'code'
+      ? codeObs?.authType
+      : (process.env.OPENSEARCH_LOGS_AUTH_TYPE as ClusterAuthType) || undefined;
   const obsAwsProfile = obsSource === 'file'
     ? config?.observability?.awsProfile
-    : process.env.OPENSEARCH_LOGS_AWS_PROFILE;
+    : obsSource === 'code'
+      ? codeObs?.awsProfile
+      : process.env.OPENSEARCH_LOGS_AWS_PROFILE;
   const obsAwsRegion = obsSource === 'file'
     ? config?.observability?.awsRegion
-    : process.env.OPENSEARCH_LOGS_AWS_REGION;
+    : obsSource === 'code'
+      ? codeObs?.awsRegion
+      : process.env.OPENSEARCH_LOGS_AWS_REGION;
   const obsAwsService = obsSource === 'file'
     ? config?.observability?.awsService
-    : (process.env.OPENSEARCH_LOGS_AWS_SERVICE as 'es' | 'aoss') || undefined;
+    : obsSource === 'code'
+      ? codeObs?.awsService
+      : (process.env.OPENSEARCH_LOGS_AWS_SERVICE as 'es' | 'aoss') || undefined;
 
   // Compute runtime storage state
   const storageState = getStorageState();
-  const resolvedStorageConfig = getStorageConfigFromFile() ??
+  const resolvedStorageConfig = getStorageConfigFromFile() ?? codeStorage ??
     (process.env.OPENSEARCH_STORAGE_ENDPOINT ? { endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT } as StorageClusterConfig : null);
   const fileConfigKey = resolvedStorageConfig ? configToCacheKey(resolvedStorageConfig) : null;
   const drifted = fileConfigKey !== storageState.configKey &&
@@ -386,10 +416,14 @@ export function getConfigStatus(): ConfigStatus {
       authType: storageAuthType,
       username: storageSource === 'file'
         ? config?.storage?.username
-        : process.env.OPENSEARCH_STORAGE_USERNAME,
+        : storageSource === 'code'
+          ? codeStorage?.username
+          : process.env.OPENSEARCH_STORAGE_USERNAME,
       hasPassword: storageSource === 'file'
         ? Boolean(config?.storage?.password)
-        : Boolean(process.env.OPENSEARCH_STORAGE_PASSWORD),
+        : storageSource === 'code'
+          ? Boolean(codeStorage?.password)
+          : Boolean(process.env.OPENSEARCH_STORAGE_PASSWORD),
       awsProfile: storageAwsProfile,
       awsRegion: storageAwsRegion,
       awsService: storageAwsService,
@@ -401,10 +435,14 @@ export function getConfigStatus(): ConfigStatus {
       authType: obsAuthType,
       username: obsSource === 'file'
         ? config?.observability?.username
-        : process.env.OPENSEARCH_LOGS_USERNAME,
+        : obsSource === 'code'
+          ? codeObs?.username
+          : process.env.OPENSEARCH_LOGS_USERNAME,
       hasPassword: obsSource === 'file'
         ? Boolean(config?.observability?.password)
-        : Boolean(process.env.OPENSEARCH_LOGS_PASSWORD),
+        : obsSource === 'code'
+          ? Boolean(codeObs?.password)
+          : Boolean(process.env.OPENSEARCH_LOGS_PASSWORD),
       awsProfile: obsAwsProfile,
       awsRegion: obsAwsRegion,
       awsService: obsAwsService,

--- a/server/services/configService.ts
+++ b/server/services/configService.ts
@@ -400,9 +400,14 @@ export function getConfigStatus(): ConfigStatus {
       ? codeObs?.awsService
       : (process.env.OPENSEARCH_LOGS_AWS_SERVICE as 'es' | 'aoss') || undefined;
 
-  // Compute runtime storage state
+  // Compute runtime storage state.
+  // NOTE: drift detection compares the runtime storage backend against the
+  // file/env-derived config key only (the sources the storage adapter
+  // initializes from). Code config (defineConfig) is intentionally excluded
+  // here to avoid false drift signals; it still participates in resolution
+  // and in the `configured`/`source` reporting above.
   const storageState = getStorageState();
-  const resolvedStorageConfig = getStorageConfigFromFile() ?? codeStorage ??
+  const resolvedStorageConfig = getStorageConfigFromFile() ??
     (process.env.OPENSEARCH_STORAGE_ENDPOINT ? { endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT } as StorageClusterConfig : null);
   const fileConfigKey = resolvedStorageConfig ? configToCacheKey(resolvedStorageConfig) : null;
   const drifted = fileConfigKey !== storageState.configKey &&

--- a/server/services/configService.ts
+++ b/server/services/configService.ts
@@ -319,86 +319,51 @@ export function getConfigStatus(): ConfigStatus {
   const codeStorage = getStorageConfigFromCode();
   const codeObs = getObservabilityConfigFromCode();
 
-  // Determine storage config source
-  // Precedence: file (UI-written) → code (defineConfig) → environment → none.
-  let storageSource: 'file' | 'code' | 'environment' | 'none' = 'none';
-  let storageEndpoint: string | undefined;
+  // Resolve each cluster to a single config object + source, following the
+  // precedence: file (UI-written) → code (defineConfig) → environment → none.
+  const envStorage: StorageClusterConfig | null = process.env.OPENSEARCH_STORAGE_ENDPOINT
+    ? {
+      endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT,
+      authType: (process.env.OPENSEARCH_STORAGE_AUTH_TYPE as ClusterAuthType) || undefined,
+      username: process.env.OPENSEARCH_STORAGE_USERNAME,
+      password: process.env.OPENSEARCH_STORAGE_PASSWORD,
+      awsProfile: process.env.OPENSEARCH_STORAGE_AWS_PROFILE,
+      awsRegion: process.env.OPENSEARCH_STORAGE_AWS_REGION,
+      awsService: (process.env.OPENSEARCH_STORAGE_AWS_SERVICE as 'es' | 'aoss') || undefined,
+    }
+    : null;
 
-  if (config?.storage?.endpoint) {
-    storageSource = 'file';
-    storageEndpoint = config.storage.endpoint;
-  } else if (codeStorage?.endpoint) {
-    storageSource = 'code';
-    storageEndpoint = codeStorage.endpoint;
-  } else if (process.env.OPENSEARCH_STORAGE_ENDPOINT) {
-    storageSource = 'environment';
-    storageEndpoint = process.env.OPENSEARCH_STORAGE_ENDPOINT;
-  }
+  const envObs: ObservabilityClusterConfig | null = process.env.OPENSEARCH_LOGS_ENDPOINT
+    ? {
+      endpoint: process.env.OPENSEARCH_LOGS_ENDPOINT,
+      authType: (process.env.OPENSEARCH_LOGS_AUTH_TYPE as ClusterAuthType) || undefined,
+      username: process.env.OPENSEARCH_LOGS_USERNAME,
+      password: process.env.OPENSEARCH_LOGS_PASSWORD,
+      awsProfile: process.env.OPENSEARCH_LOGS_AWS_PROFILE,
+      awsRegion: process.env.OPENSEARCH_LOGS_AWS_REGION,
+      awsService: (process.env.OPENSEARCH_LOGS_AWS_SERVICE as 'es' | 'aoss') || undefined,
+      indexes: {
+        traces: process.env.OPENSEARCH_LOGS_TRACES_INDEX,
+        logs: process.env.OPENSEARCH_LOGS_INDEX,
+      },
+    }
+    : null;
 
-  // Determine observability config source
-  let obsSource: 'file' | 'code' | 'environment' | 'none' = 'none';
-  let obsEndpoint: string | undefined;
-  let obsIndexes: ConfigStatus['observability']['indexes'];
+  const storageSource: ConfigStatus['storage']['source'] =
+    config?.storage?.endpoint ? 'file' : codeStorage?.endpoint ? 'code' : envStorage ? 'environment' : 'none';
+  const storage: StorageClusterConfig | null =
+    storageSource === 'file' ? config!.storage!
+      : storageSource === 'code' ? codeStorage
+        : storageSource === 'environment' ? envStorage
+          : null;
 
-  if (config?.observability?.endpoint) {
-    obsSource = 'file';
-    obsEndpoint = config.observability.endpoint;
-    obsIndexes = config.observability.indexes;
-  } else if (codeObs?.endpoint) {
-    obsSource = 'code';
-    obsEndpoint = codeObs.endpoint;
-    obsIndexes = codeObs.indexes;
-  } else if (process.env.OPENSEARCH_LOGS_ENDPOINT) {
-    obsSource = 'environment';
-    obsEndpoint = process.env.OPENSEARCH_LOGS_ENDPOINT;
-    obsIndexes = {
-      traces: process.env.OPENSEARCH_LOGS_TRACES_INDEX,
-      logs: process.env.OPENSEARCH_LOGS_INDEX,
-    };
-  }
-
-  // Resolve SigV4 fields per source
-  const storageAuthType: ClusterAuthType | undefined = storageSource === 'file'
-    ? config?.storage?.authType
-    : storageSource === 'code'
-      ? codeStorage?.authType
-      : (process.env.OPENSEARCH_STORAGE_AUTH_TYPE as ClusterAuthType) || undefined;
-  const storageAwsProfile = storageSource === 'file'
-    ? config?.storage?.awsProfile
-    : storageSource === 'code'
-      ? codeStorage?.awsProfile
-      : process.env.OPENSEARCH_STORAGE_AWS_PROFILE;
-  const storageAwsRegion = storageSource === 'file'
-    ? config?.storage?.awsRegion
-    : storageSource === 'code'
-      ? codeStorage?.awsRegion
-      : process.env.OPENSEARCH_STORAGE_AWS_REGION;
-  const storageAwsService = storageSource === 'file'
-    ? config?.storage?.awsService
-    : storageSource === 'code'
-      ? codeStorage?.awsService
-      : (process.env.OPENSEARCH_STORAGE_AWS_SERVICE as 'es' | 'aoss') || undefined;
-
-  const obsAuthType: ClusterAuthType | undefined = obsSource === 'file'
-    ? config?.observability?.authType
-    : obsSource === 'code'
-      ? codeObs?.authType
-      : (process.env.OPENSEARCH_LOGS_AUTH_TYPE as ClusterAuthType) || undefined;
-  const obsAwsProfile = obsSource === 'file'
-    ? config?.observability?.awsProfile
-    : obsSource === 'code'
-      ? codeObs?.awsProfile
-      : process.env.OPENSEARCH_LOGS_AWS_PROFILE;
-  const obsAwsRegion = obsSource === 'file'
-    ? config?.observability?.awsRegion
-    : obsSource === 'code'
-      ? codeObs?.awsRegion
-      : process.env.OPENSEARCH_LOGS_AWS_REGION;
-  const obsAwsService = obsSource === 'file'
-    ? config?.observability?.awsService
-    : obsSource === 'code'
-      ? codeObs?.awsService
-      : (process.env.OPENSEARCH_LOGS_AWS_SERVICE as 'es' | 'aoss') || undefined;
+  const obsSource: ConfigStatus['observability']['source'] =
+    config?.observability?.endpoint ? 'file' : codeObs?.endpoint ? 'code' : envObs ? 'environment' : 'none';
+  const observability: ObservabilityClusterConfig | null =
+    obsSource === 'file' ? config!.observability!
+      : obsSource === 'code' ? codeObs
+        : obsSource === 'environment' ? envObs
+          : null;
 
   // Compute runtime storage state.
   // NOTE: drift detection compares the runtime storage backend against the
@@ -407,8 +372,7 @@ export function getConfigStatus(): ConfigStatus {
   // here to avoid false drift signals; it still participates in resolution
   // and in the `configured`/`source` reporting above.
   const storageState = getStorageState();
-  const resolvedStorageConfig = getStorageConfigFromFile() ??
-    (process.env.OPENSEARCH_STORAGE_ENDPOINT ? { endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT } as StorageClusterConfig : null);
+  const resolvedStorageConfig = getStorageConfigFromFile() ?? envStorage;
   const fileConfigKey = resolvedStorageConfig ? configToCacheKey(resolvedStorageConfig) : null;
   const drifted = fileConfigKey !== storageState.configKey &&
     storageState.configKey !== '__file_override__';
@@ -417,41 +381,25 @@ export function getConfigStatus(): ConfigStatus {
     storage: {
       configured: storageSource !== 'none',
       source: storageSource,
-      endpoint: storageEndpoint,
-      authType: storageAuthType,
-      username: storageSource === 'file'
-        ? config?.storage?.username
-        : storageSource === 'code'
-          ? codeStorage?.username
-          : process.env.OPENSEARCH_STORAGE_USERNAME,
-      hasPassword: storageSource === 'file'
-        ? Boolean(config?.storage?.password)
-        : storageSource === 'code'
-          ? Boolean(codeStorage?.password)
-          : Boolean(process.env.OPENSEARCH_STORAGE_PASSWORD),
-      awsProfile: storageAwsProfile,
-      awsRegion: storageAwsRegion,
-      awsService: storageAwsService,
+      endpoint: storage?.endpoint,
+      authType: storage?.authType,
+      username: storage?.username,
+      hasPassword: Boolean(storage?.password),
+      awsProfile: storage?.awsProfile,
+      awsRegion: storage?.awsRegion,
+      awsService: storage?.awsService,
     },
     observability: {
       configured: obsSource !== 'none',
       source: obsSource,
-      endpoint: obsEndpoint,
-      authType: obsAuthType,
-      username: obsSource === 'file'
-        ? config?.observability?.username
-        : obsSource === 'code'
-          ? codeObs?.username
-          : process.env.OPENSEARCH_LOGS_USERNAME,
-      hasPassword: obsSource === 'file'
-        ? Boolean(config?.observability?.password)
-        : obsSource === 'code'
-          ? Boolean(codeObs?.password)
-          : Boolean(process.env.OPENSEARCH_LOGS_PASSWORD),
-      awsProfile: obsAwsProfile,
-      awsRegion: obsAwsRegion,
-      awsService: obsAwsService,
-      indexes: obsIndexes,
+      endpoint: observability?.endpoint,
+      authType: observability?.authType,
+      username: observability?.username,
+      hasPassword: Boolean(observability?.password),
+      awsProfile: observability?.awsProfile,
+      awsRegion: observability?.awsRegion,
+      awsService: observability?.awsService,
+      indexes: observability?.indexes,
     },
     runtime: {
       storage: {

--- a/tests/unit/lib/config/loader.test.ts
+++ b/tests/unit/lib/config/loader.test.ts
@@ -122,6 +122,78 @@ describe('defineConfig', () => {
     const result = defineConfig(testConfig);
     expect(result.agents[0].hooks.beforeRequest).toBe(hookFn);
   });
+
+  it('should preserve storage and observability cluster config', () => {
+    const { defineConfig } = require('@/lib/config/defineConfig');
+
+    const testConfig = {
+      agents: [{ key: 'a', name: 'A', endpoint: 'http://localhost:3000' }],
+      storage: {
+        endpoint: 'https://store.example.com',
+        authType: 'sigv4' as const,
+        awsRegion: 'us-east-1',
+        awsService: 'es' as const,
+      },
+      observability: {
+        endpoint: 'https://obs.example.com',
+        authType: 'sigv4' as const,
+        awsRegion: 'us-east-1',
+        awsService: 'es' as const,
+        indexes: { traces: 'otel-v1-apm-span-*' },
+      },
+    };
+
+    const result = defineConfig(testConfig);
+    expect(result.storage?.endpoint).toBe('https://store.example.com');
+    expect(result.storage?.authType).toBe('sigv4');
+    expect(result.observability?.endpoint).toBe('https://obs.example.com');
+    expect(result.observability?.indexes?.traces).toBe('otel-v1-apm-span-*');
+  });
+});
+
+describe('code cluster config accessors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('return null when no config file defines storage/observability', async () => {
+    const mockFs = require('fs');
+    mockFs.existsSync.mockReturnValue(false);
+
+    const {
+      loadConfig,
+      clearConfigCache,
+      getStorageConfigFromCode,
+      getObservabilityConfigFromCode,
+    } = require('@/lib/config/loader');
+    clearConfigCache();
+    await loadConfig('/nonexistent', true);
+
+    expect(getStorageConfigFromCode()).toBeNull();
+    expect(getObservabilityConfigFromCode()).toBeNull();
+  });
+
+  it('clearConfigCache resets the published code cluster config', async () => {
+    const mockFs = require('fs');
+    mockFs.existsSync.mockReturnValue(false);
+
+    const {
+      loadConfig,
+      clearConfigCache,
+      getStorageConfigFromCode,
+    } = require('@/lib/config/loader');
+    clearConfigCache();
+    await loadConfig('/nonexistent', true);
+    clearConfigCache();
+
+    expect(getStorageConfigFromCode()).toBeNull();
+  });
 });
 
 describe('findConfigFile', () => {


### PR DESCRIPTION
## Description

Adds optional `storage` and `observability` cluster config to `defineConfig()` (`agent-health.config.ts`), so a single committed TS config can be the source of truth instead of also maintaining `agent-health.config.json`. Implements the proposal in #261.

Today `defineConfig()` cannot express storage/observability — those come only from `agent-health.config.json` or `OPENSEARCH_STORAGE_*` / `OPENSEARCH_LOGS_*` env vars. A project that already has an `agent-health.config.ts` ends up committing a second JSON file purely to share cluster config.

## Changes

- `lib/config/types.ts`: add optional `storage?: StorageClusterConfig` and `observability?: ObservabilityClusterConfig` to `UserConfig` (and `ResolvedConfig`).
- `lib/config/loader.ts`: carry these through `mergeConfigs`, and publish the TS-authored cluster config in-process via `getStorageConfigFromCode()` / `getObservabilityConfigFromCode()` (the server resolver has no access to the loaded config object). Cleared in `clearConfigCache()`.
- `server/middleware/dataSourceConfig.ts`: consult the code config between the JSON and env layers in `resolveStorageConfig` / `resolveObservabilityConfig`.
- `server/services/configService.ts`: `getConfigStatus()` gains a `'code'` source so the UI/CLI report TS-configured clusters accurately instead of "not configured".
- `docs/CONFIGURATION.md`: document the fields, the `process.env` guidance, and the precedence.

## Resolution precedence (explicit)

`agent-health.config.json` (UI-written, runtime) → `agent-health.config.ts` (`defineConfig`) → `OPENSEARCH_STORAGE_*` / `OPENSEARCH_LOGS_*` env vars.

The JSON stays highest so the admin UI's runtime edits keep winning; the TS config becomes the committed default for projects that don't mutate storage via the UI. **No behavior change for existing JSON/env users.**

## Example

```ts
export default defineConfig({
  storage: {
    endpoint: process.env.OPENSEARCH_STORAGE_ENDPOINT!,
    authType: 'sigv4',
    awsRegion: 'us-east-1',
    awsService: 'es',
  },
  observability: {
    endpoint: process.env.OPENSEARCH_LOGS_ENDPOINT!,
    authType: 'sigv4',
    awsRegion: 'us-east-1',
    awsService: 'es',
    indexes: { traces: 'otel-v1-apm-span-*' },
  },
});
```

## Testing

- `npx tsc --noEmit` clean.
- Added unit tests in `tests/unit/lib/config/loader.test.ts` (code accessors default to null; `defineConfig` preserves `storage`/`observability`; `clearConfigCache` resets the published config).
- Existing config/service suites pass (`tests/unit/lib/config`, `tests/unit/lib/dataSourceConfig.test.ts`, `tests/unit/server/services`): 657 passed, 0 failed.

## Notes

- Surfaced while migrating a real deployment (Amazon OpenSearch Service domain with IAM FGAC) to the code SDK — the `.ts` `observability` block was silently ignored and the UI reported "Observability data source not configured".
- Related to the Test SDK v2 direction (#256 / RFC 004); happy to reshape if this should land within that redesign.

Closes #261
