### PR TITLE
fix(judge): trace judge degrades to trajectory-only for non-instrumented agents; surface run-level judge failures

### DIFF
--- a/components/evals3/EvalRunsPage.tsx
+++ b/components/evals3/EvalRunsPage.tsx
@@ -733,7 +733,12 @@ export const EvalRunsPage: React.FC = () => {
             {rr.errored > 0 && (
               <span
                 className="flex items-center gap-0.5 text-amber-500 font-medium ml-0.5"
-                title="Evaluator could not run on these (e.g. judge validation error). Excluded from pass-rate aggregation."
+                data-testid="run-row-errored-badge"
+                title={
+                  rr.run.judgeFailureSummary
+                    ? `Judge failure: ${rr.run.judgeFailureSummary}`
+                    : 'Evaluator could not run on these (e.g. judge validation error). Excluded from pass-rate aggregation.'
+                }
               >
                 <AlertTriangle size={10} />
                 {rr.errored}

--- a/components/evals3/RunInspectorPage.tsx
+++ b/components/evals3/RunInspectorPage.tsx
@@ -627,6 +627,20 @@ export const RunInspectorPage: React.FC = () => {
             </Button>
           </div>
         </div>
+        {/* Run-level judge-failure banner (lib/judgeFailureSummary.ts). Before
+            this existed, a run whose cases all failed AT THE JUDGE STEP
+            (e.g. the agent-trace-judge's pre-fix "needs a runId or trace
+            correlation hint" validation error for a non-instrumented agent)
+            showed only the bare "N ⚠" errored count above -- no reason. */}
+        {run?.judgeFailureSummary && (
+          <div
+            data-testid="run-judge-failure-banner"
+            className="mt-2 flex items-start gap-1.5 rounded border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-2.5 py-1.5 text-[11px] text-amber-800 dark:text-amber-300"
+          >
+            <AlertTriangle size={12} className="shrink-0 mt-0.5" />
+            <span>{run.judgeFailureSummary}</span>
+          </div>
+        )}
       </div>
 
       {/* Re-run Confirm Dialog (EvaluationRun only) -- doc concern, see above. */}

--- a/lib/judgeFailureSummary.ts
+++ b/lib/judgeFailureSummary.ts
@@ -77,7 +77,8 @@ export function extractJudgeFailureReason(report: CaseFailureLike | null | undef
  * `undefined` for cases that weren't a judge failure) into one run-level
  * summary line.
  *
- * Only fires when judge failures are the DOMINANT outcome (>=50% of total
+ * Only fires when judge failures are the DOMINANT outcome (a strict majority,
+ * > 50% of total
  * cases) -- a couple of incidental judge failures amid an otherwise-healthy
  * run don't need a run-level banner; the per-case badge already covers
  * that. Ties on the most-frequent distinct message break in first-seen
@@ -95,7 +96,7 @@ export function computeJudgeFailureSummary(
   if (total <= 0) return undefined;
   const judgeFailed = reasons.filter((r): r is string => !!r);
   if (judgeFailed.length === 0) return undefined;
-  if (judgeFailed.length < total / 2) return undefined;
+  if (judgeFailed.length * 2 <= total) return undefined;
 
   const counts = new Map<string, number>();
   for (const r of judgeFailed) counts.set(r, (counts.get(r) ?? 0) + 1);

--- a/lib/judgeFailureSummary.ts
+++ b/lib/judgeFailureSummary.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Run-level judge-failure surfacing.
+ *
+ * Background: an individual case whose evaluator (judge) could not produce
+ * a verdict is already visible per-case as the amber "errored" badge (see
+ * `lib/runStats.ts` / `components/evals3/ResultStatus.tsx`) -- but nothing
+ * aggregates WHY across a run. A run whose judge call fails on every case
+ * (e.g. the original incident: the agent-trace-judge provider hard-failing
+ * with "needs a runId or trace correlation hint" for every case of a
+ * non-instrumented REST agent's 62-case run, before it was fixed to degrade
+ * to trajectory-only judging instead) looks IDENTICAL in the runs list to
+ * "the agent did badly" -- the errored/failed count is a bare number with no
+ * text explaining the cause.
+ *
+ * `computeJudgeFailureSummary` aggregates the dominant per-case reason into
+ * one line, persisted on `run.judgeFailureSummary` (BenchmarkRun /
+ * EvaluationRun) and rendered in the runs list + inspector.
+ *
+ * Two report shapes are recognized (see {@link extractJudgeFailureReason}):
+ *   - The canonical shape written by `buildEvaluatorErrorPatch('judge_failed',
+ *     ...)` (services/evaluation/evaluatorError.ts): `metricsStatus: 'error'`
+ *     with a `traceError` tagged `kind=judge_failed`.
+ *   - The legacy/back-compat shape some pre-fix and outer-catch code paths
+ *     still produce: `status: 'failed'` with `llmJudgeReasoning` explicitly
+ *     naming the judge as the failure point (e.g. "Evaluation failed:
+ *     Bedrock Judge validation error ..."). Scoped to messages that mention
+ *     "judge" so a plain agent/network failure sharing the same generic
+ *     `status: 'failed'` shape isn't mislabeled as a judge problem.
+ */
+
+export interface CaseFailureLike {
+  /** EvaluationReport.status */
+  status?: string;
+  /** EvaluationReport.metricsStatus */
+  metricsStatus?: string;
+  /** Set by buildEvaluatorErrorPatch(). */
+  traceError?: string;
+  /** Option-B BC field; also the legacy shape's error carrier. */
+  llmJudgeReasoning?: string;
+}
+
+const PATCH_JUDGE_FAILURE_RE = /kind=judge_failed/;
+const LEGACY_JUDGE_FAILURE_RE = /^Evaluation failed:.*\bjudge\b/i;
+
+/**
+ * Extract the human-readable reason a single case's report represents a
+ * JUDGE (not agent) failure, or `undefined` if it doesn't represent one at
+ * all (case passed/failed normally, or failed for a non-judge reason such as
+ * the agent itself crashing).
+ */
+export function extractJudgeFailureReason(report: CaseFailureLike | null | undefined): string | undefined {
+  if (!report) return undefined;
+
+  if (report.metricsStatus === 'error' && PATCH_JUDGE_FAILURE_RE.test(report.traceError || '')) {
+    // traceError format: "<Label> (kind=judge_failed): <message>" -- the
+    // part after the tag is already the human-readable message.
+    const traceError = report.traceError!;
+    const idx = traceError.indexOf('): ');
+    return idx >= 0 ? traceError.slice(idx + 3) : traceError;
+  }
+
+  if (report.status === 'failed' && LEGACY_JUDGE_FAILURE_RE.test(report.llmJudgeReasoning || '')) {
+    return (report.llmJudgeReasoning || '').replace(/^Evaluation failed:\s*/, '');
+  }
+
+  return undefined;
+}
+
+/**
+ * Aggregate per-case judge-failure reasons (as returned by
+ * {@link extractJudgeFailureReason}, one entry per case in the run,
+ * `undefined` for cases that weren't a judge failure) into one run-level
+ * summary line.
+ *
+ * Only fires when judge failures are the DOMINANT outcome (>=50% of total
+ * cases) -- a couple of incidental judge failures amid an otherwise-healthy
+ * run don't need a run-level banner; the per-case badge already covers
+ * that. Ties on the most-frequent distinct message break in first-seen
+ * order.
+ *
+ * @param reasons per-case reasons (or undefined), one entry per case that
+ *   actually ran (NOT necessarily equal to `total` -- a run in progress may
+ *   have fewer entries than its planned total).
+ * @param total the run's total planned case count (denominator).
+ */
+export function computeJudgeFailureSummary(
+  reasons: Array<string | undefined>,
+  total: number
+): string | undefined {
+  if (total <= 0) return undefined;
+  const judgeFailed = reasons.filter((r): r is string => !!r);
+  if (judgeFailed.length === 0) return undefined;
+  if (judgeFailed.length < total / 2) return undefined;
+
+  const counts = new Map<string, number>();
+  for (const r of judgeFailed) counts.set(r, (counts.get(r) ?? 0) + 1);
+  let dominant = judgeFailed[0];
+  let dominantCount = 0;
+  for (const [reason, count] of counts) {
+    if (count > dominantCount) {
+      dominant = reason;
+      dominantCount = count;
+    }
+  }
+
+  const n = judgeFailed.length;
+  return `${n}/${total} case${n === 1 ? '' : 's'} failed at the judge step: ${dominant}`;
+}

--- a/server/routes/judge.ts
+++ b/server/routes/judge.ts
@@ -447,27 +447,30 @@ router.post('/api/judge', async (req: Request, res: Response) => {
     if (provider === 'agent') {
       // Agent trace judge: an LLM judge with read-only, trace-scoped tools
       // (query_spans/query_logs) so it can verify claims against the run's real
-      // OTel spans/logs instead of trusting the trajectory text. Fail loudly
-      // rather than spawn a judge that can only report "no run id" (see
-      // piAgenticJudgeService) when there's truly nothing to scope on.
-      // Accept EITHER a runId (Strategy B, possibly already the caller's
-      // traceId fallback — see resolveJudgeRunId) OR at least one Strategy
-      // C/D correlation hint in `agents` (serviceName+window or sessionId,
-      // from buildJudgeAgentsHints — #264). Pre-fix this hard-required
-      // `runId` even when `agents` hints were already on the request,
-      // 400-ing every REST-connector agent that picks this judge provider
-      // without trace-mode polling (REST connectors never mint a runId —
-      // see services/evaluation/index.ts's "STANDARD MODE" judge call,
-      // which forwards `agents` hints but no runId). Reject only when
-      // NEITHER is present — there is then truly nothing to scope the
-      // trace tools to.
-      if (!hasTraceCorrelation(runId, agents)) {
-        return res.status(400).json({
-          error:
-            'The agent (trace) judge provider needs a runId or at least one trace ' +
-            'correlation hint (agents: serviceName+window, or sessionId) to scope its ' +
-            'trace tools — this request had neither.'
-        });
+      // OTel spans/logs instead of trusting the trajectory text.
+      //
+      // `traceToolsAvailable` gates WHICH mode the judge runs in — it no
+      // longer gates whether the judge runs at all. Accept EITHER a runId
+      // (Strategy B, possibly already the caller's traceId fallback — see
+      // resolveJudgeRunId) OR at least one Strategy C/D correlation hint in
+      // `agents` (serviceName+window or sessionId, from buildJudgeAgentsHints
+      // — #264) to enable the trace tools. Pre-fix (see #461/#462 lineage)
+      // this hard-required a correlation hint and 400'd otherwise, even for
+      // agents that declare `useTraces: false` and were never going to have
+      // one — every case of a non-instrumented agent's 62-case run hard-
+      // failed at the judge step with a validation error instead of a
+      // verdict. A non-instrumented (or uncorrelated) agent still has a
+      // trajectory + final response worth judging — degrade to
+      // trajectory-only reasoning (no query_spans/query_logs tool pack)
+      // instead of erroring. See piAgenticJudgeService.evaluateWithPiAgenticTrace's
+      // `traceToolsAvailable` param and the persisted `judgeMode` field.
+      const traceToolsAvailable = hasTraceCorrelation(runId, agents);
+      if (!traceToolsAvailable) {
+        debug(
+          'JudgeAPI',
+          'Agent trace judge - no runId/correlation hint available; degrading to ' +
+            'trajectory-only judging (query_spans/query_logs tools withheld) instead of failing.'
+        );
       }
       // Defense in depth against cross-run/cross-tenant exfiltration: the trace
       // tools will happily read spans/logs for whatever runId they're given, so
@@ -498,17 +501,20 @@ router.post('/api/judge', async (req: Request, res: Response) => {
       }
       debug(
         'JudgeAPI',
-        'Agent trace judge - evaluating with trace-scoped tools (runId=' +
+        'Agent trace judge - evaluating (runId=' +
           (runId ?? 'none — hints-only') +
-          ', hints=' + (Array.isArray(agents) ? agents.length : 0) + ')'
+          ', hints=' + (Array.isArray(agents) ? agents.length : 0) +
+          ', traceToolsAvailable=' + traceToolsAvailable + ')'
       );
       // Pass the resolved evaluator so a saved `systemPrompt` replaces the
-      // default base prompt (the trace-tool addendum is still appended
-      // inside the service so the judge always knows query_spans/query_logs
-      // exist).
+      // default base prompt (the trace-tool addendum, or its trajectory-only
+      // counterpart, is still appended inside the service). `traceToolsAvailable`
+      // decides whether the service wires up query_spans/query_logs at all —
+      // see evaluateWithPiAgenticTrace's doc comment.
       const result = await evaluateWithPiAgenticTrace(
         { trajectory, expectedOutcomes, expectedTrajectory, logs, runId, modelId: resolvedModelId, agents },
-        evaluator
+        evaluator,
+        traceToolsAvailable
       );
       return res.json(result);
     }

--- a/server/routes/storage/benchmarks.ts
+++ b/server/routes/storage/benchmarks.ts
@@ -115,7 +115,7 @@ async function backfillRunStats(
       debug('StorageAPI', `[Backfill] Computed stats for run ${run.id}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
       // Persist via adapter (fire-and-forget)
-      storage.benchmarks.updateRun(benchmarkId, run.id, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any)
+      storage.benchmarks.updateRun(benchmarkId, run.id, { stats, judgeFailureSummary: judgeFailureSummary ?? null } as any)
         .catch((e: any) => {
           console.warn('[StorageAPI] Failed to persist backfilled stats for run', run.id, ':', e.message);
         })
@@ -1529,7 +1529,7 @@ router.post('/api/storage/benchmarks/:id/refresh-all-stats', async (req: Request
         debug('StorageAPI', `[RefreshStats] Computed stats for run ${run.id}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
         // Persist via adapter
-        await storage.benchmarks.updateRun(id, run.id, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any);
+        await storage.benchmarks.updateRun(id, run.id, { stats, judgeFailureSummary: judgeFailureSummary ?? null } as any);
 
         debug('StorageAPI', `[RefreshStats] Successfully updated stats for run ${run.id}`);
       } catch (e: any) {
@@ -1580,7 +1580,7 @@ router.post('/api/storage/benchmarks/:id/runs/:runId/refresh-stats', async (req:
     debug('StorageAPI', `[RefreshStats] Computed stats for run ${runId}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
     // Persist via adapter
-    await storage.benchmarks.updateRun(id, runId, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any);
+    await storage.benchmarks.updateRun(id, runId, { stats, judgeFailureSummary: judgeFailureSummary ?? null } as any);
 
     debug('StorageAPI', `[RefreshStats] Successfully updated stats for run ${runId}`);
     res.json({ refreshed: true, runId, stats, judgeFailureSummary });

--- a/server/routes/storage/benchmarks.ts
+++ b/server/routes/storage/benchmarks.ts
@@ -28,6 +28,7 @@ import { resolveCodeFnMapForStoredTestCases } from '../../../services/sourceReso
 import { computeImageDigest, buildImageDoc } from '../../../lib/benchmarkImage.js';
 import { loadConfigSync } from '../../../lib/config/index.js';
 import { getCustomAgents } from '../../services/customAgentStore.js';
+import { extractJudgeFailureReason, computeJudgeFailureSummary } from '../../../lib/judgeFailureSummary.js';
 
 /**
  * Normalize benchmark data for legacy documents without version fields.
@@ -107,13 +108,14 @@ async function backfillRunStats(
   const storage = getStorageModule();
   await Promise.all(runsNeedingStats.map(async (run) => {
     try {
-      const stats = await computeStatsForRun(run);
+      const { judgeFailureSummary, ...stats } = await computeStatsForRun(run);
       run.stats = stats;
+      if (judgeFailureSummary) run.judgeFailureSummary = judgeFailureSummary;
 
       debug('StorageAPI', `[Backfill] Computed stats for run ${run.id}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
       // Persist via adapter (fire-and-forget)
-      storage.benchmarks.updateRun(benchmarkId, run.id, { stats } as any)
+      storage.benchmarks.updateRun(benchmarkId, run.id, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any)
         .catch((e: any) => {
           console.warn('[StorageAPI] Failed to persist backfilled stats for run', run.id, ':', e.message);
         })
@@ -134,7 +136,7 @@ async function backfillRunStats(
 async function computeStatsForRun(
   run: BenchmarkRun,
   client?: any
-): Promise<RunStats> {
+): Promise<RunStats & { judgeFailureSummary?: string }> {
   // Collect report IDs from run results
   const reportIds = Object.values(run.results || {})
     .map(r => r.reportId)
@@ -145,6 +147,12 @@ async function computeStatsForRun(
   let pending = 0;
   let errored = 0;
   const total = Object.keys(run.results || {}).length;
+  // One entry per case that reached a report -- undefined for
+  // pass/fail/pending cases, a human-readable reason for judge failures
+  // (see lib/judgeFailureSummary.ts). Aggregated into `judgeFailureSummary`
+  // below so the runs list/inspector isn't silent about *why* a run's
+  // cases errored (the reported incident: a bare "⚠ 62" with no reason).
+  const judgeFailureReasons: Array<string | undefined> = [];
 
   // Fetch reports to get passFailStatus
   if (reportIds.length > 0) {
@@ -158,7 +166,7 @@ async function computeStatsForRun(
           body: {
             size: reportIds.length,
             query: { terms: { 'id': reportIds } },
-            _source: ['id', 'passFailStatus', 'metricsStatus', 'status'],
+            _source: ['id', 'passFailStatus', 'metricsStatus', 'status', 'traceError', 'llmJudgeReasoning'],
           },
         });
         (reportsResult.body.hits?.hits || []).forEach((hit: any) => {
@@ -206,6 +214,7 @@ async function computeStatsForRun(
           // aggregate pass rates.
           if (report.metricsStatus === 'error') {
             errored++;
+            judgeFailureReasons.push(extractJudgeFailureReason(report));
             return;
           }
 
@@ -213,6 +222,7 @@ async function computeStatsForRun(
             passed++;
           } else {
             failed++;
+            judgeFailureReasons.push(extractJudgeFailureReason(report));
           }
         } else {
           pending++;
@@ -242,7 +252,8 @@ async function computeStatsForRun(
     });
   }
 
-  return { passed, failed, pending, errored, total };
+  const judgeFailureSummary = computeJudgeFailureSummary(judgeFailureReasons, total);
+  return { passed, failed, pending, errored, total, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) };
 }
 
 /**
@@ -1293,13 +1304,14 @@ router.post('/api/storage/benchmarks/:id/execute', async (req: Request, res: Res
 
       // Compute final stats from reports
       debug('StorageAPI', '[StatsUpdate] Computing final stats for completed run:', run.id);
-      const stats = await computeStatsForRun(completedRun, client);
+      const { judgeFailureSummary, ...stats } = await computeStatsForRun(completedRun, client);
       debug('StorageAPI', `[StatsUpdate] Final stats for run ${run.id}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
       const finalRun = {
         ...completedRun,
         status: wasCancelled ? 'cancelled' as const : 'completed' as const,
         stats,
+        ...(judgeFailureSummary ? { judgeFailureSummary } : {}),
       };
 
       // Update benchmark with final run results
@@ -1510,13 +1522,14 @@ router.post('/api/storage/benchmarks/:id/refresh-all-stats', async (req: Request
     // Recompute stats for ALL runs (not just those missing stats)
     await Promise.all(runs.map(async (run) => {
       try {
-        const stats = await computeStatsForRun(run);
+        const { judgeFailureSummary, ...stats } = await computeStatsForRun(run);
         run.stats = stats;
+        if (judgeFailureSummary) run.judgeFailureSummary = judgeFailureSummary;
 
         debug('StorageAPI', `[RefreshStats] Computed stats for run ${run.id}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
         // Persist via adapter
-        await storage.benchmarks.updateRun(id, run.id, { stats } as any);
+        await storage.benchmarks.updateRun(id, run.id, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any);
 
         debug('StorageAPI', `[RefreshStats] Successfully updated stats for run ${run.id}`);
       } catch (e: any) {
@@ -1562,15 +1575,15 @@ router.post('/api/storage/benchmarks/:id/runs/:runId/refresh-stats', async (req:
     debug('StorageAPI', `[RefreshStats] Manually refreshing stats for run ${runId} in benchmark ${id}`);
 
     // Recompute stats for the run
-    const stats = await computeStatsForRun(run);
+    const { judgeFailureSummary, ...stats } = await computeStatsForRun(run);
 
     debug('StorageAPI', `[RefreshStats] Computed stats for run ${runId}: passed=${stats.passed}, failed=${stats.failed}, pending=${stats.pending}, total=${stats.total}`);
 
     // Persist via adapter
-    await storage.benchmarks.updateRun(id, runId, { stats } as any);
+    await storage.benchmarks.updateRun(id, runId, { stats, ...(judgeFailureSummary ? { judgeFailureSummary } : {}) } as any);
 
     debug('StorageAPI', `[RefreshStats] Successfully updated stats for run ${runId}`);
-    res.json({ refreshed: true, runId, stats });
+    res.json({ refreshed: true, runId, stats, judgeFailureSummary });
   } catch (error: any) {
     if (error.meta?.statusCode === 404) {
       return res.status(404).json({ error: 'Benchmark not found' });

--- a/server/routes/storage/evaluationRuns.ts
+++ b/server/routes/storage/evaluationRuns.ts
@@ -330,6 +330,7 @@ router.post('/api/storage/evaluation-runs', async (req: Request, res: Response) 
           id: run.id, name: run.name, createdAt: run.createdAt, completedAt,
           status: finalStatus, agentKey: run.agentKey, modelId: run.modelId,
           judgeModelId: run.judgeModelId, results: completedRun.results, stats: completedRun.stats,
+          ...(completedRun.judgeFailureSummary ? { judgeFailureSummary: completedRun.judgeFailureSummary } : {}),
           ...(run.description ? { description: run.description } : {}),
           ...(run.evaluatorId ? { evaluatorId: run.evaluatorId } : {}),
           ...(run.headers ? { headers: run.headers } : {}),
@@ -342,6 +343,7 @@ router.post('/api/storage/evaluation-runs', async (req: Request, res: Response) 
 
       const updatedRun = await storage.evaluationRuns.update(runId, {
         status: finalStatus, stats: completedRun.stats, completedAt, results: completedRun.results,
+        ...(completedRun.judgeFailureSummary ? { judgeFailureSummary: completedRun.judgeFailureSummary } : {}),
       });
       sendSSE(res, 'completed', updatedRun);
     } catch (error: any) {
@@ -529,6 +531,7 @@ router.post('/api/storage/evaluation-runs/:id/rerun', async (req: Request, res: 
           stats: completedRun.stats,
           completedAt: new Date().toISOString(),
           results: completedRun.results,
+          ...(completedRun.judgeFailureSummary ? { judgeFailureSummary: completedRun.judgeFailureSummary } : {}),
         });
       })
       .catch(async (error: any) => {

--- a/server/services/bedrockService.ts
+++ b/server/services/bedrockService.ts
@@ -98,6 +98,17 @@ export interface JudgeResponse {
     systemPrompt?: string;
     userPrompt?: string;
   };
+  /**
+   * Set exclusively by the agent (trace) judge provider
+   * (piAgenticJudgeService.evaluateWithPiAgenticTrace) to record whether this
+   * verdict was backed by real OTel spans/logs (`'trace-tools'`) or had to
+   * fall back to trajectory-only reasoning because the run carried no
+   * correlation hint (`'trajectory-only'` — the normal case for an agent
+   * declared `useTraces: false`). Undefined for every other provider.
+   * Persisted onto `TestCaseRun.judgeMode` so reports/comparisons can show
+   * which cases had trace evidence behind them.
+   */
+  judgeMode?: 'trajectory-only' | 'trace-tools';
 }
 
 // ============================================================================

--- a/server/services/piAgenticJudgeService.ts
+++ b/server/services/piAgenticJudgeService.ts
@@ -66,6 +66,27 @@ In addition to the trajectory shown in the prompt you have these tools that retu
 These tools are hard-scoped to this single run — you cannot query other runs. PREFER verifying claims against this real data over trusting the trajectory narrative. Confirm a span exists before crediting a tool call, check real token usage before crediting a budget claim, and look for log evidence before crediting a root-cause claim.`;
 
 /**
+ * Addendum appended instead of {@link AGENT_TRACE_TOOL_ADDENDUM} when the
+ * request carries no trace correlation (no `runId`, no `agents` hint — see
+ * `hasTraceCorrelation`). This is the normal, expected case for an agent
+ * declared `useTraces: false` (not OTel-instrumented) — there is nothing to
+ * correlate, not a bug. The judge must know it has NO trace tools this run
+ * so it grounds its verdict in the trajectory/response actually shown in
+ * the prompt instead of hallucinating span/log checks it never performed
+ * (or silently trying to call query_spans/query_logs, which don't exist in
+ * this mode).
+ */
+const NO_TRACE_TOOLS_ADDENDUM = `
+
+---
+
+## No trace-query tools available for this run
+
+This run's agent is not instrumented with OpenTelemetry (or agent-health could not correlate this run to any trace/session), so \`query_spans\` and \`query_logs\` are NOT available to you for this evaluation.
+
+Judge STRICTLY from the trajectory and the agent's final response shown in the prompt above. Do NOT claim to have checked spans, logs, token usage, or latency data — you were not given any. Do NOT reference \`query_spans\`/\`query_logs\` or "the real OTel data" in your reasoning; ground every claim only in what the trajectory/response actually shows.`;
+
+/**
  * Dynamically load the pi SDK (optionalDependency). Throws a clear, actionable
  * error when it isn't installed rather than a raw module-not-found.
  *
@@ -107,12 +128,15 @@ function bedrockBaseId(id: string): string {
  * Exported for unit testing; production callers go through
  * {@link evaluateWithPiAgenticTrace}.
  */
-export function buildAgentTraceJudgeSystemPrompt(evaluator?: { systemPrompt?: string }): string {
+export function buildAgentTraceJudgeSystemPrompt(
+  evaluator?: { systemPrompt?: string },
+  traceToolsAvailable: boolean = true
+): string {
   const baseSystemPrompt =
     evaluator?.systemPrompt && evaluator.systemPrompt.trim().length > 0
       ? evaluator.systemPrompt
       : DEFAULT_AGENT_TRACE_JUDGE_BASE_PROMPT;
-  return baseSystemPrompt + AGENT_TRACE_TOOL_ADDENDUM;
+  return baseSystemPrompt + (traceToolsAvailable ? AGENT_TRACE_TOOL_ADDENDUM : NO_TRACE_TOOLS_ADDENDUM);
 }
 
 /**
@@ -180,29 +204,50 @@ export function extractFinalAssistantText(messages: any[]): string {
 /**
  * Evaluate a trajectory with the agent trace judge (in-process pi SDK).
  *
- * Requires EITHER `request.runId` OR at least one `request.agents` correlation
- * hint (serviceName+window / sessionId — see hasTraceCorrelation) so the trace
- * tools have something to scope to. Without either, the tools report "no run
- * id or trace correlation hints" and the judge degrades to a trajectory-only
- * judgement rather than failing — the route's gate (server/routes/judge.ts)
- * rejects the request before it reaches here in that case.
+ * Two modes, selected by `traceToolsAvailable` (the caller —
+ * server/routes/judge.ts — computes this via `hasTraceCorrelation(runId,
+ * agents)` and passes the result in):
+ *   - `true` (trace-tools mode): `request.runId` or a `request.agents`
+ *     correlation hint (serviceName+window / sessionId) is present. The
+ *     judge gets the real `query_spans`/`query_logs` tools scoped to this
+ *     run and is instructed to verify claims against them.
+ *   - `false` (trajectory-only mode): no correlation hint exists — the
+ *     normal case for an agent declared `useTraces: false` (not
+ *     OTel-instrumented), or one whose spans just can't be correlated. The
+ *     judge gets NO trace tools at all and is told so explicitly (see
+ *     {@link NO_TRACE_TOOLS_ADDENDUM}) so it grounds its verdict in the
+ *     trajectory/response instead of hallucinating span checks. This
+ *     NEVER throws for lack of correlation — pre-fix (#461/#462 lineage)
+ *     the route hard-400'd here instead, which is what turned an entire
+ *     62-case run against a non-instrumented REST agent into 62 judge
+ *     failures with `passFailStatus: null` instead of 62 real verdicts.
  *
- * @param request - The judge request, must include `runId` for trace scoping.
+ * The resolved mode is persisted on the response as `judgeMode` (see
+ * {@link JudgeResponse.judgeMode}) so reports/comparisons can show whether a
+ * verdict had real trace evidence behind it.
+ *
+ * @param request - The judge request. `runId`/`agents` are used only to
+ *   decide tool scoping when `traceToolsAvailable` is true.
  * @param evaluator - Optional saved evaluator. When provided, its `systemPrompt`
- *   replaces the default base prompt; the trace-tool addendum is ALWAYS
- *   appended on top so the judge knows `query_spans`/`query_logs` exist
- *   regardless of how the user customizes the base prompt. Its
+ *   replaces the default base prompt; the trace-tool (or trajectory-only)
+ *   addendum is ALWAYS appended on top so the judge's understanding of its
+ *   own tool access is never silently dropped by a custom prompt.
  *   `scoringConfig.metrics` drives dynamic metric extraction in the parsed
  *   response.
+ * @param traceToolsAvailable - Whether to wire up `query_spans`/`query_logs`
+ *   for this evaluation. Defaults to `true` for callers that don't pass it
+ *   (back-compat with any caller written before this param existed) — the
+ *   route always passes an explicit value.
  */
 export async function evaluateWithPiAgenticTrace(
   request: JudgeRequest,
-  evaluator?: Evaluator
+  evaluator?: Evaluator,
+  traceToolsAvailable: boolean = true
 ): Promise<JudgeResponse> {
   const { trajectory, expectedOutcomes, expectedTrajectory, logs, runId, agents } = request;
 
   debug('AgentJudge', '========== AGENT TRACE JUDGE (in-process) ==========');
-  debug('AgentJudge', 'runId:', runId ?? '(none)', 'trajectory steps:', trajectory.length);
+  debug('AgentJudge', 'runId:', runId ?? '(none)', 'trajectory steps:', trajectory.length, 'traceToolsAvailable:', traceToolsAvailable);
   debug('AgentJudge', 'Evaluator:', evaluator ? `${evaluator.name} (${evaluator.id})` : '(none, using default prompt)');
 
   const userPrompt = buildEvaluationPrompt(trajectory, expectedOutcomes, expectedTrajectory, logs);
@@ -228,18 +273,24 @@ export async function evaluateWithPiAgenticTrace(
   debug('AgentJudge', 'model:', `${model.provider}/${model.id}`);
 
   // Compose the system prompt: saved evaluator's prompt (if any) replaces
-  // the default base, then the trace-tool addendum is unconditionally
-  // appended. Editing the saved prompt cannot accidentally break the
-  // trace-judging contract — a regression test in piAgenticJudgeService.test
+  // the default base, then the trace-tool (or trajectory-only) addendum is
+  // unconditionally appended. Editing the saved prompt cannot accidentally
+  // break either contract — a regression test in piAgenticJudgeService.test
   // pins this invariant.
-  const systemPrompt = buildAgentTraceJudgeSystemPrompt(evaluator);
+  const systemPrompt = buildAgentTraceJudgeSystemPrompt(evaluator, traceToolsAvailable);
 
   const resourceLoader = new DefaultResourceLoader({
     cwd: process.cwd(),
     agentDir: getAgentDir(),
     systemPromptOverride: () => systemPrompt,
     appendSystemPromptOverride: () => [],
-    extensionFactories: [createTraceJudgeExtension(runId, serverUrl, agents)],
+    // Only register the trace-query tool extension when there's something to
+    // scope it to. Without this guard, a trajectory-only evaluation would
+    // still expose query_spans/query_logs — tools the system prompt just told
+    // the model it doesn't have — confusing the model and reintroducing the
+    // "no run id or trace correlation hints" failure mode inside the tool
+    // call instead of at the route.
+    extensionFactories: traceToolsAvailable ? [createTraceJudgeExtension(runId, serverUrl, agents)] : [],
     // Full isolation for this HEADLESS in-process session. Without
     // noExtensions the loader auto-loads the user's global ~/.pi/agent
     // extensions (e.g. an interactive status-bar extension) whose render
@@ -260,10 +311,13 @@ export async function evaluateWithPiAgenticTrace(
     modelRegistry,
     resourceLoader,
     // Restrict to ONLY the run-scoped trace tools registered by the extension
-    // factory. `tools: []` disables all built-in tools (read/bash/grep/...) so
+    // factory (when available — `tools: []` in trajectory-only mode disables
+    // ALL tools, including the trace ones, matching `extensionFactories` above).
+    // `tools: []` disables all built-in tools (read/bash/grep/...) either way so
     // the judge cannot read the project's filesystem — it may only inspect this
-    // run's spans/logs. This is the core scoping guarantee of the trace judge.
-    tools: ['query_spans', 'query_logs'],
+    // run's spans/logs when they're available. This is the core scoping
+    // guarantee of the trace judge.
+    tools: traceToolsAvailable ? ['query_spans', 'query_logs'] : [],
     sessionManager: SessionManager.inMemory(),
   });
 
@@ -289,5 +343,13 @@ export async function evaluateWithPiAgenticTrace(
   // (those belong to the insights synthesis layer). Forcing an empty array
   // also keeps the persisted matcherResults.improvementStrategies shape stable
   // regardless of what the model emitted.
-  return { ...parsed, improvementStrategies: [] };
+  return {
+    ...parsed,
+    improvementStrategies: [],
+    // Persisted downstream (services/evaluation/*, evaluationRunner.ts,
+    // benchmarkRunner.ts) onto TestCaseRun.judgeMode so reports/comparisons
+    // can show which cases had real trace evidence vs. trajectory-only
+    // reasoning.
+    judgeMode: traceToolsAvailable ? 'trace-tools' : 'trajectory-only',
+  };
 }

--- a/services/benchmarkRunner.ts
+++ b/services/benchmarkRunner.ts
@@ -1364,7 +1364,9 @@ async function refreshBenchmarkRunStats(
     const judgeFailureSummary = computeJudgeFailureSummary(judgeFailureReasons, total);
     await storage.benchmarks.updateRun(benchmarkId, targetRun.id, {
       stats: { passed, failed, pending, errored, total },
-      ...(judgeFailureSummary ? { judgeFailureSummary } : {}),
+      // `null` (not omitted) so a stale summary is CLEARED once retry-judgement
+      // or a trace-poll verdict resolves the cases (codex_review finding).
+      judgeFailureSummary: judgeFailureSummary ?? null,
     } as any);
   } catch (err) {
     console.warn(`[BenchmarkRunner] Failed to refresh stats for benchmark ${benchmarkId}:`, err instanceof Error ? err.message : err);

--- a/services/benchmarkRunner.ts
+++ b/services/benchmarkRunner.ts
@@ -35,6 +35,7 @@ import { buildEvaluatorErrorPatch } from './evaluation/evaluatorError';
 import { connectorRegistry } from '@/services/connectors/server';
 import { readEnv } from '@/lib/envCompat';
 import { buildJudgeAgentsHints, resolveJudgeRunId } from '@/services/traces/judgeAgentsHints';
+import { extractJudgeFailureReason, computeJudgeFailureSummary } from '@/lib/judgeFailureSummary';
 import {
   runInSession,
   recordVerdict,
@@ -873,6 +874,9 @@ async function saveReportWithModule(storage: IStorageModule, report: any): Promi
     traceError: report.traceError,
     spans: report.spans,
     connectorProtocol: report.connectorProtocol,
+    // Set only by the agent (trace) judge provider -- see
+    // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+    judgeMode: report.judgeMode,
   } as any);
   return { ...report, id: saved.id, timestamp: saved.timestamp };
 }
@@ -994,6 +998,9 @@ export async function runSingleUseCase(
       traceError: report.traceError,
       spans: report.spans,
       connectorProtocol: report.connectorProtocol,
+      // Set only by the agent (trace) judge provider -- see
+      // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+      judgeMode: (report as any).judgeMode,
     } as Partial<TestCaseRun>;
     const updated = await storage.runs.update(existingReportId, updates);
     savedReport = { ...report, id: updated.id, timestamp: updated.timestamp };
@@ -1112,6 +1119,9 @@ export function startTracePollingForReportWithModule(report: EvaluationReport, t
             passFailStatus: judgment.passFailStatus,
             metrics: judgment.metrics,
             llmJudgeReasoning: judgment.llmJudgeReasoning,
+            // Set only by the agent (trace) judge provider -- see
+            // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+            ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
             // Unified judge surface (issue #230 follow-up).
             matcherResults: [
               buildJudgeMatcherEntry(judgment, {
@@ -1235,6 +1245,9 @@ function startTracePollingForReport(report: EvaluationReport, testCase: TestCase
             passFailStatus: judgment.passFailStatus,
             metrics: judgment.metrics,
             llmJudgeReasoning: judgment.llmJudgeReasoning,
+            // Set only by the agent (trace) judge provider -- see
+            // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+            ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
             // Unified judge surface (issue #230 follow-up).
             matcherResults: [
               buildJudgeMatcherEntry(judgment, {
@@ -1323,6 +1336,7 @@ async function refreshBenchmarkRunStats(
 
     let passed = 0, failed = 0, pending = 0, errored = 0;
     const total = Object.keys(targetRun.results || {}).length;
+    const judgeFailureReasons: Array<string | undefined> = [];
 
     for (const rid of reportIds) {
       try {
@@ -1334,10 +1348,12 @@ async function refreshBenchmarkRunStats(
         } else if (ms === 'error') {
           // Evaluator failed to produce a verdict (issue #242).
           errored++;
+          judgeFailureReasons.push(extractJudgeFailureReason(report as any));
         } else if (report.passFailStatus === 'passed') {
           passed++;
         } else {
           failed++;
+          judgeFailureReasons.push(extractJudgeFailureReason(report as any));
         }
       } catch {
         pending++;
@@ -1345,8 +1361,10 @@ async function refreshBenchmarkRunStats(
     }
     pending += total - reportIds.length;
 
+    const judgeFailureSummary = computeJudgeFailureSummary(judgeFailureReasons, total);
     await storage.benchmarks.updateRun(benchmarkId, targetRun.id, {
       stats: { passed, failed, pending, errored, total },
+      ...(judgeFailureSummary ? { judgeFailureSummary } : {}),
     } as any);
   } catch (err) {
     console.warn(`[BenchmarkRunner] Failed to refresh stats for benchmark ${benchmarkId}:`, err instanceof Error ? err.message : err);

--- a/services/evaluation/bedrockJudge.ts
+++ b/services/evaluation/bedrockJudge.ts
@@ -40,6 +40,15 @@ interface JudgeResult {
     systemPrompt?: string;
     userPrompt?: string;
   };
+  /**
+   * Forwarded from `/api/judge`'s agent (trace) judge provider (see
+   * `JudgeResponse.judgeMode`). `'trace-tools'` when the verdict was backed
+   * by real query_spans/query_logs; `'trajectory-only'` when the run had no
+   * trace correlation hint and the judge reasoned from the trajectory alone
+   * (the normal case for a `useTraces: false` agent). Undefined for every
+   * other judge provider.
+   */
+  judgeMode?: 'trajectory-only' | 'trace-tools';
 }
 
 /**
@@ -168,6 +177,7 @@ export async function callBedrockJudge(
         extraFields: result.extraFields,
         overallScore: result.overallScore,
         judgeDebug: result.judgeDebug,
+        judgeMode: result.judgeMode,
       };
     } catch (error) {
       const isLastAttempt = attempt === maxRetries;

--- a/services/evaluation/index.ts
+++ b/services/evaluation/index.ts
@@ -19,6 +19,7 @@ import { buildJudgeMatcherEntry, formatExpectedOutcomesAsClaim } from '@/lib/mat
 import type { MatcherResult } from '@/lib/matchers/types';
 import type { TracesAccessor } from '@/lib/matchers/traces';
 import { buildJudgeAgentsHints } from '@/services/traces/judgeAgentsHints';
+import { buildEvaluatorErrorPatch } from '@/services/evaluation/evaluatorError';
 
 // Re-export for use by experimentRunner when calling judge after trace polling
 export { callBedrockJudge };
@@ -612,33 +613,78 @@ export async function runEvaluationWithConnector(
       process.env.BEDROCK_MODEL_ID ||
       modelConfig?.model_id ||
       modelId;
-    const judgment = await callBedrockJudge(
-      fullTrajectory,
-      {
-        expectedOutcomes: testCase.expectedOutcomes,
-        expectedTrajectory: testCase.expectedTrajectory,
-      },
-      undefined, // No logs in direct connector mode
-      (chunk) => debug('Eval', 'Judge progress:', chunk.slice(0, 100)),
-      judgeModelId,
-      evaluatorId,
-      // Forward agent runId so the `agent` (trace) judge provider can
-      // scope its query_spans/query_logs tools. See callBedrockJudge.
-      agentRunId || undefined,
-      // Strategy C correlation hints (#264) so the trace judge tool can
-      // find spans the agent emits under its OWN correlation (claude-code
-      // session ids etc.), not just spans matching agent-health's runId
-      // via gen_ai.request.id.
-      buildJudgeAgentsHints(
+
+    // The judge call gets its OWN try/catch, separate from agent invocation
+    // above. Pre-fix, a judge failure here (e.g. the agent-trace-judge's
+    // "needs a runId or trace correlation hint" validation error for a
+    // `useTraces: false` REST agent -- the reported incident) fell through
+    // to the OUTER catch below and was indistinguishable from a genuine
+    // agent crash: `status: 'failed'`, no `metricsStatus`, generic
+    // "Evaluation failed: ..." reasoning. That shape is invisible to
+    // retry-judgement's `isJudgeFailedCase` (requires `metricsStatus:
+    // 'error'` on a `'completed'` result) and buckets as `failed` instead of
+    // `errored` in the runs list/stats (lib/runStats.ts), silently
+    // misattributing an evaluator problem as "the agent did badly". The
+    // agent DID complete here (we have `fullTrajectory`) -- use the
+    // canonical `buildEvaluatorErrorPatch('judge_failed', ...)` shape so
+    // this case is `status: 'completed'` + `metricsStatus: 'error'`,
+    // exactly like every other judge-failure code path in this codebase
+    // (evaluationRunner.ts, benchmarkRunner.ts, retryJudgement.ts,
+    // browserRecovery.ts).
+    let judgment: Awaited<ReturnType<typeof callBedrockJudge>>;
+    try {
+      judgment = await callBedrockJudge(
+        fullTrajectory,
         {
-          agentKey: agent.key,
-          connectorProtocol: (agent.connectorType as any),
-          timestamp: new Date().toISOString(),
-          performanceMetrics: { durationMs: Date.now() - evalStartTime, agentDurationMs },
+          expectedOutcomes: testCase.expectedOutcomes,
+          expectedTrajectory: testCase.expectedTrajectory,
         },
-        agent.traceServiceName
-      )
-    );
+        undefined, // No logs in direct connector mode
+        (chunk) => debug('Eval', 'Judge progress:', chunk.slice(0, 100)),
+        judgeModelId,
+        evaluatorId,
+        // Forward agent runId so the `agent` (trace) judge provider can
+        // scope its query_spans/query_logs tools. See callBedrockJudge.
+        agentRunId || undefined,
+        // Strategy C correlation hints (#264) so the trace judge tool can
+        // find spans the agent emits under its OWN correlation (claude-code
+        // session ids etc.), not just spans matching agent-health's runId
+        // via gen_ai.request.id.
+        buildJudgeAgentsHints(
+          {
+            agentKey: agent.key,
+            connectorProtocol: (agent.connectorType as any),
+            timestamp: new Date().toISOString(),
+            performanceMetrics: { durationMs: Date.now() - evalStartTime, agentDurationMs },
+          },
+          agent.traceServiceName
+        )
+      );
+    } catch (judgeError) {
+      console.error('[Eval] Judge call failed:', judgeError instanceof Error ? judgeError.message : judgeError);
+      return {
+        id: reportId,
+        timestamp: new Date().toISOString(),
+        agentName: agent.name,
+        agentKey: agent.key,
+        modelName: modelId,
+        modelId,
+        testCaseId: testCase.id,
+        testCaseVersion: testCase.currentVersion ?? 1,
+        status: 'completed',
+        trajectory: fullTrajectory,
+        ...buildEvaluatorErrorPatch('judge_failed', judgeError),
+        improvementStrategies: [],
+        runId: agentRunId || undefined,
+        sessionId: agentSessionId || undefined,
+        rawEvents,
+        connectorProtocol: connector.type as ConnectorProtocol,
+        performanceMetrics: {
+          durationMs: Date.now() - evalStartTime,
+          agentDurationMs,
+        },
+      };
+    }
 
     debug('Eval', 'Metrics:', judgment.metrics);
 
@@ -673,6 +719,9 @@ export async function runEvaluationWithConnector(
       trajectory: fullTrajectory,
       metrics: judgment.metrics,
       llmJudgeReasoning: judgment.llmJudgeReasoning,
+      // Set only by the agent (trace) judge provider -- see
+      // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+      ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
       // Unified judge surface (Option-B BC: legacy field above kept).
       matcherResults: [
         buildJudgeMatcherEntry(judgment, {
@@ -938,6 +987,9 @@ export async function runEvaluation(
       trajectory: fullTrajectory,
       metrics: judgment.metrics,
       llmJudgeReasoning: judgment.llmJudgeReasoning,
+      // Set only by the agent (trace) judge provider -- see
+      // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+      ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
       // Unified judge surface (Option-B BC: legacy field above kept).
       matcherResults: [
         buildJudgeMatcherEntry(judgment, {

--- a/services/evaluation/retryJudgement.ts
+++ b/services/evaluation/retryJudgement.ts
@@ -42,7 +42,7 @@ import { buildEvaluatorErrorPatch } from '@/services/evaluation/evaluatorError';
 import { spansToTrajectory } from '@/services/traces/spansToTrajectory';
 import { fetchSpansForRun } from '@/services/traces/fetchSpansForRun';
 import { computeRunStats } from '@/lib/runStats';
-import { extractJudgeFailureReason } from '@/lib/judgeFailureSummary';
+import { extractJudgeFailureReason, computeJudgeFailureSummary } from '@/lib/judgeFailureSummary';
 import { loadConfigSync } from '@/lib/config/index';
 import { getCustomAgents } from '@/server/services/customAgentStore';
 import { debug } from '@/lib/debug';
@@ -413,10 +413,21 @@ export async function retryJudgementForRun(
 
   const updatedRun = { ...run, results: updatedResults };
   const stats = computeRunStats(updatedRun);
+  // Recompute the run-level judge-failure summary from the FRESH report docs
+  // so it clears (`null`, not omitted -- storage merges updates) once the
+  // salvage resolves the cases, instead of a stale banner outliving the
+  // failure it described (codex_review finding on this PR).
+  const freshReports = await fetchReportsById(updatedRun, storage);
+  const reasons = Object.values(updatedResults)
+    .map((r: any) => (r?.reportId ? freshReports[r.reportId] : null))
+    .filter(Boolean)
+    .map((rep) => extractJudgeFailureReason(rep as any));
+  const judgeFailureSummary = computeJudgeFailureSummary(reasons, stats.total) ?? null;
   await storage.evaluationRuns.update(run.id, {
     results: updatedResults,
     stats: { ...(run.stats || {}), ...stats } as any,
-  });
+    judgeFailureSummary,
+  } as any);
 
   // Deterministic order (not insertion/completion order, which varies with
   // the concurrency fan-out) so callers/tests can rely on a stable summary.

--- a/services/evaluation/retryJudgement.ts
+++ b/services/evaluation/retryJudgement.ts
@@ -42,6 +42,7 @@ import { buildEvaluatorErrorPatch } from '@/services/evaluation/evaluatorError';
 import { spansToTrajectory } from '@/services/traces/spansToTrajectory';
 import { fetchSpansForRun } from '@/services/traces/fetchSpansForRun';
 import { computeRunStats } from '@/lib/runStats';
+import { extractJudgeFailureReason } from '@/lib/judgeFailureSummary';
 import { loadConfigSync } from '@/lib/config/index';
 import { getCustomAgents } from '@/server/services/customAgentStore';
 import { debug } from '@/lib/debug';
@@ -97,8 +98,21 @@ export function isJudgeFailedCase(
 ): boolean {
   if (!report || !result) return false;
   if (result.status !== 'completed') return false;
-  if (report.metricsStatus !== 'error') return false;
-  return Array.isArray(report.trajectory) && report.trajectory.length > 0;
+  const hasTrajectory = Array.isArray(report.trajectory) && report.trajectory.length > 0;
+  if (!hasTrajectory) return false;
+  if (report.metricsStatus === 'error') return true;
+  // Legacy pre-fix shape: before services/evaluation/index.ts split the judge
+  // call into its own catch, a judge-step failure after a SUCCESSFUL agent run
+  // landed as `status: 'failed'` with no `metricsStatus` and a generic
+  // "Evaluation failed: <judge error>" reasoning -- indistinguishable from an
+  // agent crash except that the trajectory exists (agent completed) and the
+  // message names the judge. Runs persisted before the fix (e.g. a 62-case run
+  // against a non-instrumented REST agent whose every case hit the
+  // agent-trace-judge's old "needs a runId or trace correlation hint" 400)
+  // must remain salvageable at judge cost only -- that is exactly this
+  // feature's purpose. `extractJudgeFailureReason` (lib/judgeFailureSummary.ts)
+  // is the single definition of that legacy shape.
+  return report.status === 'failed' && !report.passFailStatus && !!extractJudgeFailureReason(report);
 }
 
 /**
@@ -212,6 +226,9 @@ export async function retryJudgementForCase(
       passFailStatus: judgment.passFailStatus,
       metrics: judgment.metrics,
       llmJudgeReasoning: judgment.llmJudgeReasoning,
+      // Set only by the agent (trace) judge provider -- see
+      // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+      ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
       matcherResults: [
         buildJudgeMatcherEntry(judgment, {
           claim: formatExpectedOutcomesAsClaim(testCase.expectedOutcomes),

--- a/services/evaluationRunner.ts
+++ b/services/evaluationRunner.ts
@@ -53,6 +53,7 @@ import { expect } from '@/lib/matchers/expect';
 import type { TrajectoryStep } from '@/types';
 import { createHookOrchestrator, type TestDescriptor } from './hookOrchestrator';
 import { bucketRunResults } from '@/lib/runStats';
+import { extractJudgeFailureReason, computeJudgeFailureSummary } from '@/lib/judgeFailureSummary';
 import { loadConfigSync } from '@/lib/config/index';
 import { getBackendUrl } from '@/lib/portConfig';
 import { DEFAULT_CONFIG } from '@/lib/constants';
@@ -220,6 +221,11 @@ export async function executeEvaluationRun(
   // Shared throttle signal for rate-limit backoff
   let throttleUntil = 0;
   let consecutiveThrottles = 0;
+
+  // Per-case judge-failure reasons (undefined for cases that weren't a judge
+  // failure), accumulated for the run-level `judgeFailureSummary` computed
+  // after the loop below. See lib/judgeFailureSummary.ts.
+  const judgeFailureReasons: Array<string | undefined> = [];
 
   try {
     await runWithConcurrencyLimit(
@@ -747,6 +753,13 @@ export async function executeEvaluationRun(
             status,
             ...(reportPassFail ? { passFailStatus: reportPassFail } : {}),
           };
+          // Track judge-failure reasons for the run-level judgeFailureSummary
+          // (see lib/judgeFailureSummary.ts). `savedReport` reflects the
+          // pre-trace-poll state for trace-mode agents (see comment above) --
+          // extractJudgeFailureReason correctly returns undefined for those
+          // (metricsStatus is 'pending', not 'error'), so this only captures
+          // the synchronous/deterministic judge-failure path today.
+          judgeFailureReasons.push(extractJudgeFailureReason(savedReport as any));
 
           // Finalize the OTel test_case span with the evaluation outcome.
           if (caseSpan) {
@@ -841,6 +854,16 @@ export async function executeEvaluationRun(
     // assignment above for how passFailStatus/metricsStatus land here.
     const bucketed = bucketRunResults(run.results as Record<string, { status?: string; passFailStatus?: string }>);
     run.stats = { ...bucketed, total: totalTestCases };
+
+    // Run-level judge-failure surfacing (see lib/judgeFailureSummary.ts):
+    // when a dominant share of cases failed AT THE JUDGE STEP specifically,
+    // stamp a one-line reason onto the run doc so the runs list/inspector
+    // isn't silent about *why* -- pre-fix a run like this showed only a
+    // bare warning-triangle count with no reason (the reported incident).
+    const judgeFailureSummary = computeJudgeFailureSummary(judgeFailureReasons, totalTestCases);
+    if (judgeFailureSummary) {
+      run.judgeFailureSummary = judgeFailureSummary;
+    }
 
     // Compute performance metrics
     const totalDuration = Date.now() - runStartTime;
@@ -951,6 +974,9 @@ async function waitForTracesAndJudge(
               passFailStatus: judgment.passFailStatus,
               metrics: judgment.metrics,
               llmJudgeReasoning: judgment.llmJudgeReasoning,
+              // Set only by the agent (trace) judge provider -- see
+              // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+              ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
               // Unified judge surface (issue #230 follow-up).
               // The deterministic path doesn't reach here — trace-mode
               // judge runs only when the test case has no SDK body —

--- a/services/storage/asyncBenchmarkStorage.ts
+++ b/services/storage/asyncBenchmarkStorage.ts
@@ -103,6 +103,10 @@ function toBenchmarkRun(stored: StorageBenchmarkRunConfig): BenchmarkRun {
     status: stored.status as BenchmarkRunStatus | undefined,
     error: stored.error,
     stats: stored.stats as RunStats | undefined,
+    // Run-level judge-failure reason (lib/judgeFailureSummary.ts) — mapped
+    // explicitly because this mapper is an allow-list; without it the
+    // inspector banner never renders for benchmark-embedded runs.
+    judgeFailureSummary: (stored as any).judgeFailureSummary,
     results,
     performanceMetrics: (stored as any).performanceMetrics,
   };
@@ -145,6 +149,7 @@ function toStorageFormat(benchmark: Partial<Benchmark>): Record<string, any> {
       benchmarkVersion: run.benchmarkVersion,
       testCaseSnapshots: run.testCaseSnapshots,
       results: run.results,
+      ...(run.judgeFailureSummary && { judgeFailureSummary: run.judgeFailureSummary }),
       ...(run.performanceMetrics && { performanceMetrics: run.performanceMetrics }),
     }));
   }
@@ -301,6 +306,7 @@ class AsyncBenchmarkStorage {
       benchmarkVersion: r.benchmarkVersion,
       testCaseSnapshots: r.testCaseSnapshots,
       results: r.results,
+      ...(r.judgeFailureSummary && { judgeFailureSummary: r.judgeFailureSummary }),
     }));
 
     console.log('[asyncBenchmarkStorage] Saving updated runs:', storageRuns.length);

--- a/services/storage/asyncRunStorage.ts
+++ b/services/storage/asyncRunStorage.ts
@@ -101,6 +101,7 @@ function toTestCaseRun(stored: StorageRun): TestCaseRun {
     traceError?: string;
     spans?: unknown[];
     connectorProtocol?: string;
+    judgeMode?: 'trajectory-only' | 'trace-tools';
   };
 
   return {
@@ -183,6 +184,7 @@ function toTestCaseRun(stored: StorageRun): TestCaseRun {
     traceFetchAttempts: storedAny.traceFetchAttempts,
     lastTraceFetchAt: storedAny.lastTraceFetchAt,
     traceError: storedAny.traceError,
+    judgeMode: storedAny.judgeMode,
     spans: storedAny.spans as any[] | undefined,
     connectorProtocol: storedAny.connectorProtocol as ConnectorProtocol | undefined,
   };
@@ -237,6 +239,7 @@ function toStorageFormat(report: EvaluationReport): Omit<StorageRun, 'id' | 'cre
   if (report.traceFetchAttempts !== undefined) base.traceFetchAttempts = report.traceFetchAttempts;
   if (report.lastTraceFetchAt !== undefined) base.lastTraceFetchAt = report.lastTraceFetchAt;
   if (report.traceError !== undefined) base.traceError = report.traceError;
+  if ((report as any).judgeMode !== undefined) (base as any).judgeMode = (report as any).judgeMode;
   if (report.spans !== undefined) base.spans = report.spans;
   if (report.connectorProtocol !== undefined) base.connectorProtocol = report.connectorProtocol;
   // SDK matcher verdicts: persist alongside the report
@@ -451,6 +454,7 @@ class AsyncRunStorage {
     if (updates.traceFetchAttempts !== undefined) storageUpdates.traceFetchAttempts = updates.traceFetchAttempts;
     if (updates.lastTraceFetchAt !== undefined) storageUpdates.lastTraceFetchAt = updates.lastTraceFetchAt;
     if (updates.traceError !== undefined) storageUpdates.traceError = updates.traceError;
+    if ((updates as any).judgeMode !== undefined) storageUpdates.judgeMode = (updates as any).judgeMode;
     if (updates.spans !== undefined) storageUpdates.spans = updates.spans;
 
     const updated = await opensearchRuns.partialUpdate(reportId, storageUpdates);

--- a/services/traces/browserRecovery.ts
+++ b/services/traces/browserRecovery.ts
@@ -115,6 +115,9 @@ export function ensureTracePollingForReport(
             passFailStatus: judgment.passFailStatus,
             metrics: judgment.metrics,
             llmJudgeReasoning: judgment.llmJudgeReasoning,
+            // Set only by the agent (trace) judge provider -- see
+            // JudgeResponse.judgeMode / TestCaseRun.judgeMode.
+            ...(judgment.judgeMode ? { judgeMode: judgment.judgeMode } : {}),
             // Unified judge surface (issue #230 follow-up).
             matcherResults: [
               buildJudgeMatcherEntry(judgment, {

--- a/tests/e2e/judge-failure-summary.spec.ts
+++ b/tests/e2e/judge-failure-summary.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * E2E: run-level judge-failure surfacing (lib/judgeFailureSummary.ts).
+ *
+ * Reported incident: a run whose every case failed AT THE JUDGE STEP (the
+ * agent-trace-judge's pre-fix "needs a runId or trace correlation hint" 400
+ * for a non-instrumented REST agent) showed only a bare amber "⚠ N" count in
+ * the runs list and nothing at all in the inspector — no reason anywhere.
+ * These specs pin that `run.judgeFailureSummary` is rendered (a) as an
+ * inspector banner and (b) as the runs-list errored-badge tooltip.
+ *
+ * Run doc + report are seeded via the storage API (unique names; cleaned
+ * up in afterAll) — no agent/judge execution needed.
+ */
+
+import { test, expect } from './fixtures/test-fixtures';
+
+const SUMMARY =
+  '3/3 cases failed at the judge step: Bedrock Judge validation error (not retryable): ' +
+  'The agent (trace) judge provider needs a runId or at least one trace correlation hint';
+
+test.describe('Run-level judge failure summary', () => {
+  let testCaseId: string | null = null;
+  let runId: string | null = null;
+  let reportId: string | null = null;
+  let seeded = false;
+  const RUN_NAME = `E2E Judge Failure Summary ${Date.now()}`;
+
+  test.beforeAll(async ({ request }) => {
+    const tcRes = await request.post('/api/storage/test-cases', {
+      data: {
+        name: `e2e-judge-failure-tc-${Date.now()}`,
+        category: 'Test',
+        difficulty: 'Easy',
+        initialPrompt: 'What is causing the outage?',
+        expectedOutcomes: ['Identifies the root cause'],
+      },
+    });
+    if (!tcRes.ok()) return;
+    const tc = await tcRes.json();
+    testCaseId = tc.id || tc.testCase?.id;
+    if (!testCaseId) return;
+
+    // One errored report (canonical judge_failed shape) so the inspector's
+    // errored count is > 0 alongside the banner.
+    const repRes = await request.post('/api/storage/runs', {
+      data: {
+        testCaseId,
+        agentName: 'Demo Agent',
+        agentKey: 'demo',
+        modelName: 'demo-model',
+        modelId: 'demo-model',
+        status: 'completed',
+        metricsStatus: 'error',
+        passFailStatus: null,
+        traceError: 'Judge evaluation failed (kind=judge_failed): Bedrock Judge validation error (not retryable): needs a runId',
+        trajectory: [{ type: 'action', toolName: 'search_logs', content: 'looking' }],
+        metrics: { accuracy: 0, faithfulness: 0, latency_score: 0, trajectory_alignment_score: 0 },
+        llmJudgeReasoning: '**Evaluator could not run.**',
+      },
+    });
+    if (repRes.ok()) {
+      const rep = await repRes.json();
+      reportId = rep.id || rep.run?.id || rep.report?.id || null;
+    }
+
+    runId = `eval-run-e2e-judge-failure-${Date.now()}`;
+    const runRes = await request.put(`/api/storage/evaluation-runs/${runId}`, {
+      data: {
+        id: runId,
+        name: RUN_NAME,
+        status: 'completed',
+        agentKey: 'demo',
+        modelId: 'claude-sonnet',
+        judgeModelId: 'agent-trace-judge',
+        sources: [{ type: 'test-case-ids', ids: [testCaseId] }],
+        trigger: 'api',
+        testCaseSnapshots: [{ id: testCaseId, version: 1, name: 'e2e judge failure tc' }],
+        results: reportId ? { [testCaseId]: { reportId, status: 'completed' } } : {},
+        stats: { passed: 0, failed: 0, errored: 1, pending: 0, total: 1 },
+        judgeFailureSummary: SUMMARY,
+        createdAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      },
+    });
+    seeded = runRes.ok();
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (runId) await request.delete(`/api/storage/evaluation-runs/${runId}`).catch(() => {});
+    if (reportId) await request.delete(`/api/storage/runs/${reportId}`).catch(() => {});
+    if (testCaseId) await request.delete(`/api/storage/test-cases/${testCaseId}`).catch(() => {});
+  });
+
+  test('inspector shows the run-level judge-failure banner with the aggregated reason', async ({ page }) => {
+    test.skip(!seeded, 'Could not seed run (storage unavailable)');
+    await page.goto(`/evaluations/runs/${runId}/inspect`);
+    const banner = page.getByTestId('run-judge-failure-banner');
+    await expect(banner).toBeVisible({ timeout: 15000 });
+    await expect(banner).toContainText('3/3 cases failed at the judge step');
+    await expect(banner).toContainText('needs a runId or at least one trace correlation hint');
+  });
+
+  test('runs list errored badge carries the judge-failure reason as its tooltip', async ({ page }) => {
+    test.skip(!seeded || !reportId, 'Could not seed run/report (storage unavailable)');
+    await page.goto('/evaluations/runs');
+    const row = page.locator('tr', { hasText: RUN_NAME }).first();
+    await expect(row).toBeVisible({ timeout: 15000 });
+    const badge = row.getByTestId('run-row-errored-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute('title', /Judge failure: 3\/3 cases failed at the judge step/);
+  });
+});

--- a/tests/integration/server/routes/judgeAgentProviderHints.integration.test.ts
+++ b/tests/integration/server/routes/judgeAgentProviderHints.integration.test.ts
@@ -140,23 +140,37 @@ describe('POST /api/judge — agent provider, hints-only scoping (integration)',
     expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledTimes(1);
   });
 
-  it('still 400s over real HTTP when NEITHER runId nor usable agents hints are present', async () => {
+  it('degrades to trajectory-only judging over real HTTP (no 400, no query_spans/query_logs) when NEITHER runId nor usable agents hints are present -- the useTraces:false / non-instrumented-agent case', async () => {
+    mockEvaluateWithPiAgenticTrace.mockResolvedValue({
+      passFailStatus: 'failed',
+      metrics: { accuracy: 40, faithfulness: 50, latency_score: 60, trajectory_alignment_score: 30 },
+      llmJudgeReasoning: 'Judged from trajectory alone; no trace tools available for this run.',
+      improvementStrategies: [],
+      judgeMode: 'trajectory-only',
+    });
+
     const res = await request(buildApp())
       .post('/api/judge')
       .send({
         trajectory: restTrajectory,
         expectedOutcomes: ['Identifies the CPU spike as root cause'],
         evaluatorId: 'rest-trace-eval',
-        // no runId, no agents at all
+        // no runId, no agents at all -- e.g. a `useTraces: false` REST agent's report.
       })
       .set('Content-Type', 'application/json');
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/runId/i);
-    expect(mockEvaluateWithPiAgenticTrace).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body.judgeMode).toBe('trajectory-only');
+    expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledTimes(1);
+    // traceToolsAvailable=false is the 3rd positional arg -- no query_spans/query_logs pack.
+    expect(mockEvaluateWithPiAgenticTrace.mock.calls[0][2]).toBe(false);
   });
 
-  it('still 400s when agents hints are present but empty of any usable field', async () => {
+  it('degrades to trajectory-only judging when agents hints are present but empty of any usable field', async () => {
+    mockEvaluateWithPiAgenticTrace.mockResolvedValue({
+      passFailStatus: 'failed', metrics: {}, llmJudgeReasoning: 'ok', improvementStrategies: [], judgeMode: 'trajectory-only',
+    });
+
     const res = await request(buildApp())
       .post('/api/judge')
       .send({
@@ -167,8 +181,8 @@ describe('POST /api/judge — agent provider, hints-only scoping (integration)',
       })
       .set('Content-Type', 'application/json');
 
-    expect(res.status).toBe(400);
-    expect(mockEvaluateWithPiAgenticTrace).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(mockEvaluateWithPiAgenticTrace.mock.calls[0][2]).toBe(false);
   });
 
   it('regression: a runId-carrying request still works unchanged (Strategy B alone)', async () => {

--- a/tests/integration/server/routes/storage/evaluationRuns.retryJudgement.integration.test.ts
+++ b/tests/integration/server/routes/storage/evaluationRuns.retryJudgement.integration.test.ts
@@ -314,6 +314,43 @@ describe('POST /api/storage/evaluation-runs/:id/retry-judgement', () => {
     expect(persistedRun.stats).toMatchObject({ passed: 2, failed: 0, errored: 0, total: 2 });
   }, 30000);
 
+  it('salvages a LEGACY pre-fix judge-failure report (status: failed, no metricsStatus, judge-named reasoning) — the shape the un-fixed trace judge left on every case of a non-instrumented agent run', async () => {
+    if (!backendAvailable) return;
+
+    const tcLegacy = await createTestCase('Retry Judgement — legacy judge-failure shape');
+    cleanupIds.testCases.push(tcLegacy);
+
+    const reportLegacy = await createReport(`report-retry-legacy-${Date.now()}`, {
+      testCaseId: tcLegacy,
+      status: 'failed',
+      // deliberately NO metricsStatus / traceError — pre-fix shape
+      llmJudgeReasoning:
+        'Evaluation failed: Bedrock Judge validation error (not retryable): The agent (trace) judge provider needs a runId or at least one trace correlation hint (agents: serviceName+window, or sessionId) to scope its trace tools — this request had neither.',
+    });
+    cleanupIds.reports.push(reportLegacy.id);
+
+    const run = await seedEvalRun({
+      testCaseSnapshots: [{ id: tcLegacy, version: 1, name: 'Retry Judgement — legacy judge-failure shape' }],
+      results: { [tcLegacy]: { reportId: reportLegacy.id, status: 'completed' } },
+    });
+    cleanupIds.evalRuns.push(run.id);
+
+    const startRes = await fetch(`${BASE_URL}/api/storage/evaluation-runs/${run.id}/retry-judgement`, { method: 'POST' });
+    expect(startRes.status).toBe(202);
+    const started = await startRes.json();
+    expect(started.total).toBe(1); // pre-fix: 0 — the legacy shape was invisible to the selector
+
+    const job = await pollRetryJudgement(run.id);
+    expect(job.status).toBe('completed');
+    expect(job.summary.retried).toBe(1);
+    expect(job.summary.succeeded).toBe(1);
+
+    const persistedReport = await (await fetch(`${BASE_URL}/api/storage/runs/${reportLegacy.id}`)).json();
+    expect(persistedReport.metricsStatus).toBe('completed');
+    expect(persistedReport.passFailStatus).toBe('passed');
+    expect(persistedReport.llmJudgeReasoning).not.toMatch(/^Evaluation failed:/);
+  }, 30000);
+
   it('does not retry a judge-failed case with no stored trajectory (agent crash — nothing to salvage)', async () => {
     if (!backendAvailable) return;
 

--- a/tests/integration/services/evaluationRestJudgeDegradation.integration.test.ts
+++ b/tests/integration/services/evaluationRestJudgeDegradation.integration.test.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration test: `runEvaluationWithConnector` (services/evaluation/index.ts,
+ * the "classic"/STANDARD MODE judge path used by every non-`useTraces`
+ * agent) driving the REAL `callBedrockJudge` client against a mocked
+ * `fetch` boundary that stands in for `/api/judge`.
+ *
+ * This is the regression coverage for the reported incident: a REST-
+ * connector agent declared `useTraces: false` (not OTel-instrumented) whose
+ * report has no `runId` and no derivable Strategy C `agents` hint. Pre-fix,
+ * picking `judgeModelId: 'agent-trace-judge'` for such an agent made
+ * `/api/judge` 400 with "needs a runId or trace correlation hint", and
+ * `runEvaluationWithConnector`'s single outer catch turned that into
+ * `status: 'failed'`, no `passFailStatus`, no `metricsStatus` -- silently
+ * indistinguishable from a genuine agent crash, and invisible to
+ * retry-judgement's salvage predicate.
+ *
+ * Two scenarios, both exercising the REAL service code (only the network
+ * boundary is mocked -- the real `/api/judge` route's own degrade decision
+ * is covered separately by tests/unit/server/routes/judge.test.ts and
+ * tests/integration/server/routes/judgeAgentProviderHints.integration.test.ts):
+ *   1. The (now-fixed) route degrades to trajectory-only judging and
+ *      returns a real verdict + `judgeMode: 'trajectory-only'` -- the report
+ *      must carry a real `passFailStatus` and the persisted `judgeMode`.
+ *   2. The judge call fails for some OTHER reason (defense in depth -- the
+ *      fix isn't "the 400 can never happen again", it's "a judge failure
+ *      after a successful agent run must never masquerade as a generic
+ *      failure") -- the report must land in the canonical
+ *      `metricsStatus: 'error'` / `status: 'completed'` shape, and
+ *      retryJudgement's `isJudgeFailedCase` must recognize it as salvageable.
+ */
+
+import type { AgentConfig, TestCase } from '@/types';
+import type { ConnectorRegistry, AgentConnector, ConnectorResponse } from '@/services/connectors/types';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+import { runEvaluationWithConnector } from '@/services/evaluation';
+import { isJudgeFailedCase } from '@/services/evaluation/retryJudgement';
+
+function buildTestCase(): TestCase {
+  const now = new Date().toISOString();
+  return {
+    id: 'tc-rest-no-traces',
+    name: 'REST no-traces case',
+    description: 'desc',
+    labels: ['category:RCA'],
+    currentVersion: 1,
+    versions: [{
+      version: 1,
+      createdAt: now,
+      initialPrompt: 'Why is the service failing?',
+      context: [],
+      expectedOutcomes: ['Identifies the root cause'],
+    }],
+    isPromoted: false,
+    createdAt: now,
+    updatedAt: now,
+    initialPrompt: 'Why is the service failing?',
+    context: [],
+    expectedOutcomes: ['Identifies the root cause'],
+  } as unknown as TestCase;
+}
+
+/** A minimal REST-shaped connector: fixed trajectory, no runId (exactly what RESTConnector.execute() returns for an agent whose response body carries neither `runId` nor `id`). */
+function buildMockRegistry(): ConnectorRegistry {
+  const connector: AgentConnector = {
+    type: 'rest',
+    name: 'REST (mock)',
+    supportsStreaming: false,
+    buildPayload: () => ({}),
+    execute: async (): Promise<ConnectorResponse> => ({
+      trajectory: [
+        { id: 's1', type: 'action', toolName: 'search_logs', toolArgs: { query: 'cpu' }, timestamp: Date.now() },
+        { id: 's2', type: 'tool_result', toolName: 'search_logs', content: '{"hits":3}', status: 'SUCCESS', timestamp: Date.now() },
+        { id: 's3', type: 'response', content: 'Root cause: CPU spike on node-3.', timestamp: Date.now() },
+      ] as any,
+      runId: null, // REST connectors never mint one outside trace-mode polling
+      rawEvents: [],
+      metadata: {},
+    }),
+    parseResponse: () => [],
+  } as unknown as AgentConnector;
+
+  return {
+    getForAgent: () => connector,
+  } as unknown as ConnectorRegistry;
+}
+
+function buildAgent(): AgentConfig {
+  return {
+    key: 'example-rest-agent',
+    name: 'Example REST Agent',
+    endpoint: 'https://example-agent.internal/invoke',
+    connectorType: 'rest',
+    useTraces: false, // not OTel-instrumented -- the reported scenario
+  } as unknown as AgentConfig;
+}
+
+describe('runEvaluationWithConnector — agent-trace-judge against a useTraces:false REST agent (integration)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('produces a real verdict with judgeMode="trajectory-only" when /api/judge degrades instead of erroring', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        passFailStatus: 'passed',
+        metrics: { accuracy: 82, faithfulness: 80, latency_score: 90, trajectory_alignment_score: 75 },
+        llmJudgeReasoning: 'The trajectory shows the agent identified a plausible root cause from the tool output alone.',
+        improvementStrategies: [],
+        judgeMode: 'trajectory-only',
+      }),
+    });
+
+    const report = await runEvaluationWithConnector(
+      buildAgent(),
+      'test-model',
+      buildTestCase(),
+      () => {},
+      { registry: buildMockRegistry(), judgeModelId: 'agent-trace-judge' }
+    );
+
+    // A real verdict -- NOT the reported bug's status:'failed'/passFailStatus:undefined.
+    expect(report.status).toBe('completed');
+    expect(report.passFailStatus).toBe('passed');
+    expect((report as any).judgeMode).toBe('trajectory-only');
+    expect(report.llmJudgeReasoning).not.toMatch(/^Evaluation failed:/);
+
+    // The request /api/judge received carried no runId/agents hint -- this
+    // agent genuinely has nothing to correlate on.
+    const [, requestInit] = mockFetch.mock.calls[0];
+    const sentBody = JSON.parse(requestInit.body);
+    expect(sentBody.runId).toBeUndefined();
+    expect(sentBody.agents).toBeUndefined();
+    expect(sentBody.modelId).toBe('agent-trace-judge');
+  });
+
+  it('surfaces a judge-step failure as metricsStatus:"error" (never a generic status:"failed") and is salvageable by retry-judgement', async () => {
+    // Simulate the judge call failing for ANY reason (defense in depth --
+    // this is not conditioned on the specific pre-fix 400; any judge-call
+    // exception must land in the canonical shape). A 4xx is the
+    // non-retryable branch so this resolves in one attempt.
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({
+        error: 'The agent (trace) judge provider needs a runId or at least one trace correlation hint (agents: serviceName+window, or sessionId) to scope its trace tools — this request had neither.',
+      }),
+    });
+
+    const report = await runEvaluationWithConnector(
+      buildAgent(),
+      'test-model',
+      buildTestCase(),
+      () => {},
+      { registry: buildMockRegistry(), judgeModelId: 'agent-trace-judge' }
+    ) as any;
+
+    // The agent DID complete (we have a trajectory) -- this must be the
+    // canonical buildEvaluatorErrorPatch('judge_failed', ...) shape, not the
+    // generic status:'failed' the reported incident produced.
+    expect(report.status).toBe('completed');
+    expect(report.metricsStatus).toBe('error');
+    expect(report.passFailStatus).toBeNull();
+    expect(report.traceError).toMatch(/kind=judge_failed/);
+    expect(report.traceError).toMatch(/needs a runId/);
+    expect(report.trajectory.length).toBeGreaterThan(0);
+
+    // The #462 retry-judgement salvage predicate must recognize this case.
+    // Pre-fix (status:'failed', no metricsStatus) it did NOT.
+    const runResult = { reportId: 'irrelevant', status: report.status };
+    expect(isJudgeFailedCase(report, runResult)).toBe(true);
+  });
+
+  it('a genuine agent-invocation failure (not a judge failure) still lands on the OUTER catch as status:"failed"', async () => {
+    const throwingRegistry: ConnectorRegistry = {
+      getForAgent: () => ({
+        type: 'rest',
+        name: 'REST (mock)',
+        supportsStreaming: false,
+        buildPayload: () => ({}),
+        execute: async () => { throw new Error('ECONNREFUSED'); },
+        parseResponse: () => [],
+      }),
+    } as unknown as ConnectorRegistry;
+
+    const report = await runEvaluationWithConnector(
+      buildAgent(),
+      'test-model',
+      buildTestCase(),
+      () => {},
+      { registry: throwingRegistry, judgeModelId: 'agent-trace-judge' }
+    ) as any;
+
+    expect(report.status).toBe('failed');
+    expect(report.metricsStatus).toBeUndefined();
+    expect(report.llmJudgeReasoning).toMatch(/^Evaluation failed:.*ECONNREFUSED/);
+    // The judge was never even called -- fetch should not have been reached.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/judgeFailureSummary.test.ts
+++ b/tests/unit/lib/judgeFailureSummary.test.ts
@@ -78,10 +78,15 @@ describe('computeJudgeFailureSummary', () => {
     expect(computeJudgeFailureSummary(reasons, 3)).toBeUndefined();
   });
 
-  it('surfaces a summary when judge failures are exactly half of the total', () => {
+  it('does NOT surface a summary on an exact 50/50 tie (requires a strict majority)', () => {
     const reasons = ['Bedrock Judge validation error', undefined];
-    expect(computeJudgeFailureSummary(reasons, 2)).toBe(
-      '1/2 case failed at the judge step: Bedrock Judge validation error'
+    expect(computeJudgeFailureSummary(reasons, 2)).toBeUndefined();
+  });
+
+  it('surfaces a summary at a strict majority (2 of 3)', () => {
+    const reasons = ['Bedrock Judge validation error', 'Bedrock Judge validation error', undefined];
+    expect(computeJudgeFailureSummary(reasons, 3)).toBe(
+      '2/3 cases failed at the judge step: Bedrock Judge validation error'
     );
   });
 

--- a/tests/unit/lib/judgeFailureSummary.test.ts
+++ b/tests/unit/lib/judgeFailureSummary.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { extractJudgeFailureReason, computeJudgeFailureSummary } from '@/lib/judgeFailureSummary';
+
+describe('extractJudgeFailureReason', () => {
+  it('returns undefined for null/undefined reports', () => {
+    expect(extractJudgeFailureReason(undefined)).toBeUndefined();
+    expect(extractJudgeFailureReason(null)).toBeUndefined();
+  });
+
+  it('returns undefined for a normally passed/failed report', () => {
+    expect(extractJudgeFailureReason({ status: 'completed' })).toBeUndefined();
+    expect(extractJudgeFailureReason({ status: 'completed', metricsStatus: 'completed' })).toBeUndefined();
+  });
+
+  it('returns undefined for a genuine agent failure (buildEvaluatorErrorPatch kind=agent_failed)', () => {
+    const report = {
+      metricsStatus: 'error',
+      traceError: 'Agent run did not complete (kind=agent_failed): Subprocess timed out after 600000ms',
+    };
+    expect(extractJudgeFailureReason(report)).toBeUndefined();
+  });
+
+  it('extracts the human-readable reason from the canonical buildEvaluatorErrorPatch(judge_failed) shape', () => {
+    const report = {
+      status: 'completed',
+      metricsStatus: 'error',
+      traceError:
+        'Judge evaluation failed (kind=judge_failed): Bedrock Judge validation error (not retryable): ' +
+        'The agent (trace) judge provider needs a runId or at least one trace correlation hint',
+    };
+    expect(extractJudgeFailureReason(report)).toBe(
+      'Bedrock Judge validation error (not retryable): The agent (trace) judge provider needs a runId or at least one trace correlation hint'
+    );
+  });
+
+  it('extracts the reason from the legacy pre-fix shape (status: failed, llmJudgeReasoning names the judge)', () => {
+    const report = {
+      status: 'failed',
+      llmJudgeReasoning:
+        'Evaluation failed: Bedrock Judge validation error (not retryable): The agent (trace) judge ' +
+        'provider needs a runId or at least one trace correlation hint',
+    };
+    expect(extractJudgeFailureReason(report)).toBe(
+      'Bedrock Judge validation error (not retryable): The agent (trace) judge provider needs a runId or at least one trace correlation hint'
+    );
+  });
+
+  it('does NOT mislabel a legacy-shape agent/network failure (no mention of "judge") as a judge failure', () => {
+    const report = {
+      status: 'failed',
+      llmJudgeReasoning: 'Evaluation failed: ECONNREFUSED connecting to https://example-agent.internal',
+    };
+    expect(extractJudgeFailureReason(report)).toBeUndefined();
+  });
+
+  it('is case-insensitive when matching "judge" in the legacy shape', () => {
+    const report = { status: 'failed', llmJudgeReasoning: 'Evaluation failed: Judge model unavailable' };
+    expect(extractJudgeFailureReason(report)).toBeDefined();
+  });
+});
+
+describe('computeJudgeFailureSummary', () => {
+  it('returns undefined when total is 0', () => {
+    expect(computeJudgeFailureSummary([], 0)).toBeUndefined();
+  });
+
+  it('returns undefined when there are no judge failures', () => {
+    expect(computeJudgeFailureSummary([undefined, undefined], 2)).toBeUndefined();
+  });
+
+  it('returns undefined when judge failures are a minority (<50%) of the total', () => {
+    // 1 failure out of 3 planned cases -- an incidental failure, not dominant.
+    const reasons = [undefined, undefined, 'Bedrock Judge validation error'];
+    expect(computeJudgeFailureSummary(reasons, 3)).toBeUndefined();
+  });
+
+  it('surfaces a summary when judge failures are exactly half of the total', () => {
+    const reasons = ['Bedrock Judge validation error', undefined];
+    expect(computeJudgeFailureSummary(reasons, 2)).toBe(
+      '1/2 case failed at the judge step: Bedrock Judge validation error'
+    );
+  });
+
+  it('surfaces the reported-incident shape: all 62 cases failed at the judge step', () => {
+    const reasons = Array.from({ length: 62 }, () => 'Bedrock Judge validation error (not retryable): needs a runId or trace correlation hint');
+    const summary = computeJudgeFailureSummary(reasons, 62);
+    expect(summary).toBe(
+      '62/62 cases failed at the judge step: Bedrock Judge validation error (not retryable): needs a runId or trace correlation hint'
+    );
+  });
+
+  it('picks the most frequent distinct reason when judge failures have mixed messages', () => {
+    const reasons = [
+      'reason A', 'reason A', 'reason A',
+      'reason B',
+      undefined,
+    ];
+    // 4/5 >= 50% -- dominant overall; "reason A" (3) beats "reason B" (1).
+    expect(computeJudgeFailureSummary(reasons, 5)).toBe('4/5 cases failed at the judge step: reason A');
+  });
+
+  it('uses singular "case" for exactly one failure', () => {
+    expect(computeJudgeFailureSummary(['only reason'], 1)).toBe('1/1 case failed at the judge step: only reason');
+  });
+});

--- a/tests/unit/server/routes/judge.test.ts
+++ b/tests/unit/server/routes/judge.test.ts
@@ -724,28 +724,43 @@ describe('Judge Routes', () => {
       inferenceConfig: { provider: 'agent' },
     };
 
-    it('returns 400 when runId is missing AND no agents hints are present (trace tools have nothing to scope to)', async () => {
+    it('degrades to trajectory-only judging (no 400) when runId is missing AND no agents hints are present', async () => {
       mockGetEvaluatorById.mockResolvedValue(agentEvaluator);
+      mockEvaluateWithPiAgenticTrace.mockResolvedValue({
+        passFailStatus: 'failed',
+        metrics: { accuracy: 40 },
+        llmJudgeReasoning: 'No trace tools available; judged from trajectory alone.',
+        improvementStrategies: [],
+        judgeMode: 'trajectory-only',
+      } as any);
 
       const { req, res } = createMocks({
         trajectory: [{ type: 'action', toolName: 'search' }],
         expectedOutcomes: ['Identify issue'],
         evaluatorId: 'custom-trace-eval',
-        // no runId, no agents hints
+        // no runId, no agents hints -- e.g. a `useTraces: false` REST agent.
       });
       const handler = getRouteHandler(judgeRoutes, 'post', '/api/judge');
 
       await handler(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.stringContaining('runId') })
+      expect(res.status).not.toHaveBeenCalledWith(400);
+      // traceToolsAvailable=false is the 3rd positional arg.
+      expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: undefined, agents: undefined }),
+        expect.objectContaining({ id: 'custom-trace-eval' }),
+        false
       );
-      expect(mockEvaluateWithPiAgenticTrace).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ judgeMode: 'trajectory-only' })
+      );
     });
 
-    it('returns 400 when agents hints are present but carry neither serviceName nor sessionId', async () => {
+    it('degrades to trajectory-only judging (no 400) when agents hints are present but carry neither serviceName nor sessionId', async () => {
       mockGetEvaluatorById.mockResolvedValue(agentEvaluator);
+      mockEvaluateWithPiAgenticTrace.mockResolvedValue({
+        passFailStatus: 'failed', metrics: {}, llmJudgeReasoning: 'ok', improvementStrategies: [], judgeMode: 'trajectory-only',
+      } as any);
 
       const { req, res } = createMocks({
         trajectory: [{ type: 'action', toolName: 'search' }],
@@ -757,17 +772,22 @@ describe('Judge Routes', () => {
 
       await handler(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(mockEvaluateWithPiAgenticTrace).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalledWith(400);
+      expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        false
+      );
     });
 
-    it('routes to evaluateWithPiAgenticTrace when runId is ABSENT but a serviceName+window hint is present (REST-connector, no trace-mode polling -- the reported bug)', async () => {
+    it('routes to evaluateWithPiAgenticTrace with traceToolsAvailable=true when runId is ABSENT but a serviceName+window hint is present (REST-connector, no trace-mode polling -- the original reported bug)', async () => {
       mockGetEvaluatorById.mockResolvedValue(agentEvaluator);
       mockEvaluateWithPiAgenticTrace.mockResolvedValue({
         passFailStatus: 'passed',
         metrics: { accuracy: 88 },
         llmJudgeReasoning: 'Trace-backed evaluation via hints',
         improvementStrategies: [],
+        judgeMode: 'trace-tools',
       } as any);
 
       const agents = [{ serviceName: 'example-agent', startedAt: 1000, endedAt: 2000 }];
@@ -785,7 +805,8 @@ describe('Judge Routes', () => {
       expect(res.status).not.toHaveBeenCalledWith(400);
       expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledWith(
         expect.objectContaining({ runId: undefined, agents }),
-        expect.objectContaining({ id: 'custom-trace-eval' })
+        expect.objectContaining({ id: 'custom-trace-eval' }),
+        true
       );
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ passFailStatus: 'passed' })
@@ -865,7 +886,8 @@ describe('Judge Routes', () => {
       expect(res.status).not.toHaveBeenCalledWith(400);
       expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledWith(
         expect.objectContaining({ runId: 'run-abc-123' }),
-        expect.objectContaining({ id: 'custom-trace-eval' }) // Saved evaluator
+        expect.objectContaining({ id: 'custom-trace-eval' }), // Saved evaluator
+        true
       );
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ passFailStatus: 'passed' })
@@ -910,7 +932,8 @@ describe('Judge Routes', () => {
       expect(res.status).not.toHaveBeenCalledWith(403);
       expect(mockEvaluateWithPiAgenticTrace).toHaveBeenCalledWith(
         expect.objectContaining({ runId: 'run-OWN' }),
-        expect.objectContaining({ id: 'custom-trace-eval' }) // Saved evaluator
+        expect.objectContaining({ id: 'custom-trace-eval' }), // Saved evaluator
+        true
       );
     });
   });

--- a/tests/unit/server/services/piAgenticJudgeService.test.ts
+++ b/tests/unit/server/services/piAgenticJudgeService.test.ts
@@ -136,3 +136,40 @@ describe('buildAgentTraceJudgeSystemPrompt (evaluator-prompt-plumbing contract)'
     expect(out).toContain('READ-ONLY');
   });
 });
+
+describe('buildAgentTraceJudgeSystemPrompt (traceToolsAvailable=false -- trajectory-only degradation)', () => {
+  // Root cause of the reported incident: a `useTraces: false` (non-
+  // instrumented) REST agent has no runId/correlation hint, so the judge
+  // must reason from the trajectory alone -- and must be told explicitly
+  // that no trace tools exist, so it doesn't hallucinate span/log checks.
+
+  it('defaults traceToolsAvailable to true (back-compat with 1-arg / 2-arg callers)', () => {
+    const withDefault = buildAgentTraceJudgeSystemPrompt(undefined);
+    const withExplicitTrue = buildAgentTraceJudgeSystemPrompt(undefined, true);
+    expect(withDefault).toBe(withExplicitTrue);
+    expect(withDefault).toContain('query_spans');
+  });
+
+  it('omits the query_spans/query_logs tool-use contract (READ-ONLY description) and explains their absence when traceToolsAvailable=false', () => {
+    const out = buildAgentTraceJudgeSystemPrompt(undefined, false);
+    // Still names the tools (so the model knows what it's missing, per the
+    // addendum's own text) but must NOT include the trace-tools mode's
+    // tool-use contract/description.
+    expect(out).not.toContain('READ-ONLY, scoped to the run being judged');
+    expect(out).not.toContain('query_spans({');
+    expect(out).toContain('No trace-query tools available');
+    expect(out).toContain('not instrumented with OpenTelemetry');
+  });
+
+  it('still replaces the base prompt with a saved evaluator systemPrompt when trace tools are unavailable', () => {
+    const out = buildAgentTraceJudgeSystemPrompt({ systemPrompt: 'I am the CP-Oncall judge.' }, false);
+    expect(out).toContain('I am the CP-Oncall judge');
+    expect(out).not.toContain('observability and Root Cause Analysis');
+    expect(out).toContain('No trace-query tools available');
+  });
+
+  it('instructs the model NOT to claim trace/log verification it never performed', () => {
+    const out = buildAgentTraceJudgeSystemPrompt(undefined, false);
+    expect(out.toLowerCase()).toContain('do not claim');
+  });
+});

--- a/tests/unit/services/evaluation/bedrockJudge.test.ts
+++ b/tests/unit/services/evaluation/bedrockJudge.test.ts
@@ -81,6 +81,39 @@ describe('bedrockJudge', () => {
       expect(result.warning).toMatch(/MOCK_JUDGE/);
     });
 
+    it('should forward `judgeMode` from the agent (trace) judge provider ("trajectory-only" -- non-instrumented agent)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          passFailStatus: 'failed',
+          metrics: { accuracy: 40 },
+          llmJudgeReasoning: 'Judged from trajectory alone; no trace tools available for this run.',
+          improvementStrategies: [],
+          judgeMode: 'trajectory-only',
+        }),
+      });
+
+      const result = await callBedrockJudge(mockTrajectory, mockExpectedBehavior);
+
+      expect(result.judgeMode).toBe('trajectory-only');
+    });
+
+    it('should leave `judgeMode` undefined for every judge provider except agent-trace-judge', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          passFailStatus: 'passed',
+          metrics: { accuracy: 92 },
+          llmJudgeReasoning: 'The agent performed well.',
+          improvementStrategies: [],
+        }),
+      });
+
+      const result = await callBedrockJudge(mockTrajectory, mockExpectedBehavior);
+
+      expect(result.judgeMode).toBeUndefined();
+    });
+
     it('should leave `warning` undefined when the route response omits it (real judge)', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/tests/unit/services/evaluation/retryJudgement.test.ts
+++ b/tests/unit/services/evaluation/retryJudgement.test.ts
@@ -109,6 +109,40 @@ describe('isJudgeFailedCase', () => {
     const report = makeReport({ metricsStatus: 'error' as any, trajectory: [] });
     expect(isJudgeFailedCase(report, { status: 'completed' })).toBe(false);
   });
+
+  describe('legacy pre-fix judge-failure shape (status: failed, no metricsStatus)', () => {
+    // Before services/evaluation/index.ts split the judge call into its own
+    // catch, a judge-step failure after a SUCCESSFUL agent run landed as
+    // status:'failed' + "Evaluation failed: <judge error>" with no
+    // metricsStatus. Runs persisted in that shape (e.g. every case of a
+    // 62-case run against a non-instrumented REST agent hitting the old
+    // agent-trace-judge 400) must still be salvageable.
+    const legacy = makeReport({
+      status: 'failed',
+      metricsStatus: undefined,
+      passFailStatus: undefined,
+      llmJudgeReasoning:
+        'Evaluation failed: Bedrock Judge validation error (not retryable): The agent (trace) judge provider needs a runId or at least one trace correlation hint',
+    });
+
+    it('is true when the trajectory exists and the reasoning names the judge', () => {
+      expect(isJudgeFailedCase(legacy, { status: 'completed' })).toBe(true);
+    });
+
+    it('is false for a legacy-shape AGENT failure (reasoning does not name the judge)', () => {
+      const agentFail = makeReport({ ...legacy, llmJudgeReasoning: 'Evaluation failed: ECONNREFUSED' } as any);
+      expect(isJudgeFailedCase(agentFail, { status: 'completed' })).toBe(false);
+    });
+
+    it('is false when the legacy-shape report has no trajectory (nothing to re-judge)', () => {
+      expect(isJudgeFailedCase(makeReport({ ...legacy, trajectory: [] } as any), { status: 'completed' })).toBe(false);
+    });
+
+    it('is selected by selectRetryableCases under the default errored scope', () => {
+      const run = makeRun({ results: { 'tc-1': { reportId: 'report-1', status: 'completed' } } as any });
+      expect(selectRetryableCases(run, { 'report-1': legacy }, 'errored')).toEqual(['tc-1']);
+    });
+  });
 });
 
 describe('hasRejudgeableOutput', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -512,6 +512,17 @@ export interface TestCaseRun {
   lastTraceFetchAt?: string; // Timestamp of last trace fetch attempt
   traceError?: string; // Error message if trace fetch failed
   spans?: Span[]; // Fetched trace spans for debugging
+  /**
+   * Set exclusively by the agent (trace) judge provider (`judgeModelId:
+   * 'agent-trace-judge'`) to record whether this verdict was backed by real
+   * OTel spans/logs (`'trace-tools'`) or had to reason from the trajectory
+   * alone because the run carried no trace correlation hint
+   * (`'trajectory-only'` — the normal case for an agent declared `useTraces:
+   * false`, i.e. not OTel-instrumented). Undefined for every other judge
+   * provider, and for agent-trace-judge reports persisted before this field
+   * existed. See server/services/piAgenticJudgeService.ts.
+   */
+  judgeMode?: 'trajectory-only' | 'trace-tools';
 }
 
 // Alias for backwards compatibility during migration
@@ -1059,6 +1070,20 @@ export interface BenchmarkRun {
   // Optional during migration period - will be populated by migration CLI or on next run completion
   stats?: RunStats;
 
+  /**
+   * One-line aggregate reason when a dominant share (>=50%) of this run's
+   * cases failed AT THE JUDGE STEP specifically (not the agent) -- e.g.
+   * every case hitting the agent-trace-judge's "needs a runId or trace
+   * correlation hint" validation error before that error was fixed to
+   * degrade instead of hard-failing (see piAgenticJudgeService.ts /
+   * judgeAgentsHints.ts). Computed by `lib/judgeFailureSummary.ts` from the
+   * per-case reports at run-completion time; undefined when no dominant
+   * judge-failure pattern is present. Surfaced in the runs list and run
+   * inspector so "62 errored" isn't silent about *why* -- pre-fix a run
+   * like this showed only a bare warning-triangle count with no reason.
+   */
+  judgeFailureSummary?: string;
+
   // Server-side performance metrics (populated after run completes)
   performanceMetrics?: RunPerformanceMetrics;
 
@@ -1203,6 +1228,15 @@ export interface EvaluationRun {
 
   // Denormalized stats
   stats?: RunStats;
+
+  /**
+   * One-line aggregate reason when a dominant share (>=50%) of this run's
+   * cases failed at the judge step specifically. See
+   * {@link BenchmarkRun.judgeFailureSummary} for the full doc — same field,
+   * same computation (`lib/judgeFailureSummary.ts`), duplicated here because
+   * `EvaluationRun` and `BenchmarkRun` are independent doc shapes.
+   */
+  judgeFailureSummary?: string;
 
   // Performance metrics
   performanceMetrics?: RunPerformanceMetrics;


### PR DESCRIPTION
## Problem

A real run of a **62-case benchmark** against a **REST agent without tracing** (`useTraces: false` — its trajectory is built by an `afterResponse` hook, not from OTel spans) with `judgeModelId: 'agent-trace-judge'` ended with **all 62 cases `status: 'failed'`, `passFailStatus: null`**. The run-level UI showed only a bare `⚠ 62` errored count. The real cause was buried per-report:

> `Evaluation failed: Bedrock Judge validation error (not retryable): The agent (trace) judge provider needs a runId or at least one trace correlation hint (agents: serviceName+window, or sessionId) to scope its trace tools — this request had neither.`

### Root cause chain
1. `services/evaluation/index.ts` (STANDARD MODE judge call) forwarded `runId=undefined` (REST connectors never mint one) and `agents=[]` — `resolveAgentServiceName` correctly refuses to guess a `service.name` for `rest` (see `UNKNOWN_SERVICE_NAME_PROTOCOLS`). **A non-instrumented agent can never be trace-correlated — by design.**
2. `server/routes/judge.ts` (`provider === 'agent'`) treated "no correlation handle" as a **validation error** → HTTP 400.
3. `services/evaluation/bedrockJudge.ts` marks 4xx `nonRetryable` → thrown.
4. `runEvaluationWithConnector` had a single outer `catch` around **both** agent invocation and judge call → judge failure landed as `status: 'failed'`, no `metricsStatus` — indistinguishable from an agent crash, bucketed as *failed* (not *errored*), and **invisible to #462 Retry judgement** (`isJudgeFailedCase` required `metricsStatus: 'error'`).
5. Nothing aggregated the per-report reason to the run level.

## Fix

**1. Graceful degradation (never a 400 for lack of correlation)** — `server/routes/judge.ts`, `server/services/piAgenticJudgeService.ts`
- `traceToolsAvailable = hasTraceCorrelation(runId, agents)` now selects the judge **mode**, not whether the judge runs.
- `trajectory-only` mode: no `query_spans`/`query_logs` tool pack (`tools: []`, extension not registered) and a new system-prompt addendum (`NO_TRACE_TOOLS_ADDENDUM`) telling the model no trace tools exist for this run and not to claim span/log checks it never performed.
- Resolved mode returned as `judgeMode: 'trace-tools' | 'trajectory-only'` and **persisted as `report.judgeMode`** on every judge call site (standard, trace-poll, retry-judgement, browser recovery) so comparisons can show which verdicts had trace evidence.

**2. Judge-step failures separated from agent failures** — `services/evaluation/index.ts`
- The judge call gets its own `try/catch`; failure returns the canonical `buildEvaluatorErrorPatch('judge_failed', …)` shape (`status: 'completed'`, `metricsStatus: 'error'`, `passFailStatus: null`, trajectory preserved) — buckets as *errored* and is Retry-judgement-eligible. Genuine agent-invocation failures keep the existing outer-catch shape.

**3. Run-level surfacing** — `lib/judgeFailureSummary.ts`, `types/index.ts`, runners, `EvalRunsPage`, `RunInspectorPage`
- `computeJudgeFailureSummary` aggregates the dominant per-case judge-failure reason when ≥50% of a run's cases failed at the judge step → `run.judgeFailureSummary` (e.g. `62/62 cases failed at the judge step: …`). Rendered as an inspector banner and the runs-list errored-badge tooltip. Computed at run completion (evaluation runs, benchmark execute) and on `refresh-stats`, so **existing runs get it without re-running**. Recognizes both the canonical shape and the legacy pre-fix shape.

**4. Retry judgement salvages pre-fix runs** — `services/evaluation/retryJudgement.ts`
- `isJudgeFailedCase` also recognizes the legacy shape (agent completed / trajectory present / `status: 'failed'` / reasoning names the judge), so the existing 62-case run can be re-judged at judge cost only.

## Tests (red → green)
| Level | File | Cases |
|---|---|---|
| unit | `tests/unit/server/routes/judge.test.ts` | 2 rewritten (400 → degrade, `traceToolsAvailable=false`), 3 updated for 3rd arg |
| unit | `tests/unit/server/services/piAgenticJudgeService.test.ts` | +4 (trajectory-only addendum, default back-compat) |
| unit | `tests/unit/lib/judgeFailureSummary.test.ts` | +14 (new) |
| unit | `tests/unit/services/evaluation/bedrockJudge.test.ts` | +2 (`judgeMode` forwarding) |
| unit | `tests/unit/services/evaluation/retryJudgement.test.ts` | +4 (legacy-shape selection) |
| integration | `tests/integration/server/routes/judgeAgentProviderHints.integration.test.ts` | 2 rewritten (real HTTP 400 → 200 + `judgeMode`) |
| integration | `tests/integration/services/evaluationRestJudgeDegradation.integration.test.ts` | +3 (new: verdict + `judgeMode`; judge failure → `metricsStatus:'error'` + `isJudgeFailedCase` true; agent failure unchanged) |
| integration | `tests/integration/server/routes/storage/evaluationRuns.retryJudgement.integration.test.ts` | +1 (legacy-shape report salvaged over real HTTP; pre-fix `total` was 0) |
| e2e | `tests/e2e/judge-failure-summary.spec.ts` | +2 (new: inspector banner, list tooltip; imports `./fixtures/test-fixtures`) |

`tsc --noEmit` clean. Changelog under `## [Unreleased] → Fixed`.
