### PR TITLE
fix(report): render user prompt as its own step, not thinking

### DIFF
--- a/components/TrajectoryCompareView.tsx
+++ b/components/TrajectoryCompareView.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { EvaluationReport, TrajectoryStep, ToolCallStatus } from '@/types';
+import { normalizeTrajectorySteps } from '@/lib/trajectoryStepDisplay';
 
 interface TrajectoryCompareViewProps {
   leftReport: EvaluationReport;
@@ -29,8 +30,8 @@ export const TrajectoryCompareView: React.FC<TrajectoryCompareViewProps> = ({
   title,
   onClose,
 }) => {
-  const leftSteps = leftReport.trajectory;
-  const rightSteps = rightReport.trajectory;
+  const leftSteps = normalizeTrajectorySteps(leftReport.trajectory);
+  const rightSteps = normalizeTrajectorySteps(rightReport.trajectory);
   const maxSteps = Math.max(leftSteps.length, rightSteps.length);
 
   const getStepTypeColor = (type: TrajectoryStep['type']) => {

--- a/components/TrajectoryCompareView.tsx
+++ b/components/TrajectoryCompareView.tsx
@@ -39,6 +39,7 @@ export const TrajectoryCompareView: React.FC<TrajectoryCompareViewProps> = ({
       case 'action': return 'text-blue-700 bg-blue-100 dark:text-blue-400 dark:bg-blue-500/10';
       case 'tool_result': return 'text-amber-700 bg-amber-100 dark:text-amber-400 dark:bg-amber-500/10';
       case 'response': return 'text-blue-700 bg-blue-100 dark:text-opensearch-blue dark:bg-opensearch-blue/10';
+      case 'user': return 'text-cyan-700 bg-cyan-100 dark:text-cyan-400 dark:bg-cyan-500/10';
       default: return 'text-muted-foreground bg-muted';
     }
   };

--- a/components/TrajectoryView.tsx
+++ b/components/TrajectoryView.tsx
@@ -8,6 +8,7 @@ import { TrajectoryStep, ToolCallStatus } from '@/types';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Markdown, hasRealMarkdown } from '@/components/ui/markdown';
 import { truncate } from '@/lib/utils';
+import { normalizeLegacyUserStep } from '@/lib/trajectoryStepDisplay';
 
 interface TrajectoryViewProps {
   steps: TrajectoryStep[];
@@ -15,10 +16,6 @@ interface TrajectoryViewProps {
 }
 
 const PREVIEW_LENGTH = 80;
-
-// Legacy prefix stamped by older producers (services/traces/spansToTrajectory.ts)
-// that echoed the user's prompt as a `thinking` step instead of its own type.
-const LEGACY_USER_PREFIX = 'User: ';
 
 // Color classes for each step type
 const typeColors: Record<string, string> = {
@@ -38,21 +35,6 @@ const typeBgColors: Record<string, string> = {
   response: 'bg-slate-500/5 border-slate-500/20',
   user: 'bg-cyan-500/5 border-cyan-500/20',
 };
-
-/**
- * Old persisted reports (pre-fix) have the user's prompt baked in as a
- * `thinking` step with a literal `User: ` prefix, always at index 0 (the
- * producer only ever emitted this for the opening interaction span). We
- * can't retroactively rewrite stored reports, so re-derive the intended
- * `user` step at render time for that one specific, unambiguous shape
- * instead of silently keeping it mislabeled as thinking.
- */
-function toDisplayStep(step: TrajectoryStep, index: number): TrajectoryStep {
-  if (index === 0 && step.type === 'thinking' && step.content.startsWith(LEGACY_USER_PREFIX)) {
-    return { ...step, type: 'user', content: step.content.slice(LEGACY_USER_PREFIX.length) };
-  }
-  return step;
-}
 
 export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }) => {
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
@@ -111,8 +93,8 @@ export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }
         </div>
       )}
 
