### PR TITLE
fix: CLI `benchmark -f` polls storage on long runs instead of reporting 0/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- **CLI `benchmark -f`: long runs no longer report `0/0` when the progress stream drops** ([cli/commands/benchmark.ts](cli/commands/benchmark.ts), [cli/utils/apiClient.ts](cli/utils/apiClient.ts)): the unified evaluation-run path read the final run **once**, the moment the SSE progress stream ended. On a long run (e.g. a subprocess agent that takes ~10 min) a proxy idle-timeout drops the stream after a few minutes, so the CLI reported partial/`0/0` results — or `fetch failed` — even though the server kept executing and persisting server-side (WebIR user feedback). Now the SSE read loop tolerates a mid-stream disconnect (as long as the runId was captured) and the CLI **polls `/api/storage/evaluation-runs/:id` until the run reaches a terminal state** (`ApiClient.pollEvaluationRunStatus`, mirroring the existing `pollRunStatus` fallback) before reporting — reading the true result from storage. Default poll budget 60 min (subprocess agents can be slow). Unit: [tests/unit/cli/utils/apiClient.test.ts](tests/unit/cli/utils/apiClient.test.ts) (polls until terminal after a `running` read; returns immediately when already terminal).
+
 ### Added
 - **Claude Code: log user prompts to OTel by default** ([services/connectors/claude-code/ClaudeCodeConnector.ts](services/connectors/claude-code/ClaudeCodeConnector.ts)): when telemetry is enabled, `createBedrockClaudeCodeConnector` now sets `OTEL_LOG_USER_PROMPTS=1` in the child env so the user's prompt is captured on the `claude_code` OTel log records and is visible in the Traces view. Opt out with `OTEL_LOG_USER_PROMPTS=0` in the host env. Unit: [tests/unit/services/connectors/claude-code/ClaudeCodeConnector.test.ts](tests/unit/services/connectors/claude-code/ClaudeCodeConnector.test.ts).
 

--- a/cli/commands/benchmark.ts
+++ b/cli/commands/benchmark.ts
@@ -25,7 +25,7 @@ import { ApiClient, ServerError, type BenchmarkExecutionEvent } from '@/cli/util
 import { validateTestCasesArrayJson, type ValidatedTestCaseInput } from '@/lib/testCaseValidation.js';
 import { calculateRunStats, getReportIdsFromRun } from '@/lib/runStats.js';
 import { formatJson, formatMarkdownTable, parseOutputFormat, OUTPUT_FORMAT_DESCRIPTION, type OutputFormat } from '@/cli/utils/formatOutput.js';
-import type { AgentConfig, Benchmark, BenchmarkRun, TestCase, TestCaseRun, EvaluationReport, TestCaseSource } from '@/types/index.js';
+import type { AgentConfig, Benchmark, BenchmarkRun, TestCase, TestCaseRun, EvaluationReport, TestCaseSource, EvaluationRun } from '@/types/index.js';
 import { existsSync, statSync } from 'fs';
 import { isCodeFile } from '@/lib/testCases/loader.js';
 
