### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-27
+
 ### Added
 - **Comparison page: agreement + category insights band** ([components/comparison/ComparisonInsightsBand.tsx](components/comparison/ComparisonInsightsBand.tsx), [lib/comparisonInsights.ts](lib/comparisonInsights.ts), [components/comparison/ComparisonPage.tsx](components/comparison/ComparisonPage.tsx)): a deterministic band between the scoreboard and Table Compare that answers "where do these runs agree, and what is weak for everyone" without an LLM call. (1) **Agreement chips** — All/Both pass, All/Both fail, Split counts across the selected runs (N-run generalized); each chip filters the table to its bucket. (2) A **collapsible (open by default) category × run pass-rate matrix**, parsed from the bracketed tag benchmarks embed in test-case names (`qst_0011 [basic] …`), with small categories rolled into `other` and click-to-filter cells. (3) A **shared-weakness callout** when one category is the weakest for every run — separating "benchmark/corpus gap" from "agent choice" (e.g. `semantic` at 60–67% across all agents on a RAG benchmark). Unit: [tests/unit/lib/comparisonInsights.test.ts](tests/unit/lib/comparisonInsights.test.ts); e2e: [tests/e2e/comparison-insights-band.spec.ts](tests/e2e/comparison-insights-band.spec.ts).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/agent-health",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/agent-health",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/agent-health",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "description": "Agent Evaluation and Observability Framework",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What
Cuts release **0.6.0**:
- Bumps `package.json` / `package-lock.json` version from `0.5.2` → `0.6.0` (via `npm version 0.6.0 --no-git-tag-version`; `package.json` `"name"` remains `@opensearch-project/agent-health`, untouched).
- Rolls the `CHANGELOG.md` `## [Unreleased]` section into a dated `## [0.6.0] - 2026-08-27` section, and adds a fresh **empty** `## [Unreleased]` heading above it. No changelog entries were reordered, deduped, or otherwise edited — only the two headings.

Diff is intentionally minimal: `package.json`, `package-lock.json`, `CHANGELOG.md` only.

## What happens after merge
Tagging + publish are separate, manual, gated steps — **not** part of this PR:
1. Push the git tag `0.6.0` (no `v` prefix).
2. That tag push triggers [`.github/workflows/release-drafter.yml`](https://github.com/opensearch-project/agent-health/blob/main/.github/workflows/release-drafter.yml)'s Release Workflow, which is gated behind the `release-approval` GitHub Environment (requires manual approval) before `npm publish` runs.

## Verification proof

**`npm run build:all`** — ✅ PASS (frontend `vite build`, `tsc`, server/CLI `esbuild` bundles, `lib` `tsc` build all succeeded; only pre-existing warnings: chunk-size and `direct-eval` in `lib/testCases/loader.ts`).

**`npm run test:unit`** — ✅ PASS
```
Test Suites: 261 passed, 261 total
Tests:       5 skipped, 4777 passed, 4782 total
```

**`npm run test:integration`** — ✅ PASS (run against a dedicated ephemeral OpenSearch 2.17.0 container + a dedicated server instance on a non-default port, to avoid colliding with an unrelated live server already bound to the default port 4001 on the build host)
```
Test Suites: 75 passed, 75 total
Tests:       767 passed, 767 total
```

**`npm run test:e2e`** — ✅ PASS with 2 pre-existing, environment-specific, non-regression failures documented (not caused by this PR's diff):
```
416 passed, 11 skipped, 2 failed (10.4m)
```
- The 11 skips are all deliberate/expected (`code-sdk-observio`, `evaluation-real-agent` Bedrock-judge tests, `orphan-benchmark-run-recovery`, etc. — features requiring dependencies/services not present in this sandbox).
- The 2 failures (`tests/e2e/skills.spec.ts` — "should enable Run Evaluation after valid skill selection" / "should show SKILL.md tab with instructions after validation") are caused by an **already-known, unmerged, unrelated bug**: the Skills page's skill-discovery dropdown picks up the build host's personal `~/.claude/skills/` directory, and skill-path resolution doesn't expand `~`, so the first (user-scope) skill in the dropdown fails validation with `Directory does not exist: <cwd>/~/.claude/skills/<name>`. A fix for exactly this ("fix(skills): expand ~ in skill paths so user-scope skills validate") already exists on an unrelated, unmerged branch — confirming this predates and is unrelated to this release bump. It will not reproduce on a CI runner (no such home-directory skills exist there), and does not reproduce with only project-scoped `.claude/skills/`.

**`npm audit --audit-level=high`** — ❌ Non-zero exit; 14 high-severity findings (React Router, undici, vite/launch-editor transitive advisories). **Confirmed pre-existing on `origin/main`**: `git diff package-lock.json` for this PR shows only the two `"version"` fields changed (`0.5.2` → `0.6.0`), zero dependency version changes — so this audit result is identical to what `origin/main` already reports today; this PR does not introduce or change it.

## DCO
Signoff present on the single commit (`git log -1 | grep Signed-off-by`):
```
Signed-off-by: Megha Goyal <goyamegh@amazon.com>
```