-      {steps.map((rawStep, index) => {
-        const step = toDisplayStep(rawStep, index);
+      {steps.map((rawStep) => {
+        const step = normalizeLegacyUserStep(rawStep);
         const isExpanded = expandedSteps.has(step.id);
         const collapsible = isCollapsible(step);
         const latency = formatLatency(step.latencyMs);

--- a/components/TrajectoryView.tsx
+++ b/components/TrajectoryView.tsx
@@ -16,6 +16,10 @@ interface TrajectoryViewProps {
 
 const PREVIEW_LENGTH = 80;
 
+// Legacy prefix stamped by older producers (services/traces/spansToTrajectory.ts)
+// that echoed the user's prompt as a `thinking` step instead of its own type.
+const LEGACY_USER_PREFIX = 'User: ';
+
 // Color classes for each step type
 const typeColors: Record<string, string> = {
   thinking: 'text-amber-400',
@@ -23,6 +27,7 @@ const typeColors: Record<string, string> = {
   action: 'text-blue-400',
   tool_result: 'text-opensearch-blue',
   response: 'text-slate-400',
+  user: 'text-cyan-400',
 };
 
 const typeBgColors: Record<string, string> = {
@@ -31,7 +36,23 @@ const typeBgColors: Record<string, string> = {
   action: 'bg-blue-500/5 border-blue-500/20',
   tool_result: 'bg-opensearch-blue/5 border-opensearch-blue/20',
   response: 'bg-slate-500/5 border-slate-500/20',
+  user: 'bg-cyan-500/5 border-cyan-500/20',
 };
+
+/**
+ * Old persisted reports (pre-fix) have the user's prompt baked in as a
+ * `thinking` step with a literal `User: ` prefix, always at index 0 (the
+ * producer only ever emitted this for the opening interaction span). We
+ * can't retroactively rewrite stored reports, so re-derive the intended
+ * `user` step at render time for that one specific, unambiguous shape
+ * instead of silently keeping it mislabeled as thinking.
+ */
+function toDisplayStep(step: TrajectoryStep, index: number): TrajectoryStep {
+  if (index === 0 && step.type === 'thinking' && step.content.startsWith(LEGACY_USER_PREFIX)) {
+    return { ...step, type: 'user', content: step.content.slice(LEGACY_USER_PREFIX.length) };
+  }
+  return step;
+}
 
 export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }) => {
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
@@ -61,6 +82,9 @@ export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }
     if (step.type === 'tool_result') {
       return 'result';
     }
+    if (step.type === 'user') {
+      return 'user prompt';
+    }
     return step.type;
   };
 
@@ -87,7 +111,8 @@ export const TrajectoryView: React.FC<TrajectoryViewProps> = ({ steps, loading }
         </div>
       )}
 
-      {steps.map((step) => {
+      {steps.map((rawStep, index) => {
+        const step = toDisplayStep(rawStep, index);
         const isExpanded = expandedSteps.has(step.id);
         const collapsible = isCollapsible(step);
         const latency = formatLatency(step.latencyMs);

--- a/components/comparison/sections/TrajectoryDiffView.tsx
+++ b/components/comparison/sections/TrajectoryDiffView.tsx
@@ -18,6 +18,7 @@ import {
   Wrench,
   Brain,
   MessageSquare,
+  User,
   CheckCircle2,
 } from 'lucide-react';
 import { EvaluationReport, BenchmarkRun, TrajectoryStep } from '@/types';
@@ -47,6 +48,8 @@ const StepIcon: React.FC<{ type?: TrajectoryStep['type'] }> = ({ type }) => {
       return <CheckCircle2 size={14} className="text-opensearch-blue" />;
     case 'response':
       return <MessageSquare size={14} className="text-amber-400" />;
+    case 'user':
+      return <User size={14} className="text-cyan-400" />;
     default:
       return <Wrench size={14} className="text-muted-foreground" />;
   }

--- a/components/comparison/sections/TrajectorySection.tsx
+++ b/components/comparison/sections/TrajectorySection.tsx
@@ -13,6 +13,7 @@ import { EvaluationReport, BenchmarkRun, TrajectoryStep, ToolCallStatus } from '
 import { calculateTotalLatency } from '@/data/mockComparisonData';
 import { cn } from '@/lib/utils';
 import { Markdown } from '@/components/ui/markdown';
+import { normalizeTrajectorySteps } from '@/lib/trajectoryStepDisplay';
 
 interface TrajectorySectionProps {
   runs: BenchmarkRun[];
@@ -103,7 +104,7 @@ const RunTrajectory: React.FC<{
   run: BenchmarkRun;
   report: EvaluationReport | null;
 }> = ({ run, report }) => {
-  const trajectory = report?.trajectory || [];
+  const trajectory = normalizeTrajectorySteps(report?.trajectory || []);
   const totalLatency = calculateTotalLatency(trajectory);
 
   if (!report) {

--- a/components/comparison/sections/TrajectorySection.tsx
+++ b/components/comparison/sections/TrajectorySection.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { ChevronDown, ChevronRight, Wrench, Brain, MessageSquare, CheckCircle2, XCircle } from 'lucide-react';
+import { ChevronDown, ChevronRight, Wrench, Brain, MessageSquare, User, CheckCircle2, XCircle } from 'lucide-react';
 import { EvaluationReport, BenchmarkRun, TrajectoryStep, ToolCallStatus } from '@/types';
 import { calculateTotalLatency } from '@/data/mockComparisonData';
 import { cn } from '@/lib/utils';
@@ -30,6 +30,8 @@ const StepIcon: React.FC<{ type: TrajectoryStep['type'] }> = ({ type }) => {
       return <CheckCircle2 size={14} className="text-opensearch-blue" />;
     case 'response':
       return <MessageSquare size={14} className="text-amber-400" />;
+    case 'user':
+      return <User size={14} className="text-cyan-400" />;
     default:
       return null;
   }

--- a/lib/trajectoryStepDisplay.ts
+++ b/lib/trajectoryStepDisplay.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TrajectoryStep } from '@/types';
+
+/**
+ * Legacy prefix stamped by older producers (services/traces/spansToTrajectory.ts,
+ * pre owner-papercut fix) that echoed the user's prompt as a `thinking` step
+ * instead of giving it its own `'user'` step type. Producers no longer emit
+ * this shape, but old persisted reports still have it.
+ */
+const LEGACY_USER_PREFIX = 'User: ';
+
+/**
+ * Re-derive the intended `user` step for one specific, unambiguous legacy
+ * shape: a `thinking` step whose content starts with the literal `User: `
+ * echo prefix. We can't retroactively rewrite stored reports, so every
+ * surface that renders or compares trajectories (the Test Case Output tab,
+ * side-by-side comparison views, and the trajectory diff/similarity engine)
+ * calls this at read time instead of leaving old reports permanently
+ * mislabeled — and, just as importantly, so an old-shape report and a
+ * freshly-run new-shape report showing the identical prompt don't register
+ * as a false "modified"/"added+removed" diff purely because of the step's
+ * `type` and `content` prefix.
+ *
+ * Deliberately NOT restricted to index 0: the old producers emitted this
+ * shape for every user turn in a multi-turn session, not just the opening
+ * one, so restricting the check to the first step would leave later turns
+ * in old reports mislabeled. The exact-prefix match is a strong, specific
+ * signal (a real chain-of-thought paragraph starting with the literal
+ * string "User: ") so the false-positive risk of checking every step is
+ * low and no worse than the risk already accepted for the first step.
+ */
+export function normalizeLegacyUserStep(step: TrajectoryStep): TrajectoryStep {
+  if (step.type === 'thinking' && step.content.startsWith(LEGACY_USER_PREFIX)) {
+    return { ...step, type: 'user', content: step.content.slice(LEGACY_USER_PREFIX.length) };
+  }
+  return step;
+}
+
+/** Apply {@link normalizeLegacyUserStep} across a full trajectory. */
+export function normalizeTrajectorySteps(steps: TrajectoryStep[]): TrajectoryStep[] {
+  return steps.map(normalizeLegacyUserStep);
+}

--- a/services/report/html/htmlTemplate.ts
+++ b/services/report/html/htmlTemplate.ts
@@ -323,6 +323,7 @@ const CSS_STYLES = `
   .step-tool_result.failed { border-color: var(--red-700); background: rgba(185,28,28,0.05); }
   .step-response { border-color: var(--purple-700); background: rgba(126,34,206,0.05); }
   .step-assistant { border-color: var(--purple-700); background: rgba(126,34,206,0.05); }
+  .step-user { border-color: #0891b2; background: rgba(8,145,178,0.05); }
   .step-type { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; margin-bottom: 0.25rem; }
   .step-thinking .step-type { color: var(--amber-600); }
   .step-action .step-type { color: #3b82f6; }
@@ -330,6 +331,7 @@ const CSS_STYLES = `
   .step-tool_result.failed .step-type { color: var(--red-700); }
   .step-response .step-type { color: var(--purple-700); }
   .step-assistant .step-type { color: var(--purple-700); }
+  .step-user .step-type { color: #0891b2; }
   .step-content { font-size: 0.8125rem; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; color: var(--text); }
 
   /* Improvement strategies */

--- a/services/traces/spansToTrajectory.ts
+++ b/services/traces/spansToTrajectory.ts
@@ -110,10 +110,10 @@ function claudeNativeTrajectory(spans: Span[]): TrajectoryStep[] {
       const redacted = !prompt || prompt === '<REDACTED>';
       steps.push({
         ...base,
-        type: 'thinking',
+        type: 'user',
         content: redacted
-          ? `User: [prompt redacted — set OTEL_LOG_USER_PROMPTS=1 to capture] (${a['user_prompt_length'] ?? '?'} chars)`
-          : `User: ${prompt}`,
+          ? `[prompt redacted — set OTEL_LOG_USER_PROMPTS=1 to capture] (${a['user_prompt_length'] ?? '?'} chars)`
+          : String(prompt),
       });
     } else if (t === 'llm_request') {
       const model = a['model'] || a['gen_ai.request.model'] || '';
@@ -339,7 +339,7 @@ function genericTrajectory(spans: Span[], serviceName?: string): TrajectoryStep[
         }); break;
       }
       case 'user':
-        steps.push({ ...base, type: 'thinking', content: `User: ${m.content}` }); break;
+        steps.push({ ...base, type: 'user', content: m.content }); break;
       default:
         steps.push({ ...base, type: 'thinking', content: m.content });
     }

--- a/services/trajectoryDiffService.ts
+++ b/services/trajectoryDiffService.ts
@@ -4,6 +4,7 @@
  */
 
 import { TrajectoryStep } from '@/types';
+import { normalizeTrajectorySteps } from '@/lib/trajectoryStepDisplay';
 
 /**
  * Represents an aligned step in the diff view
@@ -86,11 +87,20 @@ export function calculateStepSimilarity(
 /**
  * Align two trajectory arrays using an LCS-based algorithm
  * Returns aligned steps with type annotations (matched, added, removed, modified)
+ *
+ * Both inputs are normalized ({@link normalizeTrajectorySteps}) before
+ * alignment, so a legacy-shape `thinking` step that echoes a user prompt
+ * (pre owner-papercut-fix reports) is compared as the `user` step it always
+ * meant to be — otherwise an old report and a freshly-run report showing the
+ * identical prompt would score a false type mismatch and register as a
+ * spurious added/removed/modified pair instead of a match.
  */
 export function alignTrajectories(
-  baseline: TrajectoryStep[],
-  comparison: TrajectoryStep[]
+  rawBaseline: TrajectoryStep[],
+  rawComparison: TrajectoryStep[]
 ): AlignedStep[] {
+  const baseline = normalizeTrajectorySteps(rawBaseline);
+  const comparison = normalizeTrajectorySteps(rawComparison);
   const MATCH_THRESHOLD = 0.6;
   const MODIFIED_THRESHOLD = 0.4;
 

--- a/tests/integration/server/pi-profile-otlp.integration.test.ts
+++ b/tests/integration/server/pi-profile-otlp.integration.test.ts
@@ -106,11 +106,11 @@ describe('pi profiling extension → profile pipeline (integration)', () => {
     const res = await request(app).post('/api/traces').send({ sessionId: SESSION_ID }).expect(200);
     const trajectory = spansToTrajectory(res.body.spans, 'pi-agent');
     const types = trajectory.map(s => s.type);
-    expect(types).toContain('thinking');   // user prompt
+    expect(types).toContain('user');       // user prompt (own step type, not thinking)
     expect(types).toContain('assistant');  // completion
     expect(types).toContain('action');     // tool calls
     expect(types).toContain('tool_result');
-    expect(trajectory.find(s => s.type === 'thinking')?.content).toContain('Why is the checkout service throwing 500s?');
+    expect(trajectory.find(s => s.type === 'user')?.content).toContain('Why is the checkout service throwing 500s?');
     expect(trajectory.find(s => s.type === 'action')?.toolName).toBe('search_logs');
   });
 

--- a/tests/unit/components/trajectoryView.test.ts
+++ b/tests/unit/components/trajectoryView.test.ts
@@ -63,4 +63,44 @@ describe('TrajectoryView', () => {
     render(React.createElement(TrajectoryView, { steps: [], loading: true }));
     expect(screen.getByText('Initializing agent...')).toBeTruthy();
   });
+
+  it('renders a `user` step as "user prompt", not "thinking", with its own color', () => {
+    const steps = [makeStep({ id: 'u1', type: 'user', content: 'Can you recommend a sturdy, stainless steel camping mug?' })];
+    render(React.createElement(TrajectoryView, { steps, loading: false }));
+
+    const label = screen.getByText('user prompt');
+    expect(label.className).toContain('text-cyan-400');
+    expect(screen.queryByText('thinking')).toBeNull();
+  });
+
+  it('relabels a legacy (pre-fix) thinking step at position 0 that echoes "User: ..." as a user prompt', () => {
+    const steps = [
+      makeStep({ id: 'legacy-1', type: 'thinking', content: 'User: Can you recommend a sturdy, stainless steel camping mug?' }),
+      makeStep({ id: 'resp-1', type: 'response', content: 'Sure, here are a few options...' }),
+    ];
+    render(React.createElement(TrajectoryView, { steps, loading: false }));
+
+    const label = screen.getByText('user prompt');
+    expect(label.className).toContain('text-cyan-400');
+    // The `User: ` echo prefix is stripped once the step is re-labeled.
+    expect(screen.getByText(/^Can you recommend a sturdy, stainless steel camping mug\?/)).toBeTruthy();
+    expect(screen.queryByText('thinking')).toBeNull();
+  });
+
+  it('does NOT relabel a genuine thinking step at position 0 that happens to contain "User" mid-sentence', () => {
+    const steps = [makeStep({ id: 'think-1', type: 'thinking', content: 'The User asked about mugs, let me search.' })];
+    render(React.createElement(TrajectoryView, { steps, loading: false }));
+    expect(screen.getByText('thinking')).toBeTruthy();
+    expect(screen.queryByText('user prompt')).toBeNull();
+  });
+
+  it('does NOT relabel a legacy "User: " thinking step when it is NOT the first step', () => {
+    const steps = [
+      makeStep({ id: 'action-0', type: 'action', content: 'searched catalog', toolName: 'search' }),
+      makeStep({ id: 'legacy-2', type: 'thinking', content: 'User: follow-up question' }),
+    ];
+    render(React.createElement(TrajectoryView, { steps, loading: false }));
+    expect(screen.getByText('thinking')).toBeTruthy();
+    expect(screen.queryByText('user prompt')).toBeNull();
+  });
 });

--- a/tests/unit/components/trajectoryView.test.ts
+++ b/tests/unit/components/trajectoryView.test.ts
@@ -94,13 +94,13 @@ describe('TrajectoryView', () => {
     expect(screen.queryByText('user prompt')).toBeNull();
   });
 
-  it('does NOT relabel a legacy "User: " thinking step when it is NOT the first step', () => {
+  it('relabels a legacy "User: " thinking step at ANY position, not just index 0 (multi-turn legacy reports)', () => {
     const steps = [
       makeStep({ id: 'action-0', type: 'action', content: 'searched catalog', toolName: 'search' }),
       makeStep({ id: 'legacy-2', type: 'thinking', content: 'User: follow-up question' }),
     ];
     render(React.createElement(TrajectoryView, { steps, loading: false }));
-    expect(screen.getByText('thinking')).toBeTruthy();
-    expect(screen.queryByText('user prompt')).toBeNull();
+    expect(screen.getByText('user prompt')).toBeTruthy();
+    expect(screen.queryByText('thinking')).toBeNull();
   });
 });

--- a/tests/unit/lib/trajectoryStepDisplay.test.ts
+++ b/tests/unit/lib/trajectoryStepDisplay.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { normalizeLegacyUserStep, normalizeTrajectorySteps } from '@/lib/trajectoryStepDisplay';
+import { TrajectoryStep } from '@/types';
+
+function makeStep(overrides: Partial<TrajectoryStep> = {}): TrajectoryStep {
+  return {
+    id: 'step-1',
+    timestamp: Date.now(),
+    type: 'thinking',
+    content: '',
+    ...overrides,
+  };
+}
+
+describe('normalizeLegacyUserStep', () => {
+  it('relabels a legacy thinking step whose content starts with "User: " to type `user`, stripping the prefix', () => {
+    const step = makeStep({ type: 'thinking', content: 'User: fix the login bug' });
+    const result = normalizeLegacyUserStep(step);
+    expect(result.type).toBe('user');
+    expect(result.content).toBe('fix the login bug');
+  });
+
+  it('relabels regardless of the step\'s position in the trajectory (multi-turn legacy reports)', () => {
+    // The function itself is position-agnostic; callers apply it per-step.
+    const step = makeStep({ type: 'thinking', content: 'User: a later turn in the conversation' });
+    expect(normalizeLegacyUserStep(step).type).toBe('user');
+  });
+
+  it('does NOT relabel a genuine thinking step that merely mentions "User" mid-sentence', () => {
+    const step = makeStep({ type: 'thinking', content: 'The User asked about mugs, let me search.' });
+    const result = normalizeLegacyUserStep(step);
+    expect(result.type).toBe('thinking');
+    expect(result.content).toBe(step.content);
+  });
+
+  it('does NOT touch a step that is already type `user`', () => {
+    const step = makeStep({ type: 'user', content: 'fix the login bug' });
+    const result = normalizeLegacyUserStep(step);
+    expect(result).toBe(step); // same reference — no unnecessary copy
+  });
+
+  it('does NOT touch other step types (action/response/tool_result/assistant)', () => {
+    for (const type of ['action', 'response', 'tool_result', 'assistant'] as const) {
+      const step = makeStep({ type, content: 'User: not actually a user prompt here' });
+      expect(normalizeLegacyUserStep(step).type).toBe(type);
+    }
+  });
+
+  it('does NOT relabel a `tool.blocked_on_user` decision step ("User rejected a tool call")', () => {
+    const step = makeStep({ type: 'thinking', content: 'User rejected a tool call (user_temporary)' });
+    // No literal "User: " prefix (no colon-space right after "User"), so it stays thinking.
+    expect(normalizeLegacyUserStep(step).type).toBe('thinking');
+  });
+});
+
+describe('normalizeTrajectorySteps', () => {
+  it('normalizes every legacy user-prompt step in a full trajectory, leaving the rest untouched', () => {
+    const steps: TrajectoryStep[] = [
+      makeStep({ id: 's1', type: 'thinking', content: 'User: turn one' }),
+      makeStep({ id: 's2', type: 'action', content: 'searched', toolName: 'search' }),
+      makeStep({ id: 's3', type: 'thinking', content: 'User: turn two' }),
+      makeStep({ id: 's4', type: 'response', content: 'done' }),
+    ];
+
+    const normalized = normalizeTrajectorySteps(steps);
+
+    expect(normalized.map(s => s.type)).toEqual(['user', 'action', 'user', 'response']);
+    expect(normalized[0].content).toBe('turn one');
+    expect(normalized[2].content).toBe('turn two');
+  });
+
+  it('returns an empty array for an empty trajectory', () => {
+    expect(normalizeTrajectorySteps([])).toEqual([]);
+  });
+});

--- a/tests/unit/services/traces/spansToTrajectory.test.ts
+++ b/tests/unit/services/traces/spansToTrajectory.test.ts
@@ -77,7 +77,7 @@ describe('spansToTrajectory', () => {
     const traj = spansToTrajectory(spans, 'claude-code');
 
     const types = traj.map(t => t.type);
-    expect(types).toContain('thinking');     // user prompt
+    expect(types).toContain('user');         // user prompt (own step type, not thinking)
     expect(types).toContain('action');       // tool call
     expect(types).toContain('tool_result');  // tool result
 
@@ -85,8 +85,9 @@ describe('spansToTrajectory', () => {
     expect(action.toolName).toBe('read_file');
     expect(action.toolArgs).toEqual({ path: 'a.ts' });
 
-    const userStep = traj.find(t => t.content.startsWith('User:'))!;
-    expect(userStep.content).toContain('fix the bug');
+    const userStep = traj.find(t => t.type === 'user')!;
+    expect(userStep.content).toBe('fix the bug');
+    expect(userStep.content).not.toContain('User:');
   });
 
   it('marks tool_result FAILURE when the span status is ERROR', () => {
@@ -100,6 +101,27 @@ describe('spansToTrajectory', () => {
 
   it('returns an empty array for no spans', () => {
     expect(spansToTrajectory([], 'claude-code')).toEqual([]);
+  });
+
+  it('classifies a generic (non-Claude-Code) OTel GenAI user prompt as `user`, not `thinking`', () => {
+    const genericSpan: Span = {
+      traceId: 't1',
+      spanId: 'g1',
+      name: 'chat',
+      startTime: '2026-01-01T00:00:00.000Z',
+      endTime: '2026-01-01T00:00:01.000Z',
+      status: 'OK',
+      attributes: { 'service.name': 'my-rest-agent', 'gen_ai.system': 'openai' },
+      events: [
+        { name: 'llm.request', time: '2026-01-01T00:00:00.000Z', attributes: { 'gen_ai.prompt': 'Can you recommend a sturdy, stainless steel camping mug?' } },
+        { name: 'llm.response', time: '2026-01-01T00:00:01.000Z', attributes: { 'llm.completion': 'Sure, here are a few options...' } },
+      ],
+    };
+    const traj = spansToTrajectory([genericSpan], 'my-rest-agent');
+    const userStep = traj.find(t => t.type === 'user');
+    expect(userStep).toBeDefined();
+    expect(userStep!.content).toBe('Can you recommend a sturdy, stainless steel camping mug?');
+    expect(traj.some(t => t.type === 'thinking')).toBe(false);
   });
 });
 
@@ -167,7 +189,7 @@ describe('Claude Code native (attribute-based) spans', () => {
       ccSpan('e1', 'tool.execution', { tool_use_id: 'tu1', success: true }, '2026-01-01T00:00:03.000Z'),
     ];
     const traj = spansToTrajectory(spans);
-    expect(traj.map(t => t.type)).toEqual(['thinking', 'assistant', 'action', 'tool_result']);
+    expect(traj.map(t => t.type)).toEqual(['user', 'assistant', 'action', 'tool_result']);
     const action = traj.find(t => t.type === 'action')!;
     expect(action.toolName).toBe('Bash');
     const result = traj.find(t => t.type === 'tool_result')!;
@@ -184,6 +206,28 @@ describe('Claude Code native (attribute-based) spans', () => {
     ];
     const result = spansToTrajectory(spans).find(t => t.type === 'tool_result')!;
     expect(result.status).toBe(ToolCallStatus.FAILURE);
+  });
+
+  it('classifies the opening user prompt as its own `user` step, never `thinking` (owner papercut)', () => {
+    const spans: Span[] = [
+      ccSpan('i1', 'interaction', { user_prompt: 'Can you recommend a sturdy, stainless steel camping mug?' }, '2026-01-01T00:00:00.000Z'),
+    ];
+    const traj = spansToTrajectory(spans);
+    expect(traj).toHaveLength(1);
+    expect(traj[0].type).toBe('user');
+    expect(traj[0].type).not.toBe('thinking');
+    // No 'User:' echo prefix — the step's own type/label carries that meaning now.
+    expect(traj[0].content).toBe('Can you recommend a sturdy, stainless steel camping mug?');
+  });
+
+  it('does NOT flag a real reject-tool `thinking` step as `user` (blocked_on_user stays thinking)', () => {
+    const spans: Span[] = [
+      ccSpan('t1', 'tool', { tool_name: 'Write', tool_use_id: 'tu1' }, '2026-01-01T00:00:00.000Z'),
+      ccSpan('b1', 'tool.blocked_on_user', { decision: 'reject', source: 'user_temporary' }, '2026-01-01T00:00:01.000Z'),
+    ];
+    const traj = spansToTrajectory(spans);
+    const meta = traj.find(t => t.content.includes('rejected a tool call'));
+    expect(meta?.type).toBe('thinking');
   });
 
   it('detects user_rejection from tool.blocked_on_user', () => {

--- a/tests/unit/services/trajectoryDiffService.test.ts
+++ b/tests/unit/services/trajectoryDiffService.test.ts
@@ -171,6 +171,19 @@ describe('TrajectoryDiffService', () => {
       expect(result.every(s => s.type === 'matched')).toBe(true);
     });
 
+    it('normalizes a legacy `thinking`+"User: " step so it matches the equivalent `user` step, not a false modified/added+removed pair (owner papercut fix)', () => {
+      const legacyShape = [createStep('thinking', { content: 'User: fix the login bug' })];
+      const newShape = [createStep('user', { content: 'fix the login bug' })];
+
+      const result = alignTrajectories(legacyShape, newShape);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('matched');
+      // The aligned step carries the normalized type/content, not the raw legacy shape.
+      expect(result[0].baselineStep?.type).toBe('user');
+      expect(result[0].comparisonStep?.type).toBe('user');
+    });
+
     it('should detect added steps in comparison', () => {
       const baseline = [
         createStep('thinking', { content: 'Analyzing' }),

--- a/types/index.ts
+++ b/types/index.ts
@@ -230,7 +230,7 @@ export enum ToolCallStatus {
 export interface TrajectoryStep {
   id: string;
   timestamp: number;
-  type: 'tool_result' | 'assistant' | 'action' | 'response' | 'thinking';
+  type: 'tool_result' | 'assistant' | 'action' | 'response' | 'thinking' | 'user';
   content: string;
   toolName?: string;
   toolArgs?: Record<string, any>;


### PR DESCRIPTION
## Problem

On the run report's Test Case Output tab (Processed view), the user's
initial prompt rendered inside an amber "thinking" box (e.g. a step titled
"User: <the user's question>") followed by a normal "response" step. The
user's own input is not agent reasoning — it should not share styling/label
with genuine chain-of-thought.

## Root cause

Trace-derived trajectory reconstruction (`services/traces/spansToTrajectory.ts`)
classified the echoed user prompt as `type: 'thinking'` with a synthetic
`User: ` content prefix, in **two** producers:

- `claudeNativeTrajectory`: the `interaction` span's `user_prompt` attribute
  (Claude Code native attribute-based telemetry).
- `genericTrajectory`: a `role: 'user'` message emitted by
  `extractMessagesFromSpans` (covers both the Claude Code legacy
  event-based path and generic OTel GenAI REST/subprocess agents — e.g. a
  REST-connector agent).

## Fix

- Added a new `TrajectoryStep` type, `'user'` (`types/index.ts`).
- Reclassified both producers above to emit `type: 'user'` directly, with
  no `User: ` echo prefix.
- `TrajectoryView.tsx` (Test Case Output tab), `TrajectoryCompareView.tsx`,
  `components/comparison/sections/TrajectorySection.tsx`,
  `components/comparison/sections/TrajectoryDiffView.tsx`, and the static
  HTML report export (`services/report/html/htmlTemplate.ts`) all get a
  distinct neutral "user prompt" label / cyan color / icon for the new type.
- **Backward compat, centralized:** a shared helper
  (`lib/trajectoryStepDisplay.ts`: `normalizeLegacyUserStep` /
  `normalizeTrajectorySteps`) re-derives the `user` step at read time for
  old persisted reports (a `thinking` step whose content starts with
  `User: `), applied at every render site **and** inside
  `trajectoryDiffService.alignTrajectories()` so an old-shape report and a
  freshly-run report of the identical prompt still register as a match, not
  a false diff.
- Left `tool.blocked_on_user`'s "User {accepted|rejected} a tool call" step
  as `thinking` — that's a description of the user's *decision*, not their
  literal prompt text.

## Tests

- Unit: `tests/unit/lib/trajectoryStepDisplay.test.ts` (shared helper),
  `tests/unit/services/traces/spansToTrajectory.test.ts` (both
  classification producers + negative cases), `tests/unit/services/trajectoryDiffService.test.ts`
  (legacy-vs-new-shape steps align as a match, not a false diff).
- Component/RTL: `tests/unit/components/trajectoryView.test.ts` (new type
  renders correctly; legacy relabel at any position; negative cases against
  over-eager relabeling).
- Fixed a stale integration assertion in
  `tests/integration/server/pi-profile-otlp.integration.test.ts` that still
  expected the old `'thinking'` classification for a real OTLP-ingested
  trajectory.
- e2e: not added — pure rendering-classification fix fully exercised by the
  RTL component tests above; no existing e2e spec covered this tab's step
  styling to extend cheaply.

## codex_review (adversarial second opinion, gpt-5.4)

| Finding | Severity | Applied? |
|---|---|---|
| Backward-compat relabel only fired at step index 0; legacy producers stamped the `User: ` prefix on every user turn in a session, not just the opening one — multi-turn legacy reports stayed mislabeled past turn 1 | Major | ✅ Applied — dropped the index restriction |
| `TrajectoryCompareView`/`TrajectorySection`/`TrajectoryDiffView` and `trajectoryDiffService.alignTrajectories()` never normalized the legacy shape — an old-shape report diffed against a freshly-run report of the identical prompt scored a false type mismatch, rendering as a spurious added+removed pair instead of a match | Major | ✅ Applied — centralized the normalization helper and called it in every renderer + inside `alignTrajectories()` |
| `tests/integration/server/pi-profile-otlp.integration.test.ts` still asserted the pre-fix `'thinking'` classification for a real end-to-end OTLP-ingested trajectory — would have failed `npm run test:integration` | Major | ✅ Applied — fixed the assertion |
| `TrajectoryDiffView.tsx`'s `StepIcon` had no `'user'` case, silently falling back to a generic wrench icon | Minor | ✅ Applied — added the icon case |

All four findings were applied; none were rejected.

## Verification

```
npm run build:all       # PASS
npm run test:unit       # 337 suites, 5716 passed, 5 skipped, 0 failed
npm run test:integration  # 84 suites, 819 passed, 7 skipped, 0 failed (CI=1 AH_PORT=5015 AH_DEV_PORT=5016 + recovery-disable env vars)
npm audit --audit-level=high  # pre-existing findings only; no package.json/lockfile changes in this PR
```

DCO signoff present on both commits; `CHANGELOG.md` updated under `## [Unreleased]`.