@@ -639,53 +639,80 @@ async function runUnifiedMode(
     let totalTestCases = 0;
     let completedCount = 0;
     let runId = '';
+    let sseSawTerminal = false;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
 
-      for (const line of lines) {
-        if (line.startsWith('event: ')) {
-          const eventType = line.slice(7);
-          continue;
-        }
-        if (line.startsWith('data: ')) {
-          try {
-            const data = JSON.parse(line.slice(6));
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            const eventType = line.slice(7);
+            continue;
+          }
+          if (line.startsWith('data: ')) {
+            try {
+              const data = JSON.parse(line.slice(6));
 
-            if (data.runId && data.testCases) {
-              // Started event
-              runId = data.runId;
-              totalTestCases = data.testCases.length;
-              spinner.text = `Running evaluation (0/${totalTestCases})`;
-            } else if (data.completedCount !== undefined) {
-              // Progress event
-              completedCount = data.completedCount;
-              spinner.text = `Running evaluation (${completedCount}/${totalTestCases})`;
-            } else if (data.status === 'completed' || data.status === 'cancelled') {
-              // Completed event
-              break;
-            } else if (data.error) {
-              spinner.fail(`Run failed: ${data.error}`);
-              process.exit(1);
+              if (data.runId && data.testCases) {
+                // Started event
+                runId = data.runId;
+                totalTestCases = data.testCases.length;
+                spinner.text = `Running evaluation (0/${totalTestCases})`;
+              } else if (data.completedCount !== undefined) {
+                // Progress event
+                completedCount = data.completedCount;
+                spinner.text = `Running evaluation (${completedCount}/${totalTestCases})`;
+              } else if (data.status === 'completed' || data.status === 'cancelled') {
+                // Completed event
+                sseSawTerminal = true;
+                break;
+              } else if (data.error) {
+                spinner.fail(`Run failed: ${data.error}`);
+                process.exit(1);
+              }
+            } catch {
+              // Skip malformed SSE data
             }
-          } catch {
-            // Skip malformed SSE data
           }
         }
       }
+    } catch (streamErr) {
+      // The progress stream dropped (proxy idle-timeout ~4 min, network blip)
+      // BEFORE the run finished. This is expected on long runs. The server
+      // keeps executing and persisting results, so as long as we captured the
+      // runId we recover the true result by polling storage below rather than
+      // aborting the whole command (the old behavior surfaced "0/0 / fetch
+      // failed" even though the run finished server-side).
+      if (!runId) {
+        spinner.fail(`Lost connection before the run started: ${streamErr instanceof Error ? streamErr.message : String(streamErr)}`);
+        process.exit(1);
+      }
+    }
+
+    // Read the TRUE final state from storage. If the SSE stream ended before
+    // the run reached a terminal state (long run + dropped stream), poll until
+    // it does — the server finishes independently of the client connection.
+    const api = new ApiClient(serverResult.baseUrl);
+    let run: EvaluationRun | null = null;
+    if (runId && !sseSawTerminal) {
+      spinner.text = 'Stream ended; waiting for the run to finish server-side…';
+      run = await api.pollEvaluationRunStatus(runId, (r) => {
+        const done = Object.values(r.results || {}).filter((x: any) => x.status !== 'pending' && x.status !== 'running').length;
+        spinner.text = `Waiting for run to finish server-side (${done}/${totalTestCases || Object.keys(r.results || {}).length})…`;
+      });
+    } else if (runId) {
+      run = await api.getEvaluationRun(runId);
     }
 
     spinner.succeed(`Evaluation run completed (${completedCount}/${totalTestCases} test cases)`);
 
-    // Fetch final run state
-    const finalRun = await fetch(`${serverResult.baseUrl}/api/storage/evaluation-runs/${runId}`);
-    if (finalRun.ok) {
-      const run = await finalRun.json();
+    if (run) {
       const passed = Object.values(run.results || {}).filter((r: any) => r.status === 'completed').length;
       const failed = Object.values(run.results || {}).filter((r: any) => r.status === 'failed').length;
 

--- a/cli/utils/apiClient.ts
+++ b/cli/utils/apiClient.ts
@@ -400,6 +400,46 @@ export class ApiClient {
   }
 
   /**
+   * Get a code-import / SDK evaluation run by id.
+   * GET /api/storage/evaluation-runs/:id — returns the run directly (not nested
+   * under a benchmark). Returns null on 404.
+   */
+  async getEvaluationRun(runId: string): Promise<EvaluationRun | null> {
+    const res = await fetch(
+      `${this.baseUrl}/api/storage/evaluation-runs/${encodeURIComponent(runId)}`
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`Failed to get evaluation run: ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Poll an evaluation run until it reaches a terminal state
+   * (completed / failed / cancelled).
+   *
+   * This is the fallback for long runs where the SSE progress stream drops
+   * (idle-timeout at a proxy, ~4 min) while the server keeps executing and
+   * persisting results. The CLI must read the true final state from storage
+   * rather than trusting the point at which the stream happened to end.
+   *
+   * Default timeout is deliberately generous (60 min): subprocess agents
+   * (Kiro / Claude Code / custom ops agents) can run many minutes per case.
+   */
+  async pollEvaluationRunStatus(
+    runId: string,
+    onProgress?: (run: EvaluationRun) => void,
+    timeoutMs = 3_600_000
+  ): Promise<EvaluationRun | null> {
+    return this.pollUntilTerminal(
+      () => this.getEvaluationRun(runId),
+      (run) => !!run.status && ['completed', 'failed', 'cancelled'].includes(run.status),
+      { timeoutMs, onPoll: onProgress }
+    );
+  }
+
+  /**
    * Get a single report (TestCaseRun) by ID.
    *
    * This is the preferred method for fetching reports - use report IDs

--- a/tests/unit/cli/utils/apiClient.test.ts
+++ b/tests/unit/cli/utils/apiClient.test.ts
@@ -1679,4 +1679,58 @@ describe('ApiClient', () => {
       expect(progressEvents.some(e => e.type === 'reconnecting' && e.reportId === 'report-noend-2')).toBe(true);
     });
   });
+
+  describe('getEvaluationRun', () => {
+    it('returns the run on 200', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ id: 'run-1', status: 'completed', results: {} }),
+      });
+      const run = await client.getEvaluationRun('run-1');
+      expect(mockFetch).toHaveBeenCalledWith(`${baseUrl}/api/storage/evaluation-runs/run-1`);
+      expect(run?.status).toBe('completed');
+    });
+
+    it('returns null on 404', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+      expect(await client.getEvaluationRun('missing')).toBeNull();
+    });
+  });
+
+  describe('pollEvaluationRunStatus', () => {
+    afterEach(() => jest.useRealTimers());
+
+    it('keeps polling storage until the run is terminal (SSE-dropped-mid-run fallback)', async () => {
+      jest.useFakeTimers();
+      // First read: still running (as it would be right after the SSE dropped
+      // on a long run). Second read: the server finished and persisted.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: jest.fn().mockResolvedValue({ id: 'run-1', status: 'running', results: { a: { status: 'running' } } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: jest.fn().mockResolvedValue({ id: 'run-1', status: 'completed', results: { a: { status: 'completed' } } }),
+        });
+
+      const promise = client.pollEvaluationRunStatus('run-1');
+      await jest.advanceTimersByTimeAsync(5000); // skip the inter-poll wait
+      const run = await promise;
+
+      expect(run?.status).toBe('completed');
+      expect(mockFetch).toHaveBeenCalledTimes(2); // polled again after 'running'
+    });
+
+    it('returns immediately when the first read is already terminal', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true, status: 200,
+        json: jest.fn().mockResolvedValue({ id: 'run-1', status: 'failed', results: {} }),
+      });
+      const run = await client.pollEvaluationRunStatus('run-1');
+      expect(run?.status).toBe('failed');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## What & why

`benchmark -f <file>` (SDK `.eval.js` / JSON) runs via `/api/storage/evaluation-runs` and streams progress over SSE. The CLI read the final run **once**, the moment the SSE stream ended. On a **long run** — e.g. a subprocess ops agent that takes ~10 min per case — a proxy idle-timeout drops the stream after a few minutes, so the loop broke early and the CLI reported partial / `0/0` results (or `fetch failed`) **even though the server kept executing and persisting server-side**. A WebIR user hit exactly this ("CLI reports 0/0; results must be read from storage").

## Change

- The SSE read loop now tolerates a mid-stream disconnect once the `runId` is captured (instead of aborting the whole command).
- After the stream ends, the CLI **polls `/api/storage/evaluation-runs/:id` until the run reaches a terminal state** (`ApiClient.pollEvaluationRunStatus`, mirroring the existing `pollRunStatus` fallback used by the stored-benchmark path) and reports the **true** result from storage. Default poll budget 60 min (subprocess agents are slow).

Files: `cli/commands/benchmark.ts`, `cli/utils/apiClient.ts`.

## Verification
- Unit: `tests/unit/cli/utils/apiClient.test.ts` — new tests for `getEvaluationRun` + `pollEvaluationRunStatus` (polls past a `running` read; returns immediately when already terminal). Suite 100/100.
- tsc clean; `build:cli` green.
